### PR TITLE
EC2 Security Rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lab-auto-pulumi"
-version = "0.1.8"
+version = "0.1.9"
 description = "Pulumi helpers. Especially useful for tooling created by the LabAutomationAndScreening github organization."
 authors = [
     {name = "Eli Fine"},

--- a/src/lab_auto_pulumi/ec2.py
+++ b/src/lab_auto_pulumi/ec2.py
@@ -15,6 +15,7 @@ from pulumi_aws_native import TagArgs
 from pulumi_aws_native import ec2
 from pulumi_aws_native import iam
 
+from .constants import CENTRAL_NETWORKING_SSM_PREFIX
 from .lib import get_org_managed_ssm_param_value
 
 logger = logging.getLogger(__name__)
@@ -38,7 +39,7 @@ class Ec2WithRdp(ComponentResource):
         parent: Resource | None = None,
     ):
         super().__init__("labauto:Ec2WithRdp", append_resource_suffix(name), None, opts=ResourceOptions(parent=parent))
-
+        self.name = name
         if additional_instance_tags is None:
             additional_instance_tags = []
         resource_name = f"{name}-ec2"
@@ -68,7 +69,7 @@ class Ec2WithRdp(ComponentResource):
         self.security_group = ec2.SecurityGroup(
             append_resource_suffix(name),
             vpc_id=get_org_managed_ssm_param_value(
-                f"/org-managed/central-networking/vpcs/{central_networking_vpc_name}/id"
+                f"{CENTRAL_NETWORKING_SSM_PREFIX}/vpcs/{central_networking_vpc_name}/id"
             ),
             group_description=security_group_description,
             security_group_egress=[  # TODO: see if this can be further restricted
@@ -83,7 +84,7 @@ class Ec2WithRdp(ComponentResource):
             instance_type=instance_type,
             image_id=image_id,
             subnet_id=get_org_managed_ssm_param_value(
-                f"/org-managed/central-networking/subnets/{central_networking_subnet_name}/id"
+                f"{CENTRAL_NETWORKING_SSM_PREFIX}/subnets/{central_networking_subnet_name}/id"
             ),
             security_group_ids=[self.security_group.id],
             block_device_mappings=None

--- a/src/lab_auto_pulumi/ec2.py
+++ b/src/lab_auto_pulumi/ec2.py
@@ -79,7 +79,7 @@ class Ec2WithRdp(ComponentResource):
             opts=ResourceOptions(parent=self),
         )
         for idx, rule_args in enumerate(ingress_rules):
-            _ = ec2.SecurityGroupIngress(  # TODO: see if this can be further restricted
+            _ = ec2.SecurityGroupIngress(
                 append_resource_suffix(f"{name}-ingress-{idx}", max_length=190),
                 opts=ResourceOptions(parent=self.security_group),
                 ip_protocol=rule_args.ip_protocol,

--- a/uv.lock
+++ b/uv.lock
@@ -624,7 +624,7 @@ wheels = [
 
 [[package]]
 name = "lab-auto-pulumi"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
 ## How does this change address the issue?
Using separate security group rule objects to allow more flexiblitity with other parts of the program adding rules to the security group (rather than defining them inline)


 ## What side effects does this change have?
Might need to adjust some existing stacks so rules play nicely


 ## How is this change tested?
downstream stack using this


 ## Other
added name attribute