### PR TITLE
Specific names for EC2 Security Group Ingress Rules

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -15,7 +15,7 @@ python_package_registry: PyPI
 python_version: 3.12.7
 repo_name: lab-auto-pulumi
 repo_org_name: LabAutomationAndScreening
-ssh_port_number: 56805
+ssh_port_number: 64123
 use_codecov: true
 use_windows_in_ci: false
 use_windows_in_exe_ci: false

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - python_venv:/workspaces/lab-auto-pulumi/.venv
     command: sleep infinity
     ports:
-      - "56805:2222"
+      - "64123:2222"
     environment:
       - AWS_PROFILE=localstack
       - AWS_DEFAULT_REGION=us-east-1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lab-auto-pulumi"
-version = "0.1.11"
+version = "0.1.12"
 description = "Pulumi helpers. Especially useful for tooling created by the LabAutomationAndScreening github organization."
 authors = [
     {name = "Eli Fine"},

--- a/src/lab_auto_pulumi/__init__.py
+++ b/src/lab_auto_pulumi/__init__.py
@@ -20,6 +20,7 @@ from .ec2 import Ec2WithRdp
 from .lib import AwsAccountId
 from .lib import AwsLogicalWorkload
 from .lib import WorkloadName
+from .lib import create_resource_name_safe_str
 from .lib import get_manual_artifacts_bucket_name
 from .lib import get_org_managed_ssm_param_value
 from .lib import get_ssm_param_value
@@ -67,6 +68,7 @@ __all__ = [
     "WorkloadName",
     "all_created_users",
     "constants",
+    "create_resource_name_safe_str",
     "get_manual_artifacts_bucket_name",
     "get_org_managed_ssm_param_value",
     "get_ssm_param_value",

--- a/src/lab_auto_pulumi/lib.py
+++ b/src/lab_auto_pulumi/lib.py
@@ -10,6 +10,21 @@ type WorkloadName = str
 type AwsAccountId = str
 
 
+def create_resource_name_safe_str(name: str) -> str:
+    return (
+        name.lower()
+        .replace(" ", "-")
+        .replace(":", "-")
+        .replace("(", "-")
+        .replace(")", "-")
+        .replace("'", "-")
+        .replace('"', "-")
+        .replace("/", "-")
+        .replace(chr(92), "-")  # backslash
+        .replace("=", "-")
+    )
+
+
 def get_ssm_param_value(
     param_name: str, *, ssm_client: SSMClient | None = None, session: boto3.Session | None = None
 ) -> str:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,7 @@
+from lab_auto_pulumi import create_resource_name_safe_str
+
+
+def test_When_create_resource_name_safe_str__Then_invalid_characters_converted():
+    actual = create_resource_name_safe_str("a:b c(d)e'f" + '"g/h=i' + r"\j" + ":k")
+
+    assert actual == "a-b-c-d-e-f-g-h-i-j-k"

--- a/uv.lock
+++ b/uv.lock
@@ -624,7 +624,7 @@ wheels = [
 
 [[package]]
 name = "lab-auto-pulumi"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
 ## Why is this change necessary?
With just using `idx` there were weird cases when changes happened of not all rules being recreated successfully


 ## How does this change address the issue?
Uses the rule description to set the pulumi resource name


 ## What side effects does this change have?
None


 ## How is this change tested?
Downstream repo using this