### PR TITLE
Always use separate ingress resource for EC2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lab-auto-pulumi"
-version = "0.1.10"
+version = "0.1.11"
 description = "Pulumi helpers. Especially useful for tooling created by the LabAutomationAndScreening github organization."
 authors = [
     {name = "Eli Fine"},

--- a/src/lab_auto_pulumi/ec2.py
+++ b/src/lab_auto_pulumi/ec2.py
@@ -78,7 +78,6 @@ class Ec2WithRdp(ComponentResource):
                 f"{CENTRAL_NETWORKING_SSM_PREFIX}/vpcs/{central_networking_vpc_name}/id"
             ),
             group_description=security_group_description,
-            security_group_ingress=ingress_rules,
             tags=[TagArgs(key="Name", value=name), *common_tags_native()],
             opts=ResourceOptions(parent=self),
         )

--- a/src/lab_auto_pulumi/permissions/permissions.py
+++ b/src/lab_auto_pulumi/permissions/permissions.py
@@ -1,6 +1,7 @@
 import logging
 
 from ephemeral_pulumi_deploy import common_tags
+from ephemeral_pulumi_deploy import get_config_str
 from pulumi import ComponentResource
 from pulumi import ResourceOptions
 from pulumi_aws import identitystore as identitystore_classic
@@ -48,6 +49,8 @@ class AwsSsoPermissionSet(ComponentResource):
         relay_state: str | None = None,
     ):
         super().__init__("labauto:AwsSsoPermissionSet", name, None)
+        if relay_state is None:
+            relay_state = f"https://{get_config_str('proj:aws_org_home_region')}.console.aws.amazon.com/console/home"
         if managed_policies is None:
             managed_policies = []
         self.name = name

--- a/uv.lock
+++ b/uv.lock
@@ -624,7 +624,7 @@ wheels = [
 
 [[package]]
 name = "lab-auto-pulumi"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
 ## Why is this change necessary?
There were conflicting ingress rules being made for the security group


 ## How does this change address the issue?
stops creating ingress args in the security group directly


 ## What side effects does this change have?
less possible problems


 ## How is this change tested?
repo using this library


 ## Other
Also created a default relay state with home region. this was tested in identity center