### PR TITLE
Bump pulumi-aws to v7

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,9 +1,10 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.42
+_commit: v0.0.48
 _src_path: gh:LabAutomationAndScreening/copier-python-package-template
 create_docs: false
 description: Pulumi helpers
 full_repo_url: https://github.com/LabAutomationAndScreening/lab-auto-pulumi
+install_aws_ssm_port_forwarding_plugin: false
 is_frozen_executable: false
 is_open_source: true
 package_name: lab-auto-pulumi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,7 @@
         "ms-python.python@2025.7.2025051401",
         "ms-python.vscode-pylance@2025.4.104",
         "ms-vscode-remote.remote-containers@0.414.0",
-        "charliermarsh.ruff@2025.22.0",
+        "charliermarsh.ruff@2025.24.0",
 
         // Misc file formats
         "bierner.markdown-mermaid@1.28.0",
@@ -61,5 +61,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 147bbf24 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): e94f1924 # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -61,5 +61,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): e94f1924 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 2fd031ee # spellchecker:disable-line
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,7 @@
 services:
   devcontainer:
+    # added the platform flag to override any local settings since this image is only compatible with linux/amd64.
+    platform: linux/amd64
     build:
       context: .
       args:

--- a/.devcontainer/install-ci-tooling.py
+++ b/.devcontainer/install-ci-tooling.py
@@ -7,11 +7,11 @@ import sys
 import tempfile
 from pathlib import Path
 
-UV_VERSION = "0.8.3"
+UV_VERSION = "0.8.4"
 PNPM_VERSION = "10.14.0"
-COPIER_VERSION = "9.8.0"
+COPIER_VERSION = "9.9.1"
 COPIER_TEMPLATE_EXTENSIONS_VERSION = "0.3.2"
-PRE_COMMIT_VERSION = "4.2.0"
+PRE_COMMIT_VERSION = "4.3.0"
 GITHUB_WINDOWS_RUNNER_BIN_PATH = r"C:\Users\runneradmin\.local\bin"
 INSTALL_SSM_PLUGIN_BY_DEFAULT = False
 parser = argparse.ArgumentParser(description="Install CI tooling for the repo")

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,18 +11,22 @@ env:
   PRE_COMMIT_HOME: ${{ github.workspace }}/.precommit_cache
 
 permissions:
-    id-token: write
-    contents: write # needed for mutex, and updating dependabot branches
-    statuses: write # needed for updating status on Dependabot PRs
+  id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
+  contents: read # need to explicitly provide this whenever defining permissions because the default value is 'none' for anything not explicitly set when permissions are defined
 
 jobs:
   get-values:
     uses: ./.github/workflows/get-values.yaml
+    permissions:
+      contents: write # needed updating dependabot branches
 
   lint:
     needs: [ get-values ]
     name: Pre-commit
     uses: ./.github/workflows/pre-commit.yaml
+    permissions:
+      contents: write # needed for mutex
+      id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
     with:
       python-version: 3.12.7
 
@@ -45,7 +49,8 @@ jobs:
             JOB_MATCHING_DEV_ENV: true
 
     runs-on: ${{ matrix.os }}
-
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2
@@ -78,6 +83,8 @@ jobs:
 
   required-check:
     runs-on: ubuntu-24.04
+    permissions:
+      statuses: write # needed for updating status on Dependabot PRs
     needs:
       - test
       - get-values

--- a/.github/workflows/get-values.yaml
+++ b/.github/workflows/get-values.yaml
@@ -14,7 +14,7 @@ env:
   PYTHONUNBUFFERED: True
 
 permissions:
-    contents: write # needed to push commit of new devcontainer hash for dependabot PRs
+  contents: write # needed to push commit of new devcontainer hash for dependabot PRs
 
 jobs:
   get-values:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -22,7 +22,8 @@ env:
   PRE_COMMIT_HOME: ${{ github.workspace }}/.precommit_cache
 
 permissions:
-    contents: write # needed for mutex
+  contents: write # needed for mutex
+  id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
 
 jobs:
   pre-commit:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,8 +13,8 @@ env:
   PRE_COMMIT_HOME: ${{ github.workspace }}/.precommit_cache
 
 permissions:
-    id-token: write
-    contents: write # needed for mutex
+  id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
+  contents: read # need to explicitly provide this whenever defining permissions because the default value is 'none' for anything not explicitly set when permissions are defined
 
 jobs:
   get-values:
@@ -39,6 +39,9 @@ jobs:
   lint:
     name: Pre-commit
     uses: ./.github/workflows/pre-commit.yaml
+    permissions:
+      contents: write # needed for mutex
+      id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
     with:
       python-version: 3.12.7
 
@@ -61,6 +64,8 @@ jobs:
             JOB_MATCHING_DEV_ENV: true
 
     runs-on: ${{ matrix.os }}
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
 
     steps:
       - name: Checkout code
@@ -146,6 +151,8 @@ jobs:
             JOB_MATCHING_DEV_ENV: true
 
     runs-on: ${{ matrix.os }}
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
 
     steps:
       - name: Checkout code
@@ -158,18 +165,20 @@ jobs:
       - name: Sleep to allow PyPI Index to update before proceeding to the next step
         uses: juliangruber/sleep-action@v2.0.3
         with:
-          time: 60s
+          time: 90s
       - name: Install from staging registry
         run: pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://www.pypi.org/simple lab-auto-pulumi==${{ needs.get-values.outputs.package-version }}
       - name: Display dependencies
         run: pip list
       - name: Confirm library can be imported successfully
-        run: python -c "import lab_auto_pulumi"
+        run: python -c "import sys; print(f'Python version {sys.version}'); import lab_auto_pulumi"
 
   create-tag:
     name: Create the git tag
     if: ${{ github.event.inputs.publish_to_primary }}
     needs: [ install-from-staging ]
+    permissions:
+      contents: write # needed to push the tag
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
@@ -227,6 +236,8 @@ jobs:
             JOB_MATCHING_DEV_ENV: true
 
     runs-on: ${{ matrix.os }}
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
 
     steps:
       - name: Checkout code
@@ -239,10 +250,10 @@ jobs:
       - name: Sleep to allow PyPI Index to update before proceeding to the next step
         uses: juliangruber/sleep-action@v2.0.3
         with:
-          time: 60s
+          time: 90s
       - name: Install from primary registry
         run: pip install lab-auto-pulumi==${{ needs.get-values.outputs.package-version }}
       - name: Display dependencies
         run: pip list
       - name: Confirm library can be imported successfully
-        run: python -c "import lab_auto_pulumi"
+        run: python -c "import sys; print(f'Python version {sys.version}'); import lab_auto_pulumi"

--- a/.github/workflows/publish_to_staging.yaml
+++ b/.github/workflows/publish_to_staging.yaml
@@ -8,13 +8,16 @@ env:
   PRE_COMMIT_HOME: ${{ github.workspace }}/.precommit_cache
 
 permissions:
-    id-token: write
-    contents: write # needed for mutex
+  id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
+  contents: read # need to explicitly provide this whenever defining permissions because the default value is 'none' for anything not explicitly set when permissions are defined
 
 jobs:
   lint:
     name: Pre-commit
     uses: ./.github/workflows/pre-commit.yaml
+    permissions:
+      contents: write # needed for mutex
+      id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
     with:
       python-version: 3.12.7
 
@@ -37,6 +40,8 @@ jobs:
             JOB_MATCHING_DEV_ENV: true
 
     runs-on: ${{ matrix.os }}
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
 
     steps:
       - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ coverage-report-pytest
 .mypy_cache/
 .coverage
 .coverage.*
+coverage.xml
 
 # test profiling
 prof/
@@ -75,5 +76,10 @@ dist
 # Logs
 *.log
 **/logs/log*.txt
+**/logs/*.log.*
+
+# macOS dev cleanliness
+*.DS_Store
+.DS_Store
 
 # Ignores specific to this repository

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-minimum_pre_commit_version: 4.0.1
+minimum_pre_commit_version: 4.2.0
 # run `pre-commit autoupdate --freeze` to update all hooks
 default_install_hook_types: [pre-commit, post-checkout]
 repos:
@@ -42,7 +42,7 @@ repos:
 
   # Reformatting (should generally come before any file format or other checks, because reformatting can change things)
   - repo: https://github.com/crate-ci/typos
-    rev: 392b78fe18a52790c53f42456e46124f77346842  # frozen: v1.34.0
+    rev: 7fb6e0951ad91e4772a2470012fc1ae621016b80  # frozen: v1
     hooks:
       - id: typos
         exclude:
@@ -53,13 +53,14 @@ repos:
               .*\.umd.js|
           )$
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # frozen: v5.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude:
           |
           (?x)^(
               .*/vendor_files/.*|
+              .*tests/.*/__snapshots__/.*|
           )$
       - id: end-of-file-fixer
         # the XML formatter hook doesn't leave a blank line at the end, so excluding XML files from this hook to avoid conflicts
@@ -71,6 +72,8 @@ repos:
               template/.copier-answers.yml.jinja-base|
               template/template/.copier-answers.yml.jinja|
               template/.copier-answers.yml.jinja|
+              .*generated/graphql.ts|
+              .*tests/.*/__snapshots__/.*|
               .devcontainer/devcontainer-lock.json|
               .copier-answers.yml|
               .*\.xml|
@@ -85,6 +88,7 @@ repos:
               .*pyrightconfig.json|
               .*tsconfig.json|
               .*biome.jsonc|
+              .*tests/.*/__snapshots__/.*|
               .*/vendor_files/.*|
           )$
         args: [--autofix, --no-sort-keys]
@@ -150,7 +154,7 @@ repos:
 
   # Invalid File Checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # frozen: v5.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: check-added-large-files
         args: ["--maxkb=123"]
@@ -200,7 +204,7 @@ repos:
 
   # Safety/Security Issues
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # frozen: v5.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: detect-private-key
 
@@ -222,7 +226,7 @@ repos:
         description: Runs hadolint to lint Dockerfiles
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 3d44372123ca5e8617fdb65d9f11facd159b9e95  # frozen: v0.12.3
+    rev: 54a455f7ce629598b7535ff828fd5fb796f4b83f  # frozen: v0.12.9
     hooks:
       - id: ruff
         name: ruff-src
@@ -235,7 +239,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pylint-dev/pylint
-    rev: f798a4a3508bcbb8ad0773ae14bf32d28dcfdcbe  # frozen: v3.3.7
+    rev: 98942ba4126a6fe1657bad77027bcc11016d16da  # frozen: v3.3.8
     hooks:
       - id: pylint
         name: pylint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lab-auto-pulumi"
-version = "0.1.15"
+version = "0.1.16"
 description = "Pulumi helpers. Especially useful for tooling created by the LabAutomationAndScreening github organization."
 authors = [
     {name = "Eli Fine"},
@@ -17,13 +17,13 @@ classifiers = [
 
 ]
 dependencies = [
-    "pulumi>=3.156.0",
-    "pulumi-aws>=6.72.0",
-    "pulumi-aws-native>=1.26.0",
-    "ephemeral-pulumi-deploy>=0.0.4",
-    "boto3>=1.37.11",
-    "boto3-stubs[ssm]>=1.37.11",
-    "pydantic>=2.10.6",
+    "pulumi>=3.190.0",
+    "pulumi-aws>=7.5.0",
+    "pulumi-aws-native>=1.32.0",
+    "ephemeral-pulumi-deploy>=0.0.5",
+    "boto3>=1.40.9",
+    "boto3-stubs[ssm]>=1.40.9",
+    "pydantic>=2.11.7",
 ]
 
 
@@ -31,7 +31,7 @@ dependencies = [
 dev = [
     # Specific to this repository
 
-    "boto3-stubs[all]>=1.37.11",
+    "boto3-stubs[all]>=1.40.9",
 
 
     # Managed by upstream template

--- a/uv.lock
+++ b/uv.lock
@@ -31,29 +31,29 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.38.13"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/89/a47f62b3f81a2e3484d2a2b8dd4906c5b6e57da0af0bd59d36f99ba20baf/boto3-1.38.13.tar.gz", hash = "sha256:6633bce2b73284acce1453ca85834c7c5a59e0dbcce1170be461cc079bdcdfcf", size = 111812, upload-time = "2025-05-09T19:33:02.962Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/d4/ad261cb17f202082ba8598fd6d1d27eac5d11307ce99e3f5867bc9e376ee/boto3-1.40.16.tar.gz", hash = "sha256:667bc3a9bd1f26579957d95a2612359103c343dd74d44f202d09a155ed4189c6", size = 111944, upload-time = "2025-08-22T19:28:30.643Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/25/79e219648f10d060d152542fcf3be0093120471774b99c1a7f41ceaeca9b/boto3-1.38.13-py3-none-any.whl", hash = "sha256:668400d13889d2d2fcd66ce785cc0b0fc040681f58a9c7f67daa9149a52b6c63", size = 139934, upload-time = "2025-05-09T19:33:00.855Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ce/6030ebcde6a19920c36d633643811a80e53d2b92a4a125ddf07520b2da66/boto3-1.40.16-py3-none-any.whl", hash = "sha256:4b7fbd2b469d5fa6325f0e90310b2d430c9a35e8a984a9919103e6d248422537", size = 140076, upload-time = "2025-08-22T19:28:28.656Z" },
 ]
 
 [[package]]
 name = "boto3-stubs"
-version = "1.38.13"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "botocore-stubs" },
     { name = "types-s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/4d/34fd1a6387bf03abc387cf618186eaeccb5c12fbf09bc08b58e0892e71ce/boto3_stubs-1.38.13.tar.gz", hash = "sha256:8f73a745745d5ed3a206427ff46ae82c48c37f86d0d264395898bdf0e5563520", size = 99277, upload-time = "2025-05-09T19:47:11.116Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/c9/6e95f300d184c50d9ff9858f5732dbdc6e8eddf9acbe110eeb69a7eedfab/boto3_stubs-1.40.16.tar.gz", hash = "sha256:30960a4a46a4c49aac440deb1281356fe8907facff100e76ce4587738dc77d01", size = 101370, upload-time = "2025-08-22T19:47:52.4Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/d0/a054ededc8d37a9969eeb944d288014bb816d2aca3fe3cc50d0a109d4277/boto3_stubs-1.38.13-py3-none-any.whl", hash = "sha256:19361506afd23f47692264be90c668c952ef27b08cc7acaf6d9fddea81ce7455", size = 68777, upload-time = "2025-05-09T19:47:02.674Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/91/932828f253b3c081814ccdeb6a6d00f2ec2e3dbebdba70f54233415ce6ba/boto3_stubs-1.40.16-py3-none-any.whl", hash = "sha256:6b4e555fdd183c0615cda7d4048f4f8ebcd78428374f307ae5f56c4dacd00871", size = 70011, upload-time = "2025-08-22T19:47:42.58Z" },
 ]
 
 [package.optional-dependencies]
@@ -62,6 +62,7 @@ all = [
     { name = "mypy-boto3-account" },
     { name = "mypy-boto3-acm" },
     { name = "mypy-boto3-acm-pca" },
+    { name = "mypy-boto3-aiops" },
     { name = "mypy-boto3-amp" },
     { name = "mypy-boto3-amplify" },
     { name = "mypy-boto3-amplifybackend" },
@@ -83,6 +84,7 @@ all = [
     { name = "mypy-boto3-appstream" },
     { name = "mypy-boto3-appsync" },
     { name = "mypy-boto3-apptest" },
+    { name = "mypy-boto3-arc-region-switch" },
     { name = "mypy-boto3-arc-zonal-shift" },
     { name = "mypy-boto3-artifact" },
     { name = "mypy-boto3-athena" },
@@ -94,11 +96,15 @@ all = [
     { name = "mypy-boto3-backup-gateway" },
     { name = "mypy-boto3-backupsearch" },
     { name = "mypy-boto3-batch" },
+    { name = "mypy-boto3-bcm-dashboards" },
     { name = "mypy-boto3-bcm-data-exports" },
     { name = "mypy-boto3-bcm-pricing-calculator" },
+    { name = "mypy-boto3-bcm-recommended-actions" },
     { name = "mypy-boto3-bedrock" },
     { name = "mypy-boto3-bedrock-agent" },
     { name = "mypy-boto3-bedrock-agent-runtime" },
+    { name = "mypy-boto3-bedrock-agentcore" },
+    { name = "mypy-boto3-bedrock-agentcore-control" },
     { name = "mypy-boto3-bedrock-data-automation" },
     { name = "mypy-boto3-bedrock-data-automation-runtime" },
     { name = "mypy-boto3-bedrock-runtime" },
@@ -202,6 +208,7 @@ all = [
     { name = "mypy-boto3-es" },
     { name = "mypy-boto3-events" },
     { name = "mypy-boto3-evidently" },
+    { name = "mypy-boto3-evs" },
     { name = "mypy-boto3-finspace" },
     { name = "mypy-boto3-finspace-data" },
     { name = "mypy-boto3-firehose" },
@@ -259,6 +266,7 @@ all = [
     { name = "mypy-boto3-kendra" },
     { name = "mypy-boto3-kendra-ranking" },
     { name = "mypy-boto3-keyspaces" },
+    { name = "mypy-boto3-keyspacesstreams" },
     { name = "mypy-boto3-kinesis" },
     { name = "mypy-boto3-kinesis-video-archived-media" },
     { name = "mypy-boto3-kinesis-video-media" },
@@ -314,6 +322,7 @@ all = [
     { name = "mypy-boto3-migrationhub-config" },
     { name = "mypy-boto3-migrationhuborchestrator" },
     { name = "mypy-boto3-migrationhubstrategy" },
+    { name = "mypy-boto3-mpa" },
     { name = "mypy-boto3-mq" },
     { name = "mypy-boto3-mturk" },
     { name = "mypy-boto3-mwaa" },
@@ -328,6 +337,7 @@ all = [
     { name = "mypy-boto3-notificationscontacts" },
     { name = "mypy-boto3-oam" },
     { name = "mypy-boto3-observabilityadmin" },
+    { name = "mypy-boto3-odb" },
     { name = "mypy-boto3-omics" },
     { name = "mypy-boto3-opensearch" },
     { name = "mypy-boto3-opensearchserverless" },
@@ -354,7 +364,6 @@ all = [
     { name = "mypy-boto3-pipes" },
     { name = "mypy-boto3-polly" },
     { name = "mypy-boto3-pricing" },
-    { name = "mypy-boto3-privatenetworks" },
     { name = "mypy-boto3-proton" },
     { name = "mypy-boto3-qapps" },
     { name = "mypy-boto3-qbusiness" },
@@ -389,6 +398,7 @@ all = [
     { name = "mypy-boto3-s3control" },
     { name = "mypy-boto3-s3outposts" },
     { name = "mypy-boto3-s3tables" },
+    { name = "mypy-boto3-s3vectors" },
     { name = "mypy-boto3-sagemaker" },
     { name = "mypy-boto3-sagemaker-a2i-runtime" },
     { name = "mypy-boto3-sagemaker-edge" },
@@ -459,6 +469,7 @@ all = [
     { name = "mypy-boto3-workmail" },
     { name = "mypy-boto3-workmailmessageflow" },
     { name = "mypy-boto3-workspaces" },
+    { name = "mypy-boto3-workspaces-instances" },
     { name = "mypy-boto3-workspaces-thin-client" },
     { name = "mypy-boto3-workspaces-web" },
     { name = "mypy-boto3-xray" },
@@ -469,16 +480,16 @@ ssm = [
 
 [[package]]
 name = "botocore"
-version = "1.38.13"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/36/5b0faba074684744244e1e030e73fd5612bc2c38f557eec0a7f1a3d7ddd2/botocore-1.38.13.tar.gz", hash = "sha256:22feee15753cd3f9f7179d041604078a1024701497d27b22be7c6707e8d13ccb", size = 13882010, upload-time = "2025-05-09T19:32:51.172Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/4c/7087a282f10dc2258a107e4a29645678b5d3fa7cbabed05d540370aa8c57/botocore-1.40.16.tar.gz", hash = "sha256:522a8b7e3837667aca978b5b2dd2d12c3834f58f13df3c8d3369070d883d608d", size = 14368291, upload-time = "2025-08-22T19:28:20.227Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/df/a7a8097471d5a3bc7d408850222292d874ffc190aef7e1cacf9af770339e/botocore-1.38.13-py3-none-any.whl", hash = "sha256:de29fee43a1f02787fb5b3756ec09917d5661ed95b2b2d64797ab04196f69e14", size = 13544507, upload-time = "2025-05-09T19:32:37.727Z" },
+    { url = "https://files.pythonhosted.org/packages/03/5c/81ff55d99c0f38fdcaee693228a6af61486f368fe7e49bc27da1317682b9/botocore-1.40.16-py3-none-any.whl", hash = "sha256:0296a245cb349431279d825522ae70270edf8d8be7b91108fdcc086ea347c0b6", size = 14030380, upload-time = "2025-08-22T19:28:14.793Z" },
 ]
 
 [[package]]
@@ -569,7 +580,7 @@ wheels = [
 
 [[package]]
 name = "ephemeral-pulumi-deploy"
-version = "0.0.4"
+version = "0.0.5"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "boto3" },
@@ -577,35 +588,37 @@ dependencies = [
     { name = "pulumi-aws" },
     { name = "pulumi-aws-native" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/66/77303bd5f85af3d4788e303eabd91f5e7fbbdf4da80b708d56f4f6b70f0d/ephemeral_pulumi_deploy-0.0.4.tar.gz", hash = "sha256:e6c255cbdef3362a96574eb14aa16636687e7ac6113e4a386fb71690ec267955", size = 8221, upload-time = "2025-03-17T15:57:00.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/bb/f185c984a5912e29cd63809cff4cd948d8007df387b6404377359c5b4275/ephemeral_pulumi_deploy-0.0.5.tar.gz", hash = "sha256:35b771a5387661d1a75dedac6c845d64c522637d4141937ffcdf9fb2738e36ff", size = 8279, upload-time = "2025-08-25T13:22:23.239Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/c9/d44d1468b577817453f10812b5343f802d7deff3afe94c40d99626188319/ephemeral_pulumi_deploy-0.0.4-py3-none-any.whl", hash = "sha256:67578ff8b1c0c472a68f99570997b1992adb9e1fd9173877f784be2548b74485", size = 7888, upload-time = "2025-03-17T15:56:59.319Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e9/770a5449aee346a3e80b9c0ea5eba744739b3972f3dd76f4d27a275e2033/ephemeral_pulumi_deploy-0.0.5-py3-none-any.whl", hash = "sha256:7a2f95c671ceb3ceb8c0155e14496a4ad08101ad77f034ad4fe9917328e2b68d", size = 8004, upload-time = "2025-08-25T13:22:22.122Z" },
 ]
 
 [[package]]
 name = "grpcio"
-version = "1.66.2"
+version = "1.74.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/d1/49a96df4eb1d805cf546247df40636515416d2d5c66665e5129c8b4162a8/grpcio-1.66.2.tar.gz", hash = "sha256:563588c587b75c34b928bc428548e5b00ea38c46972181a4d8b75ba7e3f24231", size = 12489713, upload-time = "2024-09-28T12:44:01.429Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/b4/35feb8f7cab7239c5b94bd2db71abb3d6adb5f335ad8f131abb6060840b6/grpcio-1.74.0.tar.gz", hash = "sha256:80d1f4fbb35b0742d3e3d3bb654b7381cd5f015f8497279a1e9c21ba623e01b1", size = 12756048, upload-time = "2025-07-24T18:54:23.039Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/5c/c4da36b7a77dbb15c4bc72228dff7161874752b2c6bddf7bb046d9da1b90/grpcio-1.66.2-cp312-cp312-linux_armv7l.whl", hash = "sha256:802d84fd3d50614170649853d121baaaa305de7b65b3e01759247e768d691ddf", size = 5002933, upload-time = "2024-09-28T12:38:24.109Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/d5/b631445dff250a5301f51ff56c5fc917c7f955cd02fa55379f158a89abeb/grpcio-1.66.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:80fd702ba7e432994df208f27514280b4b5c6843e12a48759c9255679ad38db8", size = 10793953, upload-time = "2024-09-28T12:38:27.02Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/1c/2179ac112152e92c02990f98183edf645df14aa3c38b39f1a3a60358b6c6/grpcio-1.66.2-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:12fda97ffae55e6526825daf25ad0fa37483685952b5d0f910d6405c87e3adb6", size = 5499791, upload-time = "2024-09-28T12:38:30.065Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/53/8d7ab865fbd983309c8242930f00b28a01047f70c2b2e4c79a5c92a46a08/grpcio-1.66.2-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:950da58d7d80abd0ea68757769c9db0a95b31163e53e5bb60438d263f4bed7b7", size = 6109606, upload-time = "2024-09-28T12:38:33.566Z" },
-    { url = "https://files.pythonhosted.org/packages/86/e9/3dfb5a3ff540636d46b8b723345e923e8c553d9b3f6a8d1b09b0d915eb46/grpcio-1.66.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e636ce23273683b00410f1971d209bf3689238cf5538d960adc3cdfe80dd0dbd", size = 5762866, upload-time = "2024-09-28T12:38:36.023Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/cb/c07493ad5dd73d51e4e15b0d483ff212dfec136ee1e4f3b49d115bdc7a13/grpcio-1.66.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:a917d26e0fe980b0ac7bfcc1a3c4ad6a9a4612c911d33efb55ed7833c749b0ee", size = 6446819, upload-time = "2024-09-28T12:38:38.69Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/5f/142e19db367a34ea0ee8a8451e43215d0a1a5dbffcfdcae8801f22903301/grpcio-1.66.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:49f0ca7ae850f59f828a723a9064cadbed90f1ece179d375966546499b8a2c9c", size = 6040273, upload-time = "2024-09-28T12:38:41.348Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/3b/12fcd752c55002e4b0e0a7bd5faec101bc0a4e3890be3f95a43353142481/grpcio-1.66.2-cp312-cp312-win32.whl", hash = "sha256:31fd163105464797a72d901a06472860845ac157389e10f12631025b3e4d0453", size = 3537988, upload-time = "2024-09-28T12:38:44.544Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/70/76bfea3faa862bfceccba255792e780691ff25b8227180759c9d38769379/grpcio-1.66.2-cp312-cp312-win_amd64.whl", hash = "sha256:ff1f7882e56c40b0d33c4922c15dfa30612f05fb785074a012f7cda74d1c3679", size = 4275553, upload-time = "2024-09-28T12:38:47.734Z" },
-    { url = "https://files.pythonhosted.org/packages/72/31/8708a8dfb3f1ac89926c27c5dd17412764157a2959dbc5a606eaf8ac71f6/grpcio-1.66.2-cp313-cp313-linux_armv7l.whl", hash = "sha256:3b00efc473b20d8bf83e0e1ae661b98951ca56111feb9b9611df8efc4fe5d55d", size = 5004245, upload-time = "2024-09-28T12:38:50.596Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/37/0b57c3769efb3cc9ec97fcaa9f7243046660e7ed58c0faebc4ef315df92c/grpcio-1.66.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:1caa38fb22a8578ab8393da99d4b8641e3a80abc8fd52646f1ecc92bcb8dee34", size = 10756749, upload-time = "2024-09-28T12:38:54.131Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/5a/425e995724a19a1b110340ed653bc7c5de8019d9fc84b3798a0f79c3eb31/grpcio-1.66.2-cp313-cp313-manylinux_2_17_aarch64.whl", hash = "sha256:c408f5ef75cfffa113cacd8b0c0e3611cbfd47701ca3cdc090594109b9fcbaed", size = 5499666, upload-time = "2024-09-28T12:38:57.145Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/e4/86a5c5ec40a6b683671a1d044ebca433812d99da8fcfc2889e9c43cecbd4/grpcio-1.66.2-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c806852deaedee9ce8280fe98955c9103f62912a5b2d5ee7e3eaa284a6d8d8e7", size = 6109578, upload-time = "2024-09-28T12:38:59.835Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/86/a86742f3deaa22385c3bff984c5947fc62d47d3fab26c508730037d027e5/grpcio-1.66.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f145cc21836c332c67baa6fc81099d1d27e266401565bf481948010d6ea32d46", size = 5763274, upload-time = "2024-09-28T12:39:02.287Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/61/b9a2a4345dea0a354c4ed8ac7aacbdd0ff986acbc8f92680213cf3d2faa3/grpcio-1.66.2-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:73e3b425c1e155730273f73e419de3074aa5c5e936771ee0e4af0814631fb30a", size = 6450416, upload-time = "2024-09-28T12:39:05.06Z" },
-    { url = "https://files.pythonhosted.org/packages/50/b9/ad303ce75d8cd71d855a661519aa160ce42f27498f589f1ae6d9f8c5e8ac/grpcio-1.66.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:9c509a4f78114cbc5f0740eb3d7a74985fd2eff022971bc9bc31f8bc93e66a3b", size = 6040045, upload-time = "2024-09-28T12:39:08.214Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/b3/8db1873e3240ef1672ba87b89e949ece367089e29e4d221377bfdd288bd3/grpcio-1.66.2-cp313-cp313-win32.whl", hash = "sha256:20657d6b8cfed7db5e11b62ff7dfe2e12064ea78e93f1434d61888834bc86d75", size = 3537126, upload-time = "2024-09-28T12:39:10.655Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/df/133216989fe7e17caeafd7ff5b17cc82c4e722025d0b8d5d2290c11fe2e6/grpcio-1.66.2-cp313-cp313-win_amd64.whl", hash = "sha256:fb70487c95786e345af5e854ffec8cb8cc781bcc5df7930c4fbb7feaa72e1cdf", size = 4278018, upload-time = "2024-09-28T12:39:13.196Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/5d/e504d5d5c4469823504f65687d6c8fb97b7f7bf0b34873b7598f1df24630/grpcio-1.74.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:8533e6e9c5bd630ca98062e3a1326249e6ada07d05acf191a77bc33f8948f3d8", size = 5445551, upload-time = "2025-07-24T18:53:23.641Z" },
+    { url = "https://files.pythonhosted.org/packages/43/01/730e37056f96f2f6ce9f17999af1556df62ee8dab7fa48bceeaab5fd3008/grpcio-1.74.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:2918948864fec2a11721d91568effffbe0a02b23ecd57f281391d986847982f6", size = 10979810, upload-time = "2025-07-24T18:53:25.349Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3d/09fd100473ea5c47083889ca47ffd356576173ec134312f6aa0e13111dee/grpcio-1.74.0-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:60d2d48b0580e70d2e1954d0d19fa3c2e60dd7cbed826aca104fff518310d1c5", size = 5941946, upload-time = "2025-07-24T18:53:27.387Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/99/12d2cca0a63c874c6d3d195629dcd85cdf5d6f98a30d8db44271f8a97b93/grpcio-1.74.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3601274bc0523f6dc07666c0e01682c94472402ac2fd1226fd96e079863bfa49", size = 6621763, upload-time = "2025-07-24T18:53:29.193Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/2c/930b0e7a2f1029bbc193443c7bc4dc2a46fedb0203c8793dcd97081f1520/grpcio-1.74.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:176d60a5168d7948539def20b2a3adcce67d72454d9ae05969a2e73f3a0feee7", size = 6180664, upload-time = "2025-07-24T18:53:30.823Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d5/ff8a2442180ad0867717e670f5ec42bfd8d38b92158ad6bcd864e6d4b1ed/grpcio-1.74.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e759f9e8bc908aaae0412642afe5416c9f983a80499448fcc7fab8692ae044c3", size = 6301083, upload-time = "2025-07-24T18:53:32.454Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ba/b361d390451a37ca118e4ec7dccec690422e05bc85fba2ec72b06cefec9f/grpcio-1.74.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:9e7c4389771855a92934b2846bd807fc25a3dfa820fd912fe6bd8136026b2707", size = 6994132, upload-time = "2025-07-24T18:53:34.506Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/0c/3a5fa47d2437a44ced74141795ac0251bbddeae74bf81df3447edd767d27/grpcio-1.74.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:cce634b10aeab37010449124814b05a62fb5f18928ca878f1bf4750d1f0c815b", size = 6489616, upload-time = "2025-07-24T18:53:36.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/95/ab64703b436d99dc5217228babc76047d60e9ad14df129e307b5fec81fd0/grpcio-1.74.0-cp312-cp312-win32.whl", hash = "sha256:885912559974df35d92219e2dc98f51a16a48395f37b92865ad45186f294096c", size = 3807083, upload-time = "2025-07-24T18:53:37.911Z" },
+    { url = "https://files.pythonhosted.org/packages/84/59/900aa2445891fc47a33f7d2f76e00ca5d6ae6584b20d19af9c06fa09bf9a/grpcio-1.74.0-cp312-cp312-win_amd64.whl", hash = "sha256:42f8fee287427b94be63d916c90399ed310ed10aadbf9e2e5538b3e497d269bc", size = 4490123, upload-time = "2025-07-24T18:53:39.528Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d8/1004a5f468715221450e66b051c839c2ce9a985aa3ee427422061fcbb6aa/grpcio-1.74.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:2bc2d7d8d184e2362b53905cb1708c84cb16354771c04b490485fa07ce3a1d89", size = 5449488, upload-time = "2025-07-24T18:53:41.174Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0e/33731a03f63740d7743dced423846c831d8e6da808fcd02821a4416df7fa/grpcio-1.74.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c14e803037e572c177ba54a3e090d6eb12efd795d49327c5ee2b3bddb836bf01", size = 10974059, upload-time = "2025-07-24T18:53:43.066Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/c6/3d2c14d87771a421205bdca991467cfe473ee4c6a1231c1ede5248c62ab8/grpcio-1.74.0-cp313-cp313-manylinux_2_17_aarch64.whl", hash = "sha256:f6ec94f0e50eb8fa1744a731088b966427575e40c2944a980049798b127a687e", size = 5945647, upload-time = "2025-07-24T18:53:45.269Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/83/5a354c8aaff58594eef7fffebae41a0f8995a6258bbc6809b800c33d4c13/grpcio-1.74.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:566b9395b90cc3d0d0c6404bc8572c7c18786ede549cdb540ae27b58afe0fb91", size = 6626101, upload-time = "2025-07-24T18:53:47.015Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ca/4fdc7bf59bf6994aa45cbd4ef1055cd65e2884de6113dbd49f75498ddb08/grpcio-1.74.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1ea6176d7dfd5b941ea01c2ec34de9531ba494d541fe2057c904e601879f249", size = 6182562, upload-time = "2025-07-24T18:53:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/48/2869e5b2c1922583686f7ae674937986807c2f676d08be70d0a541316270/grpcio-1.74.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:64229c1e9cea079420527fa8ac45d80fc1e8d3f94deaa35643c381fa8d98f362", size = 6303425, upload-time = "2025-07-24T18:53:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0e/bac93147b9a164f759497bc6913e74af1cb632c733c7af62c0336782bd38/grpcio-1.74.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:0f87bddd6e27fc776aacf7ebfec367b6d49cad0455123951e4488ea99d9b9b8f", size = 6996533, upload-time = "2025-07-24T18:53:52.747Z" },
+    { url = "https://files.pythonhosted.org/packages/84/35/9f6b2503c1fd86d068b46818bbd7329db26a87cdd8c01e0d1a9abea1104c/grpcio-1.74.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3b03d8f2a07f0fea8c8f74deb59f8352b770e3900d143b3d1475effcb08eec20", size = 6491489, upload-time = "2025-07-24T18:53:55.06Z" },
+    { url = "https://files.pythonhosted.org/packages/75/33/a04e99be2a82c4cbc4039eb3a76f6c3632932b9d5d295221389d10ac9ca7/grpcio-1.74.0-cp313-cp313-win32.whl", hash = "sha256:b6a73b2ba83e663b2480a90b82fdae6a7aa6427f62bf43b29912c0cfd1aa2bfa", size = 3805811, upload-time = "2025-07-24T18:53:56.798Z" },
+    { url = "https://files.pythonhosted.org/packages/34/80/de3eb55eb581815342d097214bed4c59e806b05f1b3110df03b2280d6dfd/grpcio-1.74.0-cp313-cp313-win_amd64.whl", hash = "sha256:fd3c71aeee838299c5887230b8a1822795325ddfea635edd82954c1eaa831e24", size = 4489214, upload-time = "2025-07-24T18:53:59.771Z" },
 ]
 
 [[package]]
@@ -628,7 +641,7 @@ wheels = [
 
 [[package]]
 name = "lab-auto-pulumi"
-version = "0.1.15"
+version = "0.1.16"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -651,18 +664,18 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "boto3", specifier = ">=1.37.11" },
-    { name = "boto3-stubs", extras = ["ssm"], specifier = ">=1.37.11" },
-    { name = "ephemeral-pulumi-deploy", specifier = ">=0.0.4" },
-    { name = "pulumi", specifier = ">=3.156.0" },
-    { name = "pulumi-aws", specifier = ">=6.72.0" },
-    { name = "pulumi-aws-native", specifier = ">=1.26.0" },
-    { name = "pydantic", specifier = ">=2.10.6" },
+    { name = "boto3", specifier = ">=1.40.9" },
+    { name = "boto3-stubs", extras = ["ssm"], specifier = ">=1.40.9" },
+    { name = "ephemeral-pulumi-deploy", specifier = ">=0.0.5" },
+    { name = "pulumi", specifier = ">=3.190.0" },
+    { name = "pulumi-aws", specifier = ">=7.5.0" },
+    { name = "pulumi-aws-native", specifier = ">=1.32.0" },
+    { name = "pydantic", specifier = ">=2.11.7" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "boto3-stubs", extras = ["all"], specifier = ">=1.37.11" },
+    { name = "boto3-stubs", extras = ["all"], specifier = ">=1.40.9" },
     { name = "pyright", specifier = ">=1.1.403" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
@@ -671,3638 +684,3737 @@ dev = [
 
 [[package]]
 name = "mypy-boto3-accessanalyzer"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/73/1ceb37c831ab2c0a34d1cf185acaeaa093f306d8676165ec2ff8adfe2991/mypy_boto3_accessanalyzer-1.38.0.tar.gz", hash = "sha256:cbdff143caac6bb948d358504cab8304f6af9102ae517ee9138051cf067f6c84", size = 34773, upload-time = "2025-04-22T21:14:52.495Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/1f/48d2c794c819e5e41d035fac94ab3966289fb7dc15db6503c9e6846b43bc/mypy_boto3_accessanalyzer-1.40.0.tar.gz", hash = "sha256:858e5a4a13bd139cccc0f49452e723806d81a1dd25026e75059c8b3ffd492e06", size = 35369, upload-time = "2025-07-31T19:40:09.846Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/56/a381358fe6e8b0499ccfd517433bdc15e93a9cba5c719e3ddfbbe20668dc/mypy_boto3_accessanalyzer-1.38.0-py3-none-any.whl", hash = "sha256:1a9ac29f23da2d08e8ca0b88530a316b35411cbce4532fb520108db5be54aba0", size = 40552, upload-time = "2025-04-22T21:14:41.248Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/92/bc7b5c44e3b5e5967cb8402eea47c043cae74aaa9a74452e2880086ff17b/mypy_boto3_accessanalyzer-1.40.0-py3-none-any.whl", hash = "sha256:0a132b2768d958b8ca40155a12f98c774e0e24abab3bb6ea09bffd42b112af3b", size = 41239, upload-time = "2025-07-31T19:40:08.204Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-account"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/32/7c/4e3b9914afa22b3930b3e0fdb0062f65ab32fb03f49c3812f9f48c3042e2/mypy_boto3_account-1.38.0.tar.gz", hash = "sha256:021956a75c9f6caa0d1aebfaf3b93ed0bf2094fc051bd35bcfc322ba9da95696", size = 17565, upload-time = "2025-04-22T21:14:43.385Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/e7/9ad72910c03c39ff686bc24b32e1b52e51f587eac8292017532393b4d888/mypy_boto3_account-1.40.0.tar.gz", hash = "sha256:8ac34171c7864179153d943d5cd546b7d7821f152275a1d525bb8f9928d839c7", size = 17587, upload-time = "2025-07-31T19:35:16.231Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/a0/8b617722f1afcf585810efe32cb8fd43ba7604cbf2506b4436e37874ed21/mypy_boto3_account-1.38.0-py3-none-any.whl", hash = "sha256:393b37c22f2fea71897758428295de982e035520d35da15d487384c107170e7a", size = 22699, upload-time = "2025-04-22T21:14:41.24Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e0/df4f33947c948a01640806f2796cb44d0c8a95761c4d64e80ba374c544dd/mypy_boto3_account-1.40.0-py3-none-any.whl", hash = "sha256:28a1750b51ff5cda256a7da41066e096d174402752ea8e4b8dbe513def51abe8", size = 22756, upload-time = "2025-07-31T19:35:13.935Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-acm"
-version = "1.38.4"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e9/6c/baa20f1c4d5648e521d72d675c292e5cd80b82f2bc75c44a752400a4bd92/mypy_boto3_acm-1.38.4.tar.gz", hash = "sha256:2c3eff11f70c6ba5019b3f07bb8624a7cd0570e77096209dff4674f531c8d8a5", size = 20243, upload-time = "2025-04-28T19:26:18.793Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/b6/4252607982f765f1bd54f1de516acc83b251306477c9c710d508fc1953aa/mypy_boto3_acm-1.40.0.tar.gz", hash = "sha256:136c14b5448c5f82f28fe1e2a100fa926dec1861138e0cee8c96c47b03877393", size = 20456, upload-time = "2025-07-31T19:35:23.167Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/0a/0460775ccf3d1d56c00c7d8785a02052632a4442cc428d89d4c96cf91ae2/mypy_boto3_acm-1.38.4-py3-none-any.whl", hash = "sha256:7245bb592b0565fa21f08c6d689d4b432710e2527952cf9c79fece8090d51f89", size = 28400, upload-time = "2025-04-28T19:26:09.669Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/08/706a95a3e7faa88c6d8fb1af1b21a43a0969ed69f9d6a09532a7e5d0720e/mypy_boto3_acm-1.40.0-py3-none-any.whl", hash = "sha256:d06afbf92895a3ba5e4848fd7afdfa8c30f32d6a18db3558f07080fdf8e9330e", size = 28830, upload-time = "2025-07-31T19:35:14.997Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-acm-pca"
-version = "1.38.0"
+version = "1.40.1"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/01/0f35bf8667e107d3f80bfb839ef0f5772fd9f0dbc4617a25a70589a49dd6/mypy_boto3_acm_pca-1.38.0.tar.gz", hash = "sha256:ce9d19e0df0c46c2a3427ed46860be30f9014f59933f4c1b2746b9fa9e80dffb", size = 22824, upload-time = "2025-04-22T21:15:02.269Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/31/0afd3bb49c3f191ccd1fd0e3dc359f1fb91b174da7a7caca9d4bee41bedf/mypy_boto3_acm_pca-1.40.1.tar.gz", hash = "sha256:19931e539a8b984ede33acd2b92ddeeb7cad63c0b58e59e3515909980880a02a", size = 22900, upload-time = "2025-08-01T19:29:14.166Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/94/91a6498604aa6b248bd4bdaea24788aa23d83a9fcda41feb9440182b9553/mypy_boto3_acm_pca-1.38.0-py3-none-any.whl", hash = "sha256:d70fa37db5d2d0c5a704e32bc6c4d59e91b7f03c9ca95692ad44357751244e6b", size = 33023, upload-time = "2025-04-22T21:14:53.023Z" },
+    { url = "https://files.pythonhosted.org/packages/56/a6/74c421799a3f8c904aee39122cab1aa9aa2e00dc8218c05dca871f9e831b/mypy_boto3_acm_pca-1.40.1-py3-none-any.whl", hash = "sha256:ff53943cc265fba941ff4bd3289c82911786c84f735fca757ebd054521930a6e", size = 33107, upload-time = "2025-08-01T19:29:06.984Z" },
+]
+
+[[package]]
+name = "mypy-boto3-aiops"
+version = "1.40.1"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/5c/51a9bacd0470cf5a3c37677c35ee0e7980c316f0a77bacf865be0703b608/mypy_boto3_aiops-1.40.1.tar.gz", hash = "sha256:cb48efb0ad9cf5021b07d779b6a53ba2dd8ca1cdaaeb90e666a280c86ef8d2d8", size = 17388, upload-time = "2025-08-01T19:29:11.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/46/95d212dc21bc0762debd290c3f572588c3cb8ade52c57ddc3a272a9bdfa1/mypy_boto3_aiops-1.40.1-py3-none-any.whl", hash = "sha256:a6218386428b0cef9874200df7e2e06aff077bcefc3b9994bee94e15a3cb1ed7", size = 22333, upload-time = "2025-08-01T19:29:06.916Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-amp"
-version = "1.38.0"
+version = "1.40.11"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/25/05/9f558864be8b1de06d64c0a59d956c69b5601fe2f302d8d7532a277aa103/mypy_boto3_amp-1.38.0.tar.gz", hash = "sha256:9ef4d3762fccc2d97c4c4fc21a89eebae14577c6f5b443e5b4498eef5283e428", size = 21769, upload-time = "2025-04-22T21:14:59.455Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/3d/2c526c3b5b308194884f2288043d237a6f41e68c80240e3271b99313a8be/mypy_boto3_amp-1.40.11.tar.gz", hash = "sha256:7a9411193f6e2799c14b52d69c48d70caa0c3d59b0d332669aa229b65a61b6bf", size = 22546, upload-time = "2025-08-15T19:27:50.076Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/91/c376ae0d49e1185af834b2414965d377f67cdbd2b9b4289515fbb0d8df17/mypy_boto3_amp-1.38.0-py3-none-any.whl", hash = "sha256:a7d31ca7fb43f8df2ce88e22075a82069ec1e4ba0e5b36bb72d7031f36319a28", size = 30302, upload-time = "2025-04-22T21:14:55.691Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e5/c15d281e56fbcbc0cdf8df4c34ca30e9fed96f5bad79c03c41d17361feca/mypy_boto3_amp-1.40.11-py3-none-any.whl", hash = "sha256:b2f3c7f33daa5d0aceba42ee7651fab6bfd0e2aae09945832f7e6b79c4d11ea2", size = 31751, upload-time = "2025-08-15T19:27:44.772Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-amplify"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/50/0b/bf02ba582078d32ca654068a88805987e04a58e1ff38791d42f0e84e5a97/mypy_boto3_amplify-1.38.0.tar.gz", hash = "sha256:62ffb03f612f9ebef5ab5c92a8dbb3e63c70889022e797eb0d5aff26cf2b39de", size = 22104, upload-time = "2025-04-22T21:15:00.724Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/e3/a67262557032c52b18bde3f0a48231ecf98fd63129af0fdb4de7eb49aef8/mypy_boto3_amplify-1.40.0.tar.gz", hash = "sha256:07d00f465ded81b2da587b1739d71a603be4a4475044ee4fd4f21b41e711ee5a", size = 22235, upload-time = "2025-07-31T19:35:34.216Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/30/e9d8e7bb4117f036a6106e642a8df05e383ad3570611dfc014a8621f207e/mypy_boto3_amplify-1.38.0-py3-none-any.whl", hash = "sha256:6645fa0ba30216aa09258e3599ddbfce9d2b8bc37a9c460ac88d8df70b432784", size = 30410, upload-time = "2025-04-22T21:14:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/93/a63637eb48904c9df886adc8e4809abf726c2fb95fcdfabfd4c02b67b1f2/mypy_boto3_amplify-1.40.0-py3-none-any.whl", hash = "sha256:78021d684da5adcf0dc6946b740f678423a78a87b5a7d9eaf70cfe17ab6ceac2", size = 30632, upload-time = "2025-07-31T19:35:31.221Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-amplifybackend"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/09/58/a612ad45e61f4b3bf2910e2139719d38069b87086a6d3da3077714cf5bb6/mypy_boto3_amplifybackend-1.38.0.tar.gz", hash = "sha256:6788b4365d5f276a528115db35cfce5c782a7430782f2ca1dbcf37d04e66f1a9", size = 21416, upload-time = "2025-04-22T21:15:06.128Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/05/6fc5e394ca88fd7cb2ca49bb3fa887ba1e134d6a8d3c3144313d53768e6d/mypy_boto3_amplifybackend-1.40.0.tar.gz", hash = "sha256:d5a3fee4888923561ea6e8b29b1b65b4f6cd35d48d2b0d5d1d49f5d5e6441004", size = 21511, upload-time = "2025-07-31T19:35:40.003Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/84/dc8131c2b7ec0656769327568f76e09ad74b634f795f3f4ae3cd95e3ccd5/mypy_boto3_amplifybackend-1.38.0-py3-none-any.whl", hash = "sha256:0478baf8ed1801a381bea12c4303ef3ff36f692ff9986cb4baf8fa1849670cf9", size = 29460, upload-time = "2025-04-22T21:15:03.941Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/32/c02bb7fde553a25527add1ae5402e7655219a3103f7b1bdd46e54bb22c14/mypy_boto3_amplifybackend-1.40.0-py3-none-any.whl", hash = "sha256:2edc59d752b72fee6292c379d54d3b624749a5ba11126926476e9a752a9450dd", size = 29518, upload-time = "2025-07-31T19:35:37.149Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-amplifyuibuilder"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/44/16/d2ad8edd55cebb20e485bab6640bdd5a84976c73dec19b65e4aa7e305363/mypy_boto3_amplifyuibuilder-1.38.0.tar.gz", hash = "sha256:c3e7a58466bbfed5d4f27cda13c14d2dbb767f78810ae95a5b591d536a4ad306", size = 31087, upload-time = "2025-04-22T21:15:08.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/54/2b38a66e7bc8b585022df454dc2b12d170e98eab3df2ea2b5a375b05de86/mypy_boto3_amplifyuibuilder-1.40.0.tar.gz", hash = "sha256:c0176ade4234125d57651b86306da537466373518804e22d301bdcb45ff5d168", size = 31109, upload-time = "2025-07-31T19:35:42.819Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/1a/bfd11904a9631e130c0f32853c32d86f28c0086eafd3e26ac1b7c417ff6a/mypy_boto3_amplifyuibuilder-1.38.0-py3-none-any.whl", hash = "sha256:50cd9175ec93d5ec6f8ad307775d1b2116abeb366a2d8f25a95db01dda6169a9", size = 37227, upload-time = "2025-04-22T21:15:04.513Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/5f/d8f53f6035beb4b56125ff99844524b10642c424c8df90933e3aabbf626d/mypy_boto3_amplifyuibuilder-1.40.0-py3-none-any.whl", hash = "sha256:849b2acb5071840830b294dafb540accaa7b90621ac5e6bdc888d9dbcb6666ca", size = 37278, upload-time = "2025-07-31T19:35:41.25Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-apigateway"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/9b/0bb32b87d26580ae8a099d26734058a14334227bbe9cdb6756db8686363e/mypy_boto3_apigateway-1.38.0.tar.gz", hash = "sha256:2808f1bfea23a3bc531afcde1c27684001c35dcb84914e5240f29b9a9963979c", size = 45060, upload-time = "2025-04-22T21:15:12.805Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/4c/c8de2ecbafde4de3ec8fc935726fe672c11f563d37bf70d8e68df8502be6/mypy_boto3_apigateway-1.40.0.tar.gz", hash = "sha256:99f3134375d25470e34e340463f10bd71ab8b7429168fc06d8dbb43f0b1b937a", size = 45206, upload-time = "2025-07-31T19:35:45.881Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/5c/54cabeddd9b2d4bc5e5651b17476de262b2b3cfb58e3325b051bd6a707cf/mypy_boto3_apigateway-1.38.0-py3-none-any.whl", hash = "sha256:6c3842d2c7448cacf935da42c2e69710906106e83f63c78633491ada33f46938", size = 51174, upload-time = "2025-04-22T21:15:09.31Z" },
+    { url = "https://files.pythonhosted.org/packages/92/7e/54e29081194c58369f0111d848d93ca027b87e914923f5a885ebaa4b95f0/mypy_boto3_apigateway-1.40.0-py3-none-any.whl", hash = "sha256:d2e49373bb4a5df6b927aebe0d6f93a99e5c168c9748c1f52dd70ef19308e3e4", size = 51386, upload-time = "2025-07-31T19:35:44.042Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-apigatewaymanagementapi"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/10/34/25ee4ab24f9f43fac2ecaee7bfe22778a856ca181d64c610303701e43915/mypy_boto3_apigatewaymanagementapi-1.38.0.tar.gz", hash = "sha256:067f73bb4cf526053abd4a79ac9cdc0f81fa39e9c1fb740862703f1278f11332", size = 15292, upload-time = "2025-04-22T21:15:18.479Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/a8/9c63b9dab3f4de3392c1e93b98c38b9dea130596f6054755ee1092e77d16/mypy_boto3_apigatewaymanagementapi-1.40.15.tar.gz", hash = "sha256:13b47948e584632ba5175261d7bc7b88bf3db9c7342a99839ce5a8e2d84716e9", size = 15357, upload-time = "2025-08-21T19:42:50.948Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/06/e6a93ee6829e1fc4cf7c8d0eb5f0ca692166ca070fb44206c3410218785f/mypy_boto3_apigatewaymanagementapi-1.38.0-py3-none-any.whl", hash = "sha256:2b49437c7827684374ffe95b576134268bb54d586a7a4e74b7d5803c6846f942", size = 18410, upload-time = "2025-04-22T21:15:10.632Z" },
+    { url = "https://files.pythonhosted.org/packages/db/86/15c7349bfeb050847bd4a5dc6f20ac69072d051428219fbc46544647dd5d/mypy_boto3_apigatewaymanagementapi-1.40.15-py3-none-any.whl", hash = "sha256:e54ef7ca03fa343fb6203a4ebf9e070ce9155ecc155758c7172edd8842f1c68c", size = 18540, upload-time = "2025-08-21T19:42:48.573Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-apigatewayv2"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/ff/1f16f0a9296907d2df13cd4728b248da41bb40c05d826aef6ccbba415f7b/mypy_boto3_apigatewayv2-1.38.0.tar.gz", hash = "sha256:a25e868fe36c48e2b78489cdbf02d30df588a5f0fab6e495c87e7673a52148d2", size = 33075, upload-time = "2025-04-22T21:15:15.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/18/70c6a0b418b2bd45d2369ad51323bd2ec85b85d5dd29b099eb810cb5509e/mypy_boto3_apigatewayv2-1.40.0.tar.gz", hash = "sha256:81f9c5e6e26876185d5967664dc0f7378184c14661fcbb0e67d0bdf4c3c21d64", size = 34761, upload-time = "2025-07-31T19:35:53.239Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/ed/a207c89f57c2ca63bb631f540a6be942780436781b5bb10f9bd513e94075/mypy_boto3_apigatewayv2-1.38.0-py3-none-any.whl", hash = "sha256:535a0ac1a986cc3cd1fc3df2d61a05a6048be07cb9cab8746b2007fae3446d82", size = 37302, upload-time = "2025-04-22T21:15:11.218Z" },
+    { url = "https://files.pythonhosted.org/packages/45/74/f6190b93f9dbdd1525900821ea5a06d6031853940c3b3c7b7251d7011b35/mypy_boto3_apigatewayv2-1.40.0-py3-none-any.whl", hash = "sha256:05c42724960ba01e118f8a3cec8b38c4d3e78f2bde4e82ed5668c20ce95529a6", size = 39279, upload-time = "2025-07-31T19:35:51.606Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-appconfig"
-version = "1.38.7"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/d5/d7/8a0eefac505cc3544f21d5a14050bf655a1f36d7ebd96bd7b0d1348041db/mypy_boto3_appconfig-1.38.7.tar.gz", hash = "sha256:57750fbe728c97de3968afb7807f54aceb3f0c6c7c022cbf9ee1edc2ef4de33e", size = 26716, upload-time = "2025-05-01T19:26:17.667Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/dd/0f76816b762ae5640cf690c9319355a64bc72320508ccf83ac8ed85fd536/mypy_boto3_appconfig-1.40.0.tar.gz", hash = "sha256:9f43f793d06cedc9131229bf7075cb433b79aac8f1ceae7d4d894e6a2afad665", size = 26747, upload-time = "2025-07-31T19:35:55.864Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/62/6a1ed9f79a1f5b9e37dce939da808e419a74597cbced25f711b1e62fcb33/mypy_boto3_appconfig-1.38.7-py3-none-any.whl", hash = "sha256:2ff7c09d6c030cf54ab5e0e696abdc96229837b3ccf8c78ee7fe73ebe2da6c9f", size = 34544, upload-time = "2025-05-01T19:26:11.413Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/32/0e47d799871635f628e5f1bd311bf83407fe81f37fa8a131154d483b2d97/mypy_boto3_appconfig-1.40.0-py3-none-any.whl", hash = "sha256:40416792b5b6e8e385a0af3215b01bb03c35dfb45697ef189786686f801221fc", size = 34592, upload-time = "2025-07-31T19:35:54.561Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-appconfigdata"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/f9/d51938692cd156ccdb0cd00bede89b33c388f8bfca309c459245fd4983eb/mypy_boto3_appconfigdata-1.38.0.tar.gz", hash = "sha256:a96042dc7ce969532f3dbeb56dec1e819391fc9f9f41300ec6a235a1d2a3b599", size = 15267, upload-time = "2025-04-22T21:15:26.05Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/cb/8870f21310f8d3b72a32815745a6421e297200f89d837b689e6edbb37c34/mypy_boto3_appconfigdata-1.40.0.tar.gz", hash = "sha256:ffa4bf19d5de01863dc1d6a95a372b0b268399e8a3a7a912cbade6d084d6ddfb", size = 15321, upload-time = "2025-07-31T19:35:57.919Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/be/faf76507216f9e86a5cb2b3da4d72f27d633c2e40a976603dfa7ba865a6e/mypy_boto3_appconfigdata-1.38.0-py3-none-any.whl", hash = "sha256:d73010c5b8afeadbed17268a0fb48843140a911ed68aad6d3152877a3a850607", size = 18131, upload-time = "2025-04-22T21:15:20.255Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/09/b6ad5508ac5d8572d5b04523d97518d93be1596092d6b74aeb734d14789d/mypy_boto3_appconfigdata-1.40.0-py3-none-any.whl", hash = "sha256:60391c08b8b0cb8c9327d01518d17e0d291a2d5cac5efde0b6a94d3ef97852d1", size = 18196, upload-time = "2025-07-31T19:35:57.002Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-appfabric"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/b4/49b2e2a059457ec48551c508a5b6ca4e02330c18511c5ef60e98486acc10/mypy_boto3_appfabric-1.38.0.tar.gz", hash = "sha256:6a3c3bcc4d555485bd0e1695b80c0788e8a58b4251c099b611ad9f8fcc973186", size = 20104, upload-time = "2025-04-22T21:15:34.878Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/44/1d9fae65b667aab8d6c3399ec8d6d8b8a094d293e93e9156aa94424da954/mypy_boto3_appfabric-1.40.15.tar.gz", hash = "sha256:c0b08f04e0d4693c3a55d9db6746c3f41cc85533ee1a956565f78605963de41f", size = 20175, upload-time = "2025-08-21T19:42:55.46Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/98/ec86973c6d2c82fa3cdc7060729f8f85ac48dadabeab6839dea90f4d7354/mypy_boto3_appfabric-1.38.0-py3-none-any.whl", hash = "sha256:0fb62658a6c79c7372d77fff439f3f557a094e39ff91e2d6b41434f75045d19b", size = 26958, upload-time = "2025-04-22T21:15:24.134Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5a/fc9e9847748ee82b22bcf2b45946dcf844f05be9e6cd53ea36515e471f34/mypy_boto3_appfabric-1.40.15-py3-none-any.whl", hash = "sha256:0c1e3c180075601416d26b21d21471217d38abfc55320144ff072f95eed2684c", size = 27088, upload-time = "2025-08-21T19:42:48.737Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-appflow"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/aa/c19807e95f764f96228c3d9f1aeb1c4c8b225ff477f3d2523d3ee4a5e82c/mypy_boto3_appflow-1.38.0.tar.gz", hash = "sha256:b655f27dbc2ec3a38859a8a8a843d3dd0525f3836090c2d7161f111d40689321", size = 32198, upload-time = "2025-04-22T21:15:31.656Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/9c/5a87350770c8252e6d59e1e283d8e9a5ff86678850bab7850b468514af9c/mypy_boto3_appflow-1.40.0.tar.gz", hash = "sha256:c3634f2c174cae9153babc8e26d7b349853cd641b864bda721c441d1ce682fb3", size = 32246, upload-time = "2025-07-31T19:36:03.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/88/e01fb70cb9c1d28a4e41dbe7f188ceeec1765115b0679209a4dab2b8fb59/mypy_boto3_appflow-1.38.0-py3-none-any.whl", hash = "sha256:845be8ec05c4e0111952f9392fafafdc5419b084ed3316c0b41397928409f9c9", size = 37360, upload-time = "2025-04-22T21:15:27.949Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d6/fe58cbf2064fe0e88cb8fd559b9927a22ebc042d1a5de8a912153fafa77c/mypy_boto3_appflow-1.40.0-py3-none-any.whl", hash = "sha256:4a713788e48ffda518a32ec5f5a03c599e4520fe5d3ad86fdbaaf2d04d4ce68c", size = 37419, upload-time = "2025-07-31T19:36:01.587Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-appintegrations"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/40/46f1e7c400d5120aca0a5c4fa9826cedb0a6bd6a4a6e0c7c8cbfd227a23a/mypy_boto3_appintegrations-1.38.0.tar.gz", hash = "sha256:e40158c82264e9e1ca0daa814a5f0fa3f8e3e85930af925880cb711ab7561914", size = 20130, upload-time = "2025-04-22T21:15:32.582Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/ac/a0be67db9424e23de074f8ffab30df7ee6ebfc38d94903cdf7068ce3848b/mypy_boto3_appintegrations-1.40.0.tar.gz", hash = "sha256:eecbbcb0f074414422fb965077bd35258355aa9a08c30dead0de29b8172ccd3e", size = 20402, upload-time = "2025-07-31T19:36:06.13Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/24/9997bf0ddf0f74852ac67906967e06c1463e21134895d5d88a17bfcbd0de/mypy_boto3_appintegrations-1.38.0-py3-none-any.whl", hash = "sha256:310efe6ea13207ac04736f1ce3eb3d1d9cd7ee0dc55d31b4030248461c50ef9d", size = 26796, upload-time = "2025-04-22T21:15:29.207Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3a/8c61094f51f3328d9fe2d41b66128b79840501eb5f054178be3cc1191ffc/mypy_boto3_appintegrations-1.40.0-py3-none-any.whl", hash = "sha256:6571587e71ba7a62be9739f03a30889dc0944f05898d88c1a51898d23f3eb547", size = 27335, upload-time = "2025-07-31T19:36:04.386Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-application-autoscaling"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/36/15534274bf919b43f31aa5cedc7987c9ba9ba92aafea2e84df4965a86930/mypy_boto3_application_autoscaling-1.38.0.tar.gz", hash = "sha256:94dd9da8ba1b3a21938644a79b75bed874497c160935ef46c9a23cb180387119", size = 21315, upload-time = "2025-04-22T21:15:37.518Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/6a/112393ed1f444b4a4d312cef834cc3f02cee29a4f17599022ba4afb79c34/mypy_boto3_application_autoscaling-1.40.0.tar.gz", hash = "sha256:5ccbc69d98dd6fcb10f10112d429190fb564762b4476e75418f55a630176e459", size = 21354, upload-time = "2025-07-31T19:36:08.996Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/e8/780db1df375773167a1b6c7f50a818a19edea83feb46f7861302f79c2e2f/mypy_boto3_application_autoscaling-1.38.0-py3-none-any.whl", hash = "sha256:abaea9e47440217eabea26f0fdfc189f014d9e09bc015631bc9f9047feadbb64", size = 29656, upload-time = "2025-04-22T21:15:35.35Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/c4/50eaea54efa09c51d1988c7942776c39e2f90aa2b9c32b1a13a3c49e12d3/mypy_boto3_application_autoscaling-1.40.0-py3-none-any.whl", hash = "sha256:0a6c0d5f79c36bfa08b59ea05068db42bb7848801817c6a8b83159aea957436d", size = 29721, upload-time = "2025-07-31T19:36:07.361Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-application-insights"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/17/7b0ed910aa73317d47cde7a7b6ae7ad8e6c7bbfafe2020da51202cd7ac1b/mypy_boto3_application_insights-1.38.0.tar.gz", hash = "sha256:93e4807affdf36976388527375486436b567cb941d612228e0a6d5a1c7a7a2ec", size = 20244, upload-time = "2025-04-22T21:15:42.352Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/e7/ecc2811ad2489d8b6d38e0efe3c7dfe56280e9610b26a9c659552ec936d0/mypy_boto3_application_insights-1.40.0.tar.gz", hash = "sha256:b35b910fbc3f9b0e93e35ce40fc3d903cfa02e5727f26592d9619e5b193f1517", size = 20275, upload-time = "2025-07-31T19:36:11.866Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/ba/936768d1699ee2bbf49250d7f4a475d6a28adc39b1ca49a35467be3aa0e2/mypy_boto3_application_insights-1.38.0-py3-none-any.whl", hash = "sha256:02b85d1529b99a7875757618cdea63ae2325905934caf273e32722fd3aaa737b", size = 27037, upload-time = "2025-04-22T21:15:39.433Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/87/ebe6bfd6a32a32eb5a8838ac851cc0d347eb3aeaabca7957dbdd44c4f25e/mypy_boto3_application_insights-1.40.0-py3-none-any.whl", hash = "sha256:36cb73056a25d503bab50bf5dfffaf45284f580d2b9e281b8894d8cb1534eb4d", size = 27099, upload-time = "2025-07-31T19:36:10.262Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-application-signals"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/d7/533105e6bd0246511a18f31ccc86927642be53309e4d44fe81a48a04b469/mypy_boto3_application_signals-1.38.0.tar.gz", hash = "sha256:419c984a10a2d9d6263ba6f2d31717742653c35cc701f35868a666f6696feaf8", size = 21332, upload-time = "2025-04-22T21:15:52.432Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/b2/cef7c8f42a0974280101e4bc91768fefe6273d84e53bb80265df82e3cd98/mypy_boto3_application_signals-1.40.0.tar.gz", hash = "sha256:135d3e087cb096c65251ebdec720927cac49a4bed6346a1c419805728443db85", size = 21352, upload-time = "2025-07-31T19:36:13.902Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/e7/163e4c1a5e2b2115f73c7295a46802fe335e5afc3bfee4b3ed791a755846/mypy_boto3_application_signals-1.38.0-py3-none-any.whl", hash = "sha256:1a601271dcc71e04a90cb64fa24c906e074e995b48b1abc20e9f29a26fb89202", size = 29495, upload-time = "2025-04-22T21:15:42.875Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3d/02ed5d794ee31d51927387ce9a5abc084fbe6b50abfbe602ad4299beebac/mypy_boto3_application_signals-1.40.0-py3-none-any.whl", hash = "sha256:b8a0ec6a8b9ac83b2aed7e233671a9d38ed22ba77640e3530dc5dcfdd60d0b62", size = 29552, upload-time = "2025-07-31T19:36:13.071Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-applicationcostprofiler"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/a7/b841efeecff02a34329139d60c50f546083bbd9b921ee1939d88316d7701/mypy_boto3_applicationcostprofiler-1.38.0.tar.gz", hash = "sha256:9cbdefe1202918ec6119cc2affd3b22a19fee57d7bb40de00a7e4f669c1a695b", size = 16840, upload-time = "2025-04-22T21:15:46.859Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/71/61e1be2a34972a23dab9b71019aabacbada67e6395fcc2f16a603fdf71b2/mypy_boto3_applicationcostprofiler-1.40.0.tar.gz", hash = "sha256:2b9b6b271bee6223fd847076373d6ec4a5f35eb30957022a854e83315c6275ee", size = 16846, upload-time = "2025-07-31T19:36:17.117Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/51/e040acd28b56a31331c62b152b060c7c86a8718e19d794e6b4725b1e32b6/mypy_boto3_applicationcostprofiler-1.38.0-py3-none-any.whl", hash = "sha256:d258f1dfe0605455695ea9adb012e764fc52ddf1d82516468da8ad5af7e40e8b", size = 22170, upload-time = "2025-04-22T21:15:44.566Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3b/9e322f325c82caa0dc9138ff5cca40ba294a79512c0183cb9ff48ab0ff92/mypy_boto3_applicationcostprofiler-1.40.0-py3-none-any.whl", hash = "sha256:350a1e67bd34dc079a6d93fc0b53846ba343354f2798337b3de5ca4562c6b88f", size = 22226, upload-time = "2025-07-31T19:36:15.465Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-appmesh"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/e6/81dbef3636e2c260326e53b846dddf35cca0e6e301f3b739c12ada70afbc/mypy_boto3_appmesh-1.38.0.tar.gz", hash = "sha256:d58cc111e9f392f301a6baa1e980a9edc72aaf08cf4add23d1c571b9765df226", size = 30695, upload-time = "2025-04-22T21:15:54.081Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/03/aca9f574d5d13cb4bb08c70bf35bcf0ebd0236826b32db764435a2ee037f/mypy_boto3_appmesh-1.40.0.tar.gz", hash = "sha256:64c0dd8c9b1ee2ec809d6232fdcc1042e01e993ad405d9bc3d8429d0b4ee1e01", size = 30720, upload-time = "2025-07-31T19:36:19.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/8a/6da19e28440eafb355776edca237dad2dda26e44be8f5ccf6dc2b6a5098c/mypy_boto3_appmesh-1.38.0-py3-none-any.whl", hash = "sha256:24cec4c75417524a37bd6814024e64b8a484291cef0ee500697abff022560505", size = 36427, upload-time = "2025-04-22T21:15:48.701Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2f/9389ba8126404f33c6b950deff2bf9980abb7ee47de4a81d5bbb2fde049a/mypy_boto3_appmesh-1.40.0-py3-none-any.whl", hash = "sha256:c05d599017f2e4e0e0e1d6ddd61d40b1f5b046ff6d1c4c67b9f66f74a770efc8", size = 36470, upload-time = "2025-07-31T19:36:18.019Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-apprunner"
-version = "1.38.2"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/74/b8/ecea15a91f21ce0efda72de964c54e34ba643512d8d788a0fb7ee2da8245/mypy_boto3_apprunner-1.38.2.tar.gz", hash = "sha256:1894c8ad9354894c04d60278e9ae6ccbf195c2f9de77d6dc19e58c58bada3605", size = 21252, upload-time = "2025-04-24T19:42:27.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/c6/5d3d09bc541cca211296d4a1d1b9db5e2a7c9aea25d4b81b1fe53afc1622/mypy_boto3_apprunner-1.40.0.tar.gz", hash = "sha256:c6ba72d44abe2a57a0d28604418fd40d7bd451d669f41eabcf83ab5e8fc0f5b0", size = 21306, upload-time = "2025-07-31T19:36:22.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/b1/e4d20857d3a3ad4731919077f95d33be22e1174e81924f8d71f3fc3ccd63/mypy_boto3_apprunner-1.38.2-py3-none-any.whl", hash = "sha256:fd33e9a46ab1252ff33c1d1269a9e46f3370c1c117d0f09ec45d0285251e3431", size = 28218, upload-time = "2025-04-24T19:42:21.105Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/62/d2d6656c5b0ebfa9463288660cfa921829b73e03da3012185822f1068b04/mypy_boto3_apprunner-1.40.0-py3-none-any.whl", hash = "sha256:290d8532ea56376f6cec321a778c9c82fe571ccc2ab2bbae5cf01d0615bb18ea", size = 28276, upload-time = "2025-07-31T19:36:21.202Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-appstream"
-version = "1.38.0"
+version = "1.40.4"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/26/bb/093bead1924478329c87bbaf6abecc7a1105ce8d563725a00457b869762d/mypy_boto3_appstream-1.38.0.tar.gz", hash = "sha256:d04c7e82aee50b7275a714a90d90fa4898711e75a8b1e74d5cc14c1dd7c6d8f7", size = 39091, upload-time = "2025-04-22T21:16:01.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/ba/87c03beadc98bf6a424e64b634bdbe04b8ba2bdcbcd477ee17efc7bdd1bc/mypy_boto3_appstream-1.40.4.tar.gz", hash = "sha256:02061a429e00414972e433bcdcd802a2353b70a38fe4b752b58af55f794c004d", size = 39105, upload-time = "2025-08-06T19:45:59.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/ac/8cff0fbc4d98ca90ecb16fced2f127d532c1ac86810130e1d6cff6144f00/mypy_boto3_appstream-1.38.0-py3-none-any.whl", hash = "sha256:3303aa6ce5d8b7a68dfc2a2b06a22cf8000f1775ceec18dcd40294b5cdf301d0", size = 45601, upload-time = "2025-04-22T21:15:59.253Z" },
+    { url = "https://files.pythonhosted.org/packages/18/84/3de62e5933df4af15a9db0434add9705182872a6123b33b0329747089e97/mypy_boto3_appstream-1.40.4-py3-none-any.whl", hash = "sha256:6d392853544438ee5acd9ad8d5110cc619cb7a21ff71d373ad68a992ca7b423b", size = 45677, upload-time = "2025-08-06T19:45:52.46Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-appsync"
-version = "1.38.2"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/06/62/a9063bf2be606581a4115db4cae9157203bae20ab058b18bc87326339d0e/mypy_boto3_appsync-1.38.2.tar.gz", hash = "sha256:e61093461c2a0f56a926aa55fe2dad2d7d3d3bab80f599fa73e82cc011cee47d", size = 37709, upload-time = "2025-04-24T19:42:24.874Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/db/eb534151739a28db52500603afa42276682c9b18e0e17d6130ef7d08c777/mypy_boto3_appsync-1.40.0.tar.gz", hash = "sha256:36039af8d6bf814ec8aed109f1b54c25a4823604e71ab797d93b23b0094837e6", size = 37781, upload-time = "2025-07-31T19:36:28.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/dc/b204564e6095212c0932464253a2a4b1420a9661b17fcd7bcc19f1e83819/mypy_boto3_appsync-1.38.2-py3-none-any.whl", hash = "sha256:9ed51d5938492dce5f08f921d4adf0b9a488900ae655714fb981436123988708", size = 42554, upload-time = "2025-04-24T19:42:21.133Z" },
+    { url = "https://files.pythonhosted.org/packages/67/54/ed3f3dc2363a210c7250c8039ed130697b7f35fcd58748b7a5c795fd84a8/mypy_boto3_appsync-1.40.0-py3-none-any.whl", hash = "sha256:4f0aa17e0803e3c8a848759f3608cc2e2f9135b7e200b5e00678bc9b13ae4eba", size = 42636, upload-time = "2025-07-31T19:36:26.515Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-apptest"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/07/8b361c2a637ebc4a343ae125bd833fee0ed8ffad825097fb5e91e8ab298a/mypy_boto3_apptest-1.38.0.tar.gz", hash = "sha256:59ba9b4f9e97e61aade3a0ddbce5217eac13db035d2c805b64b881cf0aeaab3f", size = 25331, upload-time = "2025-04-22T21:16:10.62Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/b4/1a07eeb27910ca638b51bba933c1d0107dd90722d1cf7c953743f5d90783/mypy_boto3_apptest-1.40.0.tar.gz", hash = "sha256:c5200ac502a84eeed8e0bc976de8ff2b79aa2137b6591ef69b0827fab6a14603", size = 25391, upload-time = "2025-07-31T19:36:30.923Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/c1/4a8c47538053a9df8ccbf4930f2d466631f0740a38b5bb1ede98f25b214e/mypy_boto3_apptest-1.38.0-py3-none-any.whl", hash = "sha256:fb4c39dc6d08b5dc81b30afe4e1c0593d75d1c2460b15ade2c57f55a680a57e1", size = 30731, upload-time = "2025-04-22T21:16:08.613Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e0/5bd1117c9cecb710cb7609b219f25b918bd3d0de3ab5a10a6799a02c7696/mypy_boto3_apptest-1.40.0-py3-none-any.whl", hash = "sha256:56a9f61b1f5e5f9d50493509c65c581a3c4c3a91fae4959b40b4507b6b200551", size = 30787, upload-time = "2025-07-31T19:36:29.422Z" },
+]
+
+[[package]]
+name = "mypy-boto3-arc-region-switch"
+version = "1.40.10"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/da/0443bcf0ccc033fa77759d53550b9c0b71d948a0bc9b9710fb5960a873b4/mypy_boto3_arc_region_switch-1.40.10.tar.gz", hash = "sha256:358524d268c1e40ad18fda926887318efbdc37ecc66b6f31db83e502e9590763", size = 24120, upload-time = "2025-08-14T19:27:14.585Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/c5/40dad58766a240e72053a1ee58fa938616041ef9288827f8144d8f116fd1/mypy_boto3_arc_region_switch-1.40.10-py3-none-any.whl", hash = "sha256:ba79059c81e58d57e567e6ec55533308b1fc4a1d225e79e050287638b21e194a", size = 34747, upload-time = "2025-08-14T19:27:09.822Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-arc-zonal-shift"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/75/d6065543776920bb3e7edae10d6242a7d5cc4826ee6111fd7fa7557605e5/mypy_boto3_arc_zonal_shift-1.38.0.tar.gz", hash = "sha256:92c2886c04907cacdfebb3e476fe47522a687a9ffc42fee355c8c2e0a0aa0282", size = 18960, upload-time = "2025-04-22T21:16:14.896Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/20/093681dfb9650b1bb92d5ce3d65253de1f4ea180b022bd8f08ce0a26eb81/mypy_boto3_arc_zonal_shift-1.40.0.tar.gz", hash = "sha256:73c76429ecad677fe5af5816b300ad7051ac1e7bfb17eed339e34c367a1c2611", size = 19208, upload-time = "2025-07-31T19:36:34.055Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/f5/d88485d37f0762f9ce96393b97c56d17e917f472c68f87b87a56c89aa621/mypy_boto3_arc_zonal_shift-1.38.0-py3-none-any.whl", hash = "sha256:675a90fda810e67a8048ca58973b94e74591e12a3eaf5d8d247eb86f30e1f957", size = 25716, upload-time = "2025-04-22T21:16:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/37/1a/43b4eb63684f24d75f2754e61df460ab42a1ca4df490f8ba1b7886b921d6/mypy_boto3_arc_zonal_shift-1.40.0-py3-none-any.whl", hash = "sha256:fb74ec429988e6f95698db3e741c06d36889bc0e55eb79393e9b28e4bd80aec4", size = 26089, upload-time = "2025-07-31T19:36:31.923Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-artifact"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/21/47378e199f3991a05dad9a9449e5bfbaac3ae1098743f6af5ba3f7edff49/mypy_boto3_artifact-1.38.0.tar.gz", hash = "sha256:228cd02c9445c87de35b18d2cacf353a4a2620080290fd1d2bef5b0e660271b3", size = 17351, upload-time = "2025-04-22T21:16:19.488Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/6e/821bf1bd400d92cdc5ba079c3576e79189e30325b8d9e50d13c903c3330e/mypy_boto3_artifact-1.40.0.tar.gz", hash = "sha256:af8fa4339c02635fd26db9c127475cf45331a351676c434329db1814b6baa31e", size = 17475, upload-time = "2025-07-31T19:36:36.668Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/21/0aa84dfdfde2a89ebb3753afcc86738041a0105d34aee9a6ca2ec9718a15/mypy_boto3_artifact-1.38.0-py3-none-any.whl", hash = "sha256:59972898543697a98b0e9c6e134c981a9ab4f96b0a7b011584a4ce847ca63d69", size = 22526, upload-time = "2025-04-22T21:16:16.734Z" },
+    { url = "https://files.pythonhosted.org/packages/82/68/368194cb6b074c668d228d6c9584dc62aeb8d3afcd890c11fb6e84e57785/mypy_boto3_artifact-1.40.0-py3-none-any.whl", hash = "sha256:efe245a89493ac183651aae8b7b206a92504e1043a812e9909be7df2e9f9004e", size = 22580, upload-time = "2025-07-31T19:36:35.18Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-athena"
-version = "1.38.13"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/78/0dd090e24f963dfd26f702f6376a2f1ecc4a9ff9cc51a47de9fbc8e17482/mypy_boto3_athena-1.38.13.tar.gz", hash = "sha256:d45a27739e5f54cf24b2a0930705d51deaa1ca982c61e8285bc3c410fa9c4c5e", size = 36273, upload-time = "2025-05-09T19:47:01.568Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/9c/a16a597632e24f5e3ad30fe1e5f570e2bdaf713297013d81d7001bfbfabc/mypy_boto3_athena-1.40.0.tar.gz", hash = "sha256:da8429f556bcd857b2c9fed9133ef0bfecb898e2b74e9679f3aaafcc26702bf1", size = 36614, upload-time = "2025-07-31T19:36:39.469Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/98/e3286f1e713cb3b1f431886647a19152775bb2e989f3a1c2ff1b1994238a/mypy_boto3_athena-1.38.13-py3-none-any.whl", hash = "sha256:6faaa7300aacfebd220e72901c8c7321c9499323f97c54e60fa19b2f9ba04b3b", size = 40685, upload-time = "2025-05-09T19:42:08.269Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a0/7a10865896ddf356c735b1d8ba5ec509386540e89d552bd0108674cda30f/mypy_boto3_athena-1.40.0-py3-none-any.whl", hash = "sha256:3fc5e4b294248663a6030bb5f13e94f199ebcca4f4f43bfcd30705ce47d28008", size = 40986, upload-time = "2025-07-31T19:36:37.666Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-auditmanager"
-version = "1.38.0"
+version = "1.40.1"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/33/ef5233544e99c6e5b92d189eceecfe54eba3803bc65d1855a7949e97b0a1/mypy_boto3_auditmanager-1.38.0.tar.gz", hash = "sha256:a896373a6480611e3f6049dac837e8496125310d04293fbefc93be9c1a9fe00e", size = 31705, upload-time = "2025-04-22T21:16:28.833Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/a9/5a86e798c102e38b74569f863bcb70364195df38c6829179e49f6b97bb7d/mypy_boto3_auditmanager-1.40.1.tar.gz", hash = "sha256:a7c8e74c98a00fc42e2dedef8d9c04ed9c868016e5a5274cd082340abff1152f", size = 31755, upload-time = "2025-08-01T19:29:17.658Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/c1/6c17d8f5d5cecd752e5e32c9d359c54d3ffbe8346914dceef1c1a1e64aac/mypy_boto3_auditmanager-1.38.0-py3-none-any.whl", hash = "sha256:831f70197b7ed706b36d322d37d263e52341189d812ed548e74bf27aafe59f24", size = 34213, upload-time = "2025-04-22T21:16:26.542Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/933494464231dbf80cd8dc817068c40d869e7cb841f608588107c168cea3/mypy_boto3_auditmanager-1.40.1-py3-none-any.whl", hash = "sha256:2bdf57348b9605439ff4f43ee9c5a21aab69d6b854837cf8e02a300959ddb343", size = 34294, upload-time = "2025-08-01T19:29:14.697Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-autoscaling"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/55/fe/2d02f9de87a85c8cd190b60edf71df34829687984eec358d60066fac96fb/mypy_boto3_autoscaling-1.38.0.tar.gz", hash = "sha256:724b705bb9b78438e51ae962fe42e78eea7cbfaf8d332a648acd6ec1a3230c6c", size = 40167, upload-time = "2025-04-22T21:16:33.429Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/33/55d262d6952b183fd67d16265360abe3fd03a29311457d9c4c997db12bb7/mypy_boto3_autoscaling-1.40.0.tar.gz", hash = "sha256:b4193ef2c70055e3bc60c3435965b8b902bc57e5fd60b50ff34be6ddebaade0b", size = 40210, upload-time = "2025-07-31T19:36:46.45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/26/d3a54252cc591db48f033cf993009b2c5243353e4284d01203b6407454da/mypy_boto3_autoscaling-1.38.0-py3-none-any.whl", hash = "sha256:73715184bcaebe815ad3e1eb64c8f7142d7ab81a5bd02e157443504561fb4de5", size = 45791, upload-time = "2025-04-22T21:16:30.745Z" },
+    { url = "https://files.pythonhosted.org/packages/73/36/bb6a5389695088d89ae64454741ed3341240d7aa28e98fe3ed0538c5ad63/mypy_boto3_autoscaling-1.40.0-py3-none-any.whl", hash = "sha256:16250a9e3c738180dfffe300628ae57e7a513ef6e37c34eda4fc9d09d4cc5931", size = 45881, upload-time = "2025-07-31T19:36:44.107Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-autoscaling-plans"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/c1/1b3ecfcf764997ad5d2693bfdfb41e3566d7c4e0cf4f44118a1ad751d714/mypy_boto3_autoscaling_plans-1.38.0.tar.gz", hash = "sha256:83ee34549544e0f406e64d708c815c122a399322e975a4337d2169fc00445e1f", size = 18596, upload-time = "2025-04-22T21:16:40.654Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/81/a233d026e61ca334f7edb3f444129f2eb1090e533bcc2a76106c20a9b8ce/mypy_boto3_autoscaling_plans-1.40.0.tar.gz", hash = "sha256:6043036c46684bd0710ea07e69edf43523e54245fa82df95ebe2d98c0bda9ca2", size = 18603, upload-time = "2025-07-31T19:36:49.659Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/e4/d2005e0db4cded2f3b94a12376d79d750dc3895693fcb0e482dae2228ff1/mypy_boto3_autoscaling_plans-1.38.0-py3-none-any.whl", hash = "sha256:9a7b85a33ed38ae758d3876e226e00f669303671312cf4136b68443284d25f0d", size = 25043, upload-time = "2025-04-22T21:16:38.346Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/46/f119bfb94c63e2c804f37b9d82cc216acc811e2ba4d79041bad513ffc3d4/mypy_boto3_autoscaling_plans-1.40.0-py3-none-any.whl", hash = "sha256:2421496da2e04d9159227325c6cd90164093f0ce1e6bc57de18cb61095e5c06b", size = 25099, upload-time = "2025-07-31T19:36:47.772Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-b2bi"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/63/41b3358440534cc1369b11d7fa5c06ed6ad73c36062d24cd07ce94f11f87/mypy_boto3_b2bi-1.38.0.tar.gz", hash = "sha256:962e33ae4f12793c27b4f655476d0cd9504a418db47543224d8a960eb1f316fb", size = 22823, upload-time = "2025-04-22T21:16:44.868Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/bc/84dd7e084f26f6e9171249f0718b81fd38c555cf6c4b9d3ebd164a387a26/mypy_boto3_b2bi-1.40.0.tar.gz", hash = "sha256:1467750be16bee996c69fcd02de1c34e92edb964858289c4641c727f31799398", size = 24179, upload-time = "2025-07-31T19:36:52.734Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/22/a5e948d275f0ae7f8387b888b9d3e61950798b802712833179485d15189d/mypy_boto3_b2bi-1.38.0-py3-none-any.whl", hash = "sha256:5007c40a1804184dd32044fa3938733f5db03e67b82d3433766f10dc233a9a35", size = 31547, upload-time = "2025-04-22T21:16:42.7Z" },
+    { url = "https://files.pythonhosted.org/packages/42/d0/3c8a343c8527fbb0ff240317ef3de3082c9c8654a24ca48773acd9457fd0/mypy_boto3_b2bi-1.40.0-py3-none-any.whl", hash = "sha256:33c2f699882b69914aa972413e1aaefaff159ce4663e1087e5b2773a050f88d3", size = 34661, upload-time = "2025-07-31T19:36:51.102Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-backup"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/24/db59994062b21d0c9e4a7b1022685e8101831554b8738fc4315ba3ea8230/mypy_boto3_backup-1.38.0.tar.gz", hash = "sha256:5d87f3b1f42fae73dd05a03e0bcb762c6684f58f770d1508b16545ca5373f152", size = 45857, upload-time = "2025-04-22T21:16:53.798Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/2c/7255fce3c287723784c4bf22ddd855d17dffebd47d13572accaade6dae8c/mypy_boto3_backup-1.40.0.tar.gz", hash = "sha256:abb1e8686ce9c0a00f8a4f48e9ef7e7ac55bc07db346b221ccf428216e23b8f0", size = 47799, upload-time = "2025-07-31T19:36:59.993Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/43/5ffbda45eb35fda75c5b1e28079b09883c7319db4717d24ec87cb3e15672/mypy_boto3_backup-1.38.0-py3-none-any.whl", hash = "sha256:7aa3640251f22b5356fd94d98ae93f19e38193df96e8493a351d651800bc6f65", size = 50973, upload-time = "2025-04-22T21:16:51.106Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d9/63246daa9a06e3baf8123615ba1e8e6dbd3ea3f5cd3aec73f17afb508441/mypy_boto3_backup-1.40.0-py3-none-any.whl", hash = "sha256:9f7172d5b2ae17a86f60b24190061a8aa2b70e0f376860351d7814f0c62c133f", size = 53195, upload-time = "2025-07-31T19:36:57.855Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-backup-gateway"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/16/50/5109022c3228d10da5205d77f25e669bac238e1a4b90a058ef5ae3d14ca7/mypy_boto3_backup_gateway-1.38.0.tar.gz", hash = "sha256:cf7d2d972385198073d0868443846a49ae583c566546af6e968df6fcdec449b7", size = 19974, upload-time = "2025-04-22T21:16:49.197Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/ca/fd6774f4b2a8e3f010256d855c6908c04aca69cea5f1889c38d343c4ce46/mypy_boto3_backup_gateway-1.40.15.tar.gz", hash = "sha256:0595eb5a1a9fe6016b4d6d1f02c8b28b2773734713bf694f8f90d344baeffa92", size = 20037, upload-time = "2025-08-21T19:42:53.051Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/87/f2a765c8f7057c81262ab5c899a385f4724aec008b0fe0ca623f5729e16c/mypy_boto3_backup_gateway-1.38.0-py3-none-any.whl", hash = "sha256:f275f06ce7b36c0be4b96a382765d7e29827fd691865b5c1669e1cfce4a4ef30", size = 26997, upload-time = "2025-04-22T21:16:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fc/03d35aa753a0c036a07f90a4645a17df9d8e550b3b34d5f8111c868c609e/mypy_boto3_backup_gateway-1.40.15-py3-none-any.whl", hash = "sha256:043cd92807a26cf42539f9d28677a7d6a2f4f71f636afdf18aeee1f901e4484f", size = 27131, upload-time = "2025-08-21T19:42:48.587Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-backupsearch"
-version = "1.38.0"
+version = "1.40.8"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/66/db8775b57542f58705966c24a696a65ab9a0b22d1779f2afbf4080898edb/mypy_boto3_backupsearch-1.38.0.tar.gz", hash = "sha256:80ff890c8bede5f031e9ac9e342fc053b9408cf53b1e65f93adb6e067d022900", size = 19308, upload-time = "2025-04-22T21:16:57.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/2d/e23b36d3a4c9ba2328d49dc332429017a68aa4ef0819a3268cba1a9a6909/mypy_boto3_backupsearch-1.40.8.tar.gz", hash = "sha256:2449294c9eecb642af94ceea3c9b9d78c49be854233eb74580a507f2fda24b04", size = 19321, upload-time = "2025-08-12T19:28:39.658Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/9d/8292017e0d4a152ffa232eb17d873e877cd22d6b4e57a23de5e84ff6a7d3/mypy_boto3_backupsearch-1.38.0-py3-none-any.whl", hash = "sha256:4f73c9347c807f64d6e967b9463cdcf93950f8b63b85652af2b9a6e27d50ede0", size = 25709, upload-time = "2025-04-22T21:16:55.65Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/51/38448d32f8f2eda06bee839235cb0da36edee967e65165c2d7f5039a13d9/mypy_boto3_backupsearch-1.40.8-py3-none-any.whl", hash = "sha256:6d8c59c3149a0e29fdf92d3480767f32b61af27b5bc3d7919ec93f37f4f311e7", size = 25787, upload-time = "2025-08-12T19:28:37.563Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-batch"
-version = "1.38.0"
+version = "1.40.12"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/28/20f19d54780f110b06b69c1f5f170865f65f4a3e67a118f96b09166d3334/mypy_boto3_batch-1.38.0.tar.gz", hash = "sha256:ff8402eac1e1f7b9b01272e89d6c86685a8a6c6b6c93ed951a1bc27a0d9c2d50", size = 32450, upload-time = "2025-04-22T21:17:02.354Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/5a/881e72106e8b8b4fe7ea132540a749ded97d57f662263b96554d3a8e2f7a/mypy_boto3_batch-1.40.12.tar.gz", hash = "sha256:8025123f8d2293485c8e402088db15698e62bd77139a26569bcbbd7e7a5053aa", size = 35050, upload-time = "2025-08-18T19:44:21.188Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/c8/d70c23e18d648400b11b961aae53822a85dd3ec5bc1121de1061119d7ec3/mypy_boto3_batch-1.38.0-py3-none-any.whl", hash = "sha256:0a0b50f7d2f27ab1172a15e7b30cceb80ab2bc24b5bee79fdf265022e6139997", size = 38579, upload-time = "2025-04-22T21:16:59.584Z" },
+    { url = "https://files.pythonhosted.org/packages/90/46/dacef31f7bdafc423720dc30ca28419b3c605e81b18e79ceff6bf8b46380/mypy_boto3_batch-1.40.12-py3-none-any.whl", hash = "sha256:18458c35f8861f2833c7d9d775cda2d74cc414bab31d1f06f4743aead37b5b67", size = 41921, upload-time = "2025-08-18T19:44:02.082Z" },
+]
+
+[[package]]
+name = "mypy-boto3-bcm-dashboards"
+version = "1.40.12"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/02/4d51722f47f94b5cbccdd0d33b1b958d79599b6c21713dec055162880bf2/mypy_boto3_bcm_dashboards-1.40.12.tar.gz", hash = "sha256:304290dd493bcf2632fa0acee12e7940722c0749a20312ff5e3fe4712f31905c", size = 19158, upload-time = "2025-08-18T19:44:19.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/fb/bb49934c92eb555e688428626ecc69f3005f76c0cb7af6a71ff69c903660/mypy_boto3_bcm_dashboards-1.40.12-py3-none-any.whl", hash = "sha256:fba382a7ca799009934cd3de509b5ee4d8d695f3f135aba87cb4150346b528ec", size = 25770, upload-time = "2025-08-18T19:44:14.876Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-bcm-data-exports"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/6e/7f/2b095bf35b1d94c35efbd08392a66068e4149ba23b8e3c6f4af3ade5d86f/mypy_boto3_bcm_data_exports-1.38.0.tar.gz", hash = "sha256:97ac7a7176c57f6680abd82d0c238cfe70ad808aed16c62b8640cdbe4b01fe41", size = 18557, upload-time = "2025-04-22T21:17:07.032Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/72/da722749a03a30b0b92099012798cb612cb96022a24b8cbd44e2c902dd8d/mypy_boto3_bcm_data_exports-1.40.0.tar.gz", hash = "sha256:37f313abb447550925c40a7ec4175efe21f44fb502eabe894157dbfd63039297", size = 18587, upload-time = "2025-07-31T19:37:08.127Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/6a/6da27235a022941f5e7b304eca639f9ae6b7cc33752f858c742f2c09a554/mypy_boto3_bcm_data_exports-1.38.0-py3-none-any.whl", hash = "sha256:9516ef8716fd594de79181e07b6a184eb000fbe8e2fbda299484946b567f11dd", size = 24899, upload-time = "2025-04-22T21:17:04.332Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/33/caacec8bae89263b84391dc9dc0f813811393696e82d4bcf9cfc895587ee/mypy_boto3_bcm_data_exports-1.40.0-py3-none-any.whl", hash = "sha256:0cbe8db9f98b606a9f1970d160c1e15a16e1507b1502e5144a16ebebefdfbd24", size = 24949, upload-time = "2025-07-31T19:37:06.764Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-bcm-pricing-calculator"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/07/e36b007d35e88591d9d7622178a940e197c7ae6e0e6a0beb8a1d08656cbc/mypy_boto3_bcm_pricing_calculator-1.38.0.tar.gz", hash = "sha256:163242b4396f08b3dd59936b1095ebdb7b3a62ba6efc5f3166e548a6ea40c878", size = 30765, upload-time = "2025-04-22T21:17:11.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/58/146dcfee697e5af33258893b3190110538d76469e1e6becb0a4de1505dc1/mypy_boto3_bcm_pricing_calculator-1.40.0.tar.gz", hash = "sha256:68990d085b22f17c92709564e724f01526235adbcf1160458ba1bade5c1cf5dc", size = 30799, upload-time = "2025-07-31T19:37:10.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/06/9c4c85af817b9dbaf28d7d4e2d5a924096894a587eef88717fd5889b63ab/mypy_boto3_bcm_pricing_calculator-1.38.0-py3-none-any.whl", hash = "sha256:d42e95525bd305f0bc131c6e45ba14efccef5532bbc045c02c4fc257637cdf27", size = 35498, upload-time = "2025-04-22T21:17:09.033Z" },
+    { url = "https://files.pythonhosted.org/packages/66/90/1d2a992412ad9894c46c7f95369ccd49c81e3463ae4c5466b7096f61eb47/mypy_boto3_bcm_pricing_calculator-1.40.0-py3-none-any.whl", hash = "sha256:bdcd68beb3278d5c023ee8d4a6794d8ceb27f3b301a15af1e4af43d8625b7bfc", size = 35604, upload-time = "2025-07-31T19:37:09.249Z" },
+]
+
+[[package]]
+name = "mypy-boto3-bcm-recommended-actions"
+version = "1.40.10"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0d/a6994032e7996d97d575be5dedc0659ca1c0f262236cbce24f417bc086f7/mypy_boto3_bcm_recommended_actions-1.40.10.tar.gz", hash = "sha256:5727aa880667de5c43d5b15a2f1082c405fc61fd8e37bb7b9db20b1c7f76d3df", size = 16614, upload-time = "2025-08-14T19:32:14.844Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/bb/33b183f7932a04218ad914e8855c477e7b0e5cd87946a14c4a0b897801af/mypy_boto3_bcm_recommended_actions-1.40.10-py3-none-any.whl", hash = "sha256:14d4cbfe2f753751d69ca7e6b49faad42f2c7bc5f9acdd00910ab8b4d305a874", size = 22171, upload-time = "2025-08-14T19:27:26.712Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-bedrock"
-version = "1.38.6"
+version = "1.40.7"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/6d/d4709d15336eb3fa0c0fa27e476aaf2f6ca7411e881e3afbe4f769a9432d/mypy_boto3_bedrock-1.38.6.tar.gz", hash = "sha256:49fcdac39ec59bcbfd48fa60c6e4732bb6e3d8ec7a3d7edca5d8877cf1a561c5", size = 43628, upload-time = "2025-04-30T20:12:48.661Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/f0/e923a6d92bd9426f26a4fbcd15608df12df71cc728aa1a3fc9157aaafc99/mypy_boto3_bedrock-1.40.7.tar.gz", hash = "sha256:ab6a814023d41ab23ee1c0e92affbb6bee6e7e7872c4f8d59a0a0979747938f0", size = 59666, upload-time = "2025-08-11T19:35:25.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/bf/54ae4c72c60e44e495481e431b042f35d24d75b39ebfee0b47e32950770e/mypy_boto3_bedrock-1.38.6-py3-none-any.whl", hash = "sha256:f90ef407ed7fbcf4e9e225ecc4afa4abc745d962026bba883427675402600deb", size = 49243, upload-time = "2025-04-30T20:12:36.398Z" },
+    { url = "https://files.pythonhosted.org/packages/17/47/021cc05541e0a4b0f1ee2655cc2b4e5c5dd82086fba3cf25e9990bc9289d/mypy_boto3_bedrock-1.40.7-py3-none-any.whl", hash = "sha256:7bc63259e9365c31bc2127d3949a4d1c8e92feefc1c2b9d972def01b7e1ea73d", size = 66929, upload-time = "2025-08-11T19:30:31.191Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-bedrock-agent"
-version = "1.38.6"
+version = "1.40.11"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/b2/12ccb4fde961e85ca01bfccc11e6739fad3d5dfb6e877f4851e7620c06c2/mypy_boto3_bedrock_agent-1.38.6.tar.gz", hash = "sha256:0ed48b95f386b4e32fd402176f6a5955efdd474ac35efbdb653598520846add8", size = 51268, upload-time = "2025-04-30T20:12:39.052Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/d3/5f8a33bb045a1cddc6479ff079d6f22f388ec6613eabcb5949758ed719a4/mypy_boto3_bedrock_agent-1.40.11.tar.gz", hash = "sha256:4acb7be8a58124c9214fac4175ec4348e5647f29ab42f29f398f57e64bc9310f", size = 53516, upload-time = "2025-08-15T19:32:37.465Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/99/9435c23d9b278e3fb7c250fc7334e9d4b140642156f36b87d9e9d3abb78e/mypy_boto3_bedrock_agent-1.38.6-py3-none-any.whl", hash = "sha256:efb1381977a1fbffd73a91dbea270472a6994577085324a71735feff6bdaacdb", size = 57475, upload-time = "2025-04-30T20:12:36.434Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a8/47b807d522c06bc6d3c722b23acd050570e63091d59a3a63d705b3773f9f/mypy_boto3_bedrock_agent-1.40.11-py3-none-any.whl", hash = "sha256:b5788e43d31c49b3caa17b6d059c501ea0854f670a5a9b2940e48ac2516b7c7a", size = 60078, upload-time = "2025-08-15T19:27:44.764Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-bedrock-agent-runtime"
-version = "1.38.6"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/1e/5a6f21b6057423fe1f230371cf42bd21f94bed93fda54f4802ce51b2d625/mypy_boto3_bedrock_agent_runtime-1.38.6.tar.gz", hash = "sha256:e1f626f693eccc93fcc27d3d07ed7a6f0c60e005107926a6b63c811cd30fc8d7", size = 38494, upload-time = "2025-04-30T20:12:39.865Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/e1/a3531b7e5d1b8cd15493763aae76d573ffc7042a71b3385f8dc782898650/mypy_boto3_bedrock_agent_runtime-1.40.0.tar.gz", hash = "sha256:abff0cda522ec8267dfcd88234c1ccf20666657be80aafc450c6c089218a0ccf", size = 41062, upload-time = "2025-07-31T19:37:16.481Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/7d/cdfc498bf6f7070dbe45d183aa5f7695674c23ec3f210dd723baac1aeff5/mypy_boto3_bedrock_agent_runtime-1.38.6-py3-none-any.whl", hash = "sha256:c45f2a0ba5bffccd12970860db89d4e4106aab5d1e01d09a9db031dd2b9675e0", size = 46528, upload-time = "2025-04-30T20:12:36.398Z" },
+    { url = "https://files.pythonhosted.org/packages/54/8c/58875602f0857eede402cff7e5b2652eb0ae971a9c23b84537cc7de93efc/mypy_boto3_bedrock_agent_runtime-1.40.0-py3-none-any.whl", hash = "sha256:c25c82470cb2bc99383d3a7a0e19454ec34ec3199d77ddcee28af752d08b6b72", size = 49780, upload-time = "2025-07-31T19:37:14.467Z" },
+]
+
+[[package]]
+name = "mypy-boto3-bedrock-agentcore"
+version = "1.40.2"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/3f/322ef5f29bb3c71d267f076280fc5db1d29c0bcb1e03e3ea61ba7dbc9f39/mypy_boto3_bedrock_agentcore-1.40.2.tar.gz", hash = "sha256:1b2352e47893febc3495c55ec4c7d32b1868d9ce713ad061da2f53536f913430", size = 22207, upload-time = "2025-08-04T19:32:30.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c9/1b44044d06038e606a91108efdfc5d77af61ecf3ac81701d7af36ca0d34a/mypy_boto3_bedrock_agentcore-1.40.2-py3-none-any.whl", hash = "sha256:a1f47223b8aedc0e7cecf3ad0dac337e46a5c4964fad882f71aa26f362d8d82e", size = 31192, upload-time = "2025-08-04T19:32:29.486Z" },
+]
+
+[[package]]
+name = "mypy-boto3-bedrock-agentcore-control"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/11/3c20fa77f3d17f3cce7ccacfdc57c489159e94e203b73ad38f7135b79a44/mypy_boto3_bedrock_agentcore_control-1.40.0.tar.gz", hash = "sha256:99af0c403b256621a8e19ad051f4c6b98c683f53023b0c250d1c070bbec9c7a5", size = 35791, upload-time = "2025-07-31T19:37:18.823Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/15/a86b6dcd7acb5c8c19d2e941770770efe77258567d247e17b12ca058e25a/mypy_boto3_bedrock_agentcore_control-1.40.0-py3-none-any.whl", hash = "sha256:2ea5fb4f89d3be91943b31686be587e48c5acb5874b63cc4e01ea518bf5dc046", size = 42034, upload-time = "2025-07-31T19:37:17.399Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-bedrock-data-automation"
-version = "1.38.8"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/9e/c497038bae45cf4db0eb3fb9716e64a52feeace5a8b3bdba37f8da050d30/mypy_boto3_bedrock_data_automation-1.38.8.tar.gz", hash = "sha256:efe8e6818a317f955547ade6a14a7cd85ed41f79dea7fb41860f4cdd9919df48", size = 20039, upload-time = "2025-05-03T00:52:25.377Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/90/917362f79e66cc8b9cb96666992c07de08981f5dc80af3a5a620666ab464/mypy_boto3_bedrock_data_automation-1.40.0.tar.gz", hash = "sha256:ed609ab71fad86e3113b5be1f8ceb14c09330ab48f3cc1f8f852b663668fdcb5", size = 20059, upload-time = "2025-07-31T19:37:23.339Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/0d/61a8a600a693b99d0a94a09500e1ede6a4c5ea51ab4d1100da97fac8b268/mypy_boto3_bedrock_data_automation-1.38.8-py3-none-any.whl", hash = "sha256:1972c18fdb69c6686d724f91465f88435024289fb7c802bc037751566a7543cf", size = 27344, upload-time = "2025-05-03T00:52:22.119Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/6c/9c4fa65e7f119101468ea4ed483f073927865eb7ce4a87a04f9c64a81003/mypy_boto3_bedrock_data_automation-1.40.0-py3-none-any.whl", hash = "sha256:3371b4fb81ece15a3cc779efbb0ff39daa791e08399032d18e61334a723a5722", size = 27382, upload-time = "2025-07-31T19:37:22.48Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-bedrock-data-automation-runtime"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/d1/5cef4792190c1dc476d31bbd82a440f94da6c375689344ddf7f18e521658/mypy_boto3_bedrock_data_automation_runtime-1.38.0.tar.gz", hash = "sha256:fbeddcf0afb9ecb290239b73b23166b00b20bca13d4edb0e073df8a79ab05195", size = 16084, upload-time = "2025-04-22T21:17:28.831Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/e8/841498f9063ef581530031f202e703f838a5f983bb9343647083c788ff1b/mypy_boto3_bedrock_data_automation_runtime-1.40.0.tar.gz", hash = "sha256:9a134bb69fdb10d9e765040468f6bd97f7f1f3ab43905a621e6aeb34bf2da15a", size = 16230, upload-time = "2025-07-31T19:37:25.639Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/77/efb6e3802b57d39fdc337bb05c0d680fbe520aae892b37af5e8560d21660/mypy_boto3_bedrock_data_automation_runtime-1.38.0-py3-none-any.whl", hash = "sha256:e953ac978049ee996f3ca46a10bd9dcd7cea9f2869a375df8dd757981a29af10", size = 19984, upload-time = "2025-04-22T21:17:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2b/6479d4a03a67c598aeb70bc1b7423ac4516eb3b7cf35f4b9715aa1944929/mypy_boto3_bedrock_data_automation_runtime-1.40.0-py3-none-any.whl", hash = "sha256:5acd22b8ae7b48b32499dbb443f6791e27ec01489f5e6d95f508e7bbcdfe1807", size = 20264, upload-time = "2025-07-31T19:37:24.517Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-bedrock-runtime"
-version = "1.38.4"
+version = "1.40.14"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/55/56ce6f23d7fb98ce5b8a4261f089890bc94250666ea7089539dab55f6c25/mypy_boto3_bedrock_runtime-1.38.4.tar.gz", hash = "sha256:315a5f84c014c54e5406fdb80b030aba5cc79eb27982aff3d09ef331fb2cdd4d", size = 26169, upload-time = "2025-04-28T19:26:13.437Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/9e/567889deac1ae6fcb071e6c406ba0ba38afade7128c7564cc5ab842f1158/mypy_boto3_bedrock_runtime-1.40.14.tar.gz", hash = "sha256:c8041bc1402c73cb1aaa5697bf3e87a79312cd1dd4f844d8f20a568a801ff4cf", size = 28352, upload-time = "2025-08-20T19:27:09.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/eb/3015c6504540ca4888789ee14f47590c0340b748a33b059eeb6a48b406bb/mypy_boto3_bedrock_runtime-1.38.4-py3-none-any.whl", hash = "sha256:af14320532e9b798095129a3307f4b186ba80258917bb31410cda7f423592d72", size = 31858, upload-time = "2025-04-28T19:26:09.667Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/09/5bebeb6a221ea0e20e5a3ad2e44f3fc1f3104e9323cd3891f59b37dd4e51/mypy_boto3_bedrock_runtime-1.40.14-py3-none-any.whl", hash = "sha256:74e87008bb077f62ed9bcf8f9f28d49cd40ef60fdc6e2f9214ed4da9af54800c", size = 34173, upload-time = "2025-08-20T19:27:04.519Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-billing"
-version = "1.38.0"
+version = "1.40.14"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/2b/bd2eef2a546ac1cae03176b27d63bfbf805914fad5a969898238d0bcc9c7/mypy_boto3_billing-1.38.0.tar.gz", hash = "sha256:2e68e97e72cbc55ceffa59690f13ea9be531f06327c2ff0e428d77c4715946ef", size = 17699, upload-time = "2025-04-22T21:17:53.666Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/f2/c7823962a40c28f0f4029a0a945a1ecd51a3b1cd0dee855aae6081bffed1/mypy_boto3_billing-1.40.14.tar.gz", hash = "sha256:067d835117b9ceab8d93125851cd478c47ef9271926bf47e06976ff845af6207", size = 17743, upload-time = "2025-08-20T19:27:06.271Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/cb/2f2c383dd70fd9152db517a9a5a19409d27af28cb6aacae4c5d72dc6bcf1/mypy_boto3_billing-1.38.0-py3-none-any.whl", hash = "sha256:2ecd20a78c143439237139167fa78c27bfcea4d9555d650251ef02ee0b843960", size = 22956, upload-time = "2025-04-22T21:17:48.307Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8b/940982b0a8aee0eee96faf1bbc72e95530dd3f2512f899772844a1e8c6fe/mypy_boto3_billing-1.40.14-py3-none-any.whl", hash = "sha256:23d9cc210977eb998eef2f0c45043315ef92b26a361b8c3b5703ce619f2b88e2", size = 23080, upload-time = "2025-08-20T19:27:04.515Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-billingconductor"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/9c/ed/398cacf91daae8977041371dc517332ef239ac76ccf3bd854204fe7bedd5/mypy_boto3_billingconductor-1.38.0.tar.gz", hash = "sha256:a24d43b47ab872e0e07b8a0aa504dd7f5cd10fac2e1c47403517134f80e1b9c6", size = 24180, upload-time = "2025-04-22T21:18:00.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/fe/38e002960a9be8ca4f72f82fcca0e251a0e00c02626aba5c0d50be9840ee/mypy_boto3_billingconductor-1.40.0.tar.gz", hash = "sha256:5f21a4b9b162ff9ca82c6ff908644d8ed07bb4a84ea8fe8fb93be14ec9f7a503", size = 24208, upload-time = "2025-07-31T19:37:36.534Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/96/05e7c71529b20bbcc1cff18bc6a328ee9f236964234ab4b764fa5cfb0549/mypy_boto3_billingconductor-1.38.0-py3-none-any.whl", hash = "sha256:2505f1229ea1e94d10a0187e30149e293ebacc50ab32e55d1817bff00f57b759", size = 33898, upload-time = "2025-04-22T21:17:57.955Z" },
+    { url = "https://files.pythonhosted.org/packages/67/73/596104f7e9f1c0acba14b11a81fdb008d2f7dc1d4a349a06f7aa8afc32af/mypy_boto3_billingconductor-1.40.0-py3-none-any.whl", hash = "sha256:a6038dfb7b3a1ba44edba26e826455bcc0ad4d85c5f56748849bdc7891821b95", size = 33950, upload-time = "2025-07-31T19:37:34.778Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-braket"
-version = "1.38.0"
+version = "1.40.9"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/19/db0c9ff44d9a7d690267ed785f8417261f254b060386577563d43194d37e/mypy_boto3_braket-1.38.0.tar.gz", hash = "sha256:0fa60d46341e35528105aaa9558cb1de4fd81c3ec277136d495f8349201175ac", size = 19465, upload-time = "2025-04-22T21:18:10.877Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ad/2bb92393bdc9602f077917062839138f905693468bf27b8cf34f45fc7def/mypy_boto3_braket-1.40.9.tar.gz", hash = "sha256:2147fcbe728946a6b905e1082847c0734f62c4422f5517ca062ea710fd4a8d95", size = 19524, upload-time = "2025-08-13T19:29:05.244Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/ff/17be62e96d0285e4a6e3c2911aa4ae137199c51a346a61f06f1134941c2c/mypy_boto3_braket-1.38.0-py3-none-any.whl", hash = "sha256:a6418ebe62c846328adb683e48463f4a892313e9122b9f3a2e5872c7fdf9fbf3", size = 26169, upload-time = "2025-04-22T21:18:05.766Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/e6/c551408d7def0ae75f41bfea11e5d540c440b809002ba2843a10c3d84004/mypy_boto3_braket-1.40.9-py3-none-any.whl", hash = "sha256:85064ca803d6807b5bd7eaa0689df536227e3c454e1efcbc99cd05e4ef43d777", size = 26351, upload-time = "2025-08-13T19:28:56.416Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-budgets"
-version = "1.38.0"
+version = "1.40.4"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/d9/8c2d36d9873fa4a0c0dcbc7d53ad78538746de49fcebf895bdea440b04b7/mypy_boto3_budgets-1.38.0.tar.gz", hash = "sha256:5973294ca9815dad6ae75b672d3139b0ec49ca7d0b2ea3b0a55db07597ccd6fd", size = 22750, upload-time = "2025-04-22T21:18:19.205Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/a1/98d8279d37705b791160b087ea4ee090443d5cfbbf59387577fdcc14e9a9/mypy_boto3_budgets-1.40.4.tar.gz", hash = "sha256:ea40910eeaf5dc6f864d92bc47b8249dcd49dcbfc4dd8038ff18bef6a421569d", size = 22971, upload-time = "2025-08-06T19:46:04.018Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/01/58e579a25dcc3c070c8f2f072870cb4e13ff4b6736c208710ea27cbc7d33/mypy_boto3_budgets-1.38.0-py3-none-any.whl", hash = "sha256:2908b9ef97174dbe2be61fa7f49c1796997fd1a44f6cfbf6efe8f699ce7ec2ee", size = 31251, upload-time = "2025-04-22T21:18:15.017Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/b5/6f3958d3752ef203dc334cf98fdbb762f7c395ce0ecc429f51efc0f289bd/mypy_boto3_budgets-1.40.4-py3-none-any.whl", hash = "sha256:d6f9d6c19224d0cc4cbc9a1831adb38948b1f23373780221af65c1d548cd8e96", size = 31632, upload-time = "2025-08-06T19:45:52.474Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ce"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/46/2d/9ca89c806040241e7ce899a77aa8aada6c5aa219bd1c4a20c13f7f912058/mypy_boto3_ce-1.38.0.tar.gz", hash = "sha256:6ddcbf4141261d1d5ccd12bbf73fef95ac97dc7197d29cca41241283e7b24da7", size = 38415, upload-time = "2025-04-22T21:18:27.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/1a/7afe46fcc83131a37324749c17064d5ac9b1de8947a24b29a1bd223f8d34/mypy_boto3_ce-1.40.0.tar.gz", hash = "sha256:3b8d98160b654288af42ab8b890a87a07893e4db501fc238cfa1fe038d6bad21", size = 40329, upload-time = "2025-07-31T19:37:45.002Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/66/f17cd35823d0f70752f227fd2c261a196feaae03e6bceefe64f17e05e7a3/mypy_boto3_ce-1.38.0-py3-none-any.whl", hash = "sha256:5404095cada64789b94489c23428d9b68284755e3511ce39184afbcc3e653e66", size = 43246, upload-time = "2025-04-22T21:18:23.208Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/1c/77b9f69f6bc7639fa6d026fb21b7b22b824f24c3709515ccd20379bd5d58/mypy_boto3_ce-1.40.0-py3-none-any.whl", hash = "sha256:7f867d619ae169104ce95a3fdfa50d44a12908503efd91f1f1227613885cde80", size = 45327, upload-time = "2025-07-31T19:37:43.33Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-chatbot"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/4e/fd7a670cc4a3450c80005540598edbfe8beda957e50d406f3a0f0b197b4e/mypy_boto3_chatbot-1.38.0.tar.gz", hash = "sha256:d6ab53f7cc77884a7326df83e33022e6590176fa0a6ff985495e7c8d33ad6ed7", size = 24388, upload-time = "2025-04-22T21:18:34.164Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/c9/9f475ca639496d5a24219e8e18b175e436bce6cc13258ebde4726beb08b9/mypy_boto3_chatbot-1.40.0.tar.gz", hash = "sha256:c28067457f8e989f2e59af1aa4921faec278fc4ff6666670a6aee62b37b78d66", size = 24420, upload-time = "2025-07-31T19:37:47.551Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/a4/2e512f3d6b11ec1b4381f3300f3728e8cb0bc20ce5d9cf787ebbd6ebb84c/mypy_boto3_chatbot-1.38.0-py3-none-any.whl", hash = "sha256:f6ae4294b5ae870d063b4a283d06560549e8de6d0b1b4b6bbd1d74d32bcfb93d", size = 30131, upload-time = "2025-04-22T21:18:31.834Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4e/9ec9f370ef5de68b9d3c0def7f0e7d341976706f39132535adb3fdccba16/mypy_boto3_chatbot-1.40.0-py3-none-any.whl", hash = "sha256:fbf5ba4b9ee63b95a9334210a263e718f1b5c60b07a8c0900d08dfd1e145f5e7", size = 30190, upload-time = "2025-07-31T19:37:46.434Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-chime"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/72/9110cfc1328172e58a1a3ebbacea54870514d08900cf1ae94ef1e87a66ec/mypy_boto3_chime-1.38.0.tar.gz", hash = "sha256:d75227a4596ad55b6d2d1f60047bee5314c46e29b891d0e18a509f61a94d94db", size = 28126, upload-time = "2025-04-22T21:18:39.396Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/27/7a3c40e2c026d296a103f478afe871c3b43fdbddc706f0d9231172604d05/mypy_boto3_chime-1.40.0.tar.gz", hash = "sha256:8387705cf90c990c6369266dd51bd1bd5c515d6c9e168b26c0c6a208eb6fbaa6", size = 28159, upload-time = "2025-07-31T19:37:50.447Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/9e/b038f6c5cebc739fa68a59988e0e7ed252a6d2795c54dcc75cbb5df8ba44/mypy_boto3_chime-1.38.0-py3-none-any.whl", hash = "sha256:ab61bb6f4ab562c9c66e1084a4c28f90edcf868634b1d3eaece1cbc5d670a53b", size = 34138, upload-time = "2025-04-22T21:18:36.52Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/04/6d8e7da064969cea9eead20365eaa3c8a172ca0385af4a0a5c4492300cd7/mypy_boto3_chime-1.40.0-py3-none-any.whl", hash = "sha256:2334cc35b40cd8c80847748c5d969312b50874c1362dff5c640428ecc8938df6", size = 34192, upload-time = "2025-07-31T19:37:49.079Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-chime-sdk-identity"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/5d/b3/082b07ab65410380222f4501819f6f2c8e2cf344a3d41ac4f5ada42f1497/mypy_boto3_chime_sdk_identity-1.38.0.tar.gz", hash = "sha256:aaa75a11863d8c704f28b9517f37cf6a1bc3d62df1672a74af9794fa0652768c", size = 18933, upload-time = "2025-04-22T21:18:44.449Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/b2/48e64ea699ae9a9c763c15b7b21730915b8dd820f204f92e5454259198f4/mypy_boto3_chime_sdk_identity-1.40.0.tar.gz", hash = "sha256:a0f030a44c972f2c22ba688e6796fa633a652076b5d1ae1be733326f43362005", size = 18930, upload-time = "2025-07-31T19:37:53.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/c1/483af2833cc33cfa4ab512939aec0ba9fb59ee2296412ee5bdaef8c5184c/mypy_boto3_chime_sdk_identity-1.38.0-py3-none-any.whl", hash = "sha256:11df3fe745bb4efe45a6c3edbf57235dbc11c33279c04083ce87de3d08342ea9", size = 24406, upload-time = "2025-04-22T21:18:42.171Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/63/525822b8efba3c3d87fa5647728b7fa1dfdd69326f129fcc1665910b20be/mypy_boto3_chime_sdk_identity-1.40.0-py3-none-any.whl", hash = "sha256:26295e06bda7f0a1a8632c4578580963166c733caaec28b7574a068d4284bcd0", size = 24465, upload-time = "2025-07-31T19:37:52.006Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-chime-sdk-media-pipelines"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/5b/05/65501cba48ae7082c44a99c029a20fde85b0838baa3c4a0385b10a0d617b/mypy_boto3_chime_sdk_media_pipelines-1.38.0.tar.gz", hash = "sha256:2fb6041d09ee547bdd26fb421af419b5954999da804978a1e90da6aafc50d798", size = 27187, upload-time = "2025-04-22T21:18:49.669Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/1c/ec55b9389fa60c6dc24d183f2bdf918c572324d757105306c3b09a332fe0/mypy_boto3_chime_sdk_media_pipelines-1.40.0.tar.gz", hash = "sha256:3fe23e986ec185ff37fcc76ddc71b9cbf9d688a4c48c88d379b7017d9efcf6c6", size = 27226, upload-time = "2025-07-31T19:37:56.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/74/1fea96607cf7bd3f5e073341cbc303d5c4a2b256bc8a6824bd1260fc6a1f/mypy_boto3_chime_sdk_media_pipelines-1.38.0-py3-none-any.whl", hash = "sha256:d6db3c3eb2d3914bafcc9cab349751caf226e02da99c0f8854cad91c33f1b2c7", size = 32736, upload-time = "2025-04-22T21:18:47.592Z" },
+    { url = "https://files.pythonhosted.org/packages/08/bd/a7935850e3f7d76dd2873e277182e3c6c20b3469a3d9b563b00e468f3f22/mypy_boto3_chime_sdk_media_pipelines-1.40.0-py3-none-any.whl", hash = "sha256:8c4815abd501d4459d246f0ff205b5eb9179ee8690ec10713a6c4332709583bb", size = 32789, upload-time = "2025-07-31T19:37:55.023Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-chime-sdk-meetings"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/07/80/a15837fc1b66ac2d09df0121bea5e8674967767eede4fb5a6adf88f63310/mypy_boto3_chime_sdk_meetings-1.38.0.tar.gz", hash = "sha256:d629265ba8b60d175a1e77bc211ca9086933d8138174ff18722c1555b5d48b44", size = 18256, upload-time = "2025-04-22T21:18:55.833Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/00/59dcb97fbbb94c6fac551e97a76909170487f26f7da18cdc655d3a9af506/mypy_boto3_chime_sdk_meetings-1.40.0.tar.gz", hash = "sha256:f012f96cd81425e8033109f21a72e34b1cda3c04c5f346afd2593e0fe6c4aa02", size = 18297, upload-time = "2025-07-31T19:37:58.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/c1/4b151e4f4038838285983893e239c92768e4c3a8964974d84a4263ddd782/mypy_boto3_chime_sdk_meetings-1.38.0-py3-none-any.whl", hash = "sha256:98621de804724fcfc9f72c885a531e3e89e753590a95d2e1340d42beed82db14", size = 23623, upload-time = "2025-04-22T21:18:52.886Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/58/0ec8b057ed0bd358649a0b1bf1c73c3730cb25f3770474c689270df46287/mypy_boto3_chime_sdk_meetings-1.40.0-py3-none-any.whl", hash = "sha256:567e5ed52b0c6d25a8d6c5b2e1fece33c7d1cc7fc76bd56cdcdcdf41873638f1", size = 23675, upload-time = "2025-07-31T19:37:57.395Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-chime-sdk-messaging"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/50/62/5791eb50d8e1c8b39133f8bdd01a1edb76d6537ded3e7765ddbe8d455f2d/mypy_boto3_chime_sdk_messaging-1.38.0.tar.gz", hash = "sha256:b80a0add576ca567815c5ad10364ddacb7de8abb39833585e94fe6028231c98b", size = 25355, upload-time = "2025-04-22T21:19:01.397Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/75/837af1edc9c3b5109c7b6fccf258fd2379d510a39cb466a464d55a966ae0/mypy_boto3_chime_sdk_messaging-1.40.0.tar.gz", hash = "sha256:56d7f83d590ac422184b2bce5cc328d6bed9b240d5034cf0f509747a50acc36f", size = 25375, upload-time = "2025-07-31T19:38:01.404Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/f5/23f6c52cf12e69117037f606860e7d0f53539b8e33e290f7e520a9bf893f/mypy_boto3_chime_sdk_messaging-1.38.0-py3-none-any.whl", hash = "sha256:20900e69e8ddc37593f24a5878b8fd2adbac041ef7e8a832a0d482950bbcf715", size = 30364, upload-time = "2025-04-22T21:18:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/58/63/476887c34be796ec57aa2395809e8e7f9f13e77e80733c3dd1df8dac82c8/mypy_boto3_chime_sdk_messaging-1.40.0-py3-none-any.whl", hash = "sha256:fb633936da84914eda6bb397e67afa61b49dc03d2cf3950bbfb4c890d91a4a4e", size = 30415, upload-time = "2025-07-31T19:37:59.86Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-chime-sdk-voice"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/cb/43/911ed65af95525ba1b2faf607b9479428da686c29576c93913a79dcf24a8/mypy_boto3_chime_sdk_voice-1.38.0.tar.gz", hash = "sha256:b73622a08271e9a250c6209430e09097bd6ecca5bd7fd904c36c59945ae07e92", size = 37699, upload-time = "2025-04-22T21:19:06.292Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ac/18829d5d972571f496ba668ea30d31f3edb97d2249b9fe2e1ecc8657f454/mypy_boto3_chime_sdk_voice-1.40.0.tar.gz", hash = "sha256:e20651731db3d8f25c9bfab55fb51f7bc4400321cd84f11ac1188b0567960be0", size = 37808, upload-time = "2025-07-31T19:38:04.195Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/85/e91ea185be6488276830b978af5fbb1dffe5a14eb3b45052ba8605708ebd/mypy_boto3_chime_sdk_voice-1.38.0-py3-none-any.whl", hash = "sha256:4f6a5653e83c7164d7e8fc3aa41693f48b8222a1eaba2e7d11084c7143b34d1c", size = 41959, upload-time = "2025-04-22T21:19:03.74Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/94/61bb86e7da3a03fa7c7ff38e9c04b3dbfcb5acc4beb7bfb5e86fc21825ca/mypy_boto3_chime_sdk_voice-1.40.0-py3-none-any.whl", hash = "sha256:c5f2969fe27b2b3a83f5ec4da2f22059193b8569a73096cedb6b3fcb11ef70a6", size = 42012, upload-time = "2025-07-31T19:38:02.719Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cleanrooms"
-version = "1.38.6"
+version = "1.40.13"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/a7/9fa90a939c0bd43dc9bd75cf1f7b9cab5f68bf0f3913282fbe017b88619a/mypy_boto3_cleanrooms-1.38.6.tar.gz", hash = "sha256:d4e19e61c2d1a4578b7e7c4a1234943df3c8ea478b0c96d956f84d5ead7639a0", size = 48819, upload-time = "2025-04-30T20:12:52.805Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2a/f8d71f5bf71967b05657642587bfeccec0d5ae88c29db5602903fa7a4b76/mypy_boto3_cleanrooms-1.40.13.tar.gz", hash = "sha256:298e726f0ef896f04c489bcca8dcc9be0c38bee187375df3a3f80b574820080c", size = 49056, upload-time = "2025-08-19T20:45:13.752Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/6c/d1a04718c4ff781044c6fc27e43b5c6c2d78f9f2a0f5d30619b1a0c0a2f4/mypy_boto3_cleanrooms-1.38.6-py3-none-any.whl", hash = "sha256:596168799793cdd2af6e668f7ec9983d9137d67c804cf1fc56bbc0de28d4f119", size = 52906, upload-time = "2025-04-30T20:12:42.966Z" },
+    { url = "https://files.pythonhosted.org/packages/38/28/4ebd091355dc2ba1e8910dd94275194550e7956bc4c353387d950bd72bf1/mypy_boto3_cleanrooms-1.40.13-py3-none-any.whl", hash = "sha256:d646b87a13b7ca904b7ae63dbacb5524f84a7e20c96af5529071e933363bf9ca", size = 53187, upload-time = "2025-08-19T20:45:10.978Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cleanroomsml"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/d1/44/869fd66af5e81f789f22c2587e03ab0d8dde15225f7883a0f3c3e174687b/mypy_boto3_cleanroomsml-1.38.0.tar.gz", hash = "sha256:1a07ebc5949836cd43204f4a77259da5d1b8fd976563cb70f958549cc3a40202", size = 36077, upload-time = "2025-04-22T21:19:16.92Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/25/f108a32c4da6a5dd4c5c20b615626a6869b95971ad99b87dde244a65b32b/mypy_boto3_cleanroomsml-1.40.0.tar.gz", hash = "sha256:528e1c68e44182f4f16dfec824b3799e16280daa8e7b8972df197cb835059da7", size = 37264, upload-time = "2025-07-31T19:38:10.928Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/1a/c52794e4d8a34c397170ee42309c5a7609be33eb0bee789b03e4859fb313/mypy_boto3_cleanroomsml-1.38.0-py3-none-any.whl", hash = "sha256:1c4546a55f49c30a42260bdaf2c207f884f39fd52c4411573af22361c9889df7", size = 41386, upload-time = "2025-04-22T21:19:13.052Z" },
+    { url = "https://files.pythonhosted.org/packages/29/2d/5207dd0aea02954645230357a9f7e9cd68414d7820b4c11a870e8ed907a5/mypy_boto3_cleanroomsml-1.40.0-py3-none-any.whl", hash = "sha256:977b38b7c086c774c1c447ca479a383b6bd92f8f94f09b8cbc66fa12f405bdff", size = 42736, upload-time = "2025-07-31T19:38:09.731Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cloud9"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/5b/8fcc2fc679ea5f6d0ad7d8b379da1c47cef5715b6df2ee5519b5537e2879/mypy_boto3_cloud9-1.38.0.tar.gz", hash = "sha256:d42a5a43a5ebf9be568ab0fa1888f04733179a31f67093edd2dd45115ffc5abe", size = 18164, upload-time = "2025-04-22T21:19:19.942Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/dc/da48d4faf13d25697dc25c914e6762ad873b0bc761ec2bc81f5dc9f3185f/mypy_boto3_cloud9-1.40.0.tar.gz", hash = "sha256:cecdadacefcb99d284c8ffb18631d90a75ab23996818473b022490ec7a6ad2b8", size = 18151, upload-time = "2025-07-31T19:38:14.197Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/8d/db2a3a63f0054a0e490ae130b7f43606fc5cf4fe3dc0e3b869af61145ad3/mypy_boto3_cloud9-1.38.0-py3-none-any.whl", hash = "sha256:a63938ae65183304f48d5e723c47a7d5a87d1f7f118bbeb141c1bca3bcbd0911", size = 23765, upload-time = "2025-04-22T21:19:18.073Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ef/a6c5657459bd7f915e17aeaed4df449cdfee6c30825ab2377069400d7be0/mypy_boto3_cloud9-1.40.0-py3-none-any.whl", hash = "sha256:ac72a3af7d937641ae736db3651fa23dcf0c9b9e4ed88ddea8e079a1927eb288", size = 23822, upload-time = "2025-07-31T19:38:13.069Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cloudcontrol"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/2b/5f/1667745eecba2ef543eef0b8b2a20e8b40380b7dcb1177777ab05fd3b249/mypy_boto3_cloudcontrol-1.38.0.tar.gz", hash = "sha256:3108a8792861e715ac19d22a32aaab80e3e9559c6f9303f46457642e470c8ce1", size = 18119, upload-time = "2025-04-22T21:19:23.755Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/f5/a9398efddc97e1e4b77e88ec253b44015b42aa93408fc2d66e5e7945d0ea/mypy_boto3_cloudcontrol-1.40.0.tar.gz", hash = "sha256:dfc205248d5e9c577a5e759ef35cee7fcd0ddb73ab7e5d4250246de7b834cc41", size = 18174, upload-time = "2025-07-31T19:38:17.805Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/e6/a431ec16df7e4ef5d2ed23e7cf615fdfb7a0d7f1d92c61e8740e91eb6b90/mypy_boto3_cloudcontrol-1.38.0-py3-none-any.whl", hash = "sha256:95f9cb2f86e5b72c11b04e4fdf94b63b00e1ca8c1a33d29c0df0aafeaca7b0fd", size = 25241, upload-time = "2025-04-22T21:19:22.078Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/58/49552ba878464ba00f754432f11b79c7fd3dc6c65ae0e42492c261ce2964/mypy_boto3_cloudcontrol-1.40.0-py3-none-any.whl", hash = "sha256:945a36cef8e350c142801048c6ffaf95c7c8148d3b3467a57630b742eef65f00", size = 25306, upload-time = "2025-07-31T19:38:16.704Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-clouddirectory"
-version = "1.38.0"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/34/41/e24d9b058d05d83ca9306344975c46af761c800c0d49ae5d98d9cedfe28e/mypy_boto3_clouddirectory-1.38.0.tar.gz", hash = "sha256:13fbcff59f4277a4190c9d9eb36e397978948d34ac5755cd37da8d9c86d727b1", size = 39250, upload-time = "2025-04-22T21:19:27.341Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/b2/9f37fd6e2b157399a06438364cd8b168e2e5c8d9292addd0b757044820df/mypy_boto3_clouddirectory-1.40.16.tar.gz", hash = "sha256:7c59c7c2007caf6dfd7295675927de8863b530d3b19179fd30d314039a219b4e", size = 39308, upload-time = "2025-08-22T19:42:34.435Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/5c/c2f1592e6ad3a1fcf654cc7161293ada3c4ae134726906ae506ffe852481/mypy_boto3_clouddirectory-1.38.0-py3-none-any.whl", hash = "sha256:c84f0e4e4af05e53a4a9685cc9e78ab670b0dcb739247b23587c82617a4054f0", size = 44816, upload-time = "2025-04-22T21:19:24.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/3d/9f4d6648acd4239542a57978b0fa3d55ac5d0e4fe09327298500bb6342d5/mypy_boto3_clouddirectory-1.40.16-py3-none-any.whl", hash = "sha256:953ca5047bcb82904761b654fd52ebcd18f08cac238546e8702745b1c066106b", size = 44928, upload-time = "2025-08-22T19:42:30.222Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cloudformation"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/40/d5/35b9301c8b2fb870e58401d13fec36de2c83f2ddef48398b8c89c9a58995/mypy_boto3_cloudformation-1.38.0.tar.gz", hash = "sha256:563399166c07e91e0695fb1e58103a248b2bee0db5e2c3f07155776dd6311805", size = 57702, upload-time = "2025-04-22T21:19:31.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/05/a2afeb6326c0f9f9bacc47d38167a2f29ebc7bac40b28edcf98ce71f60bd/mypy_boto3_cloudformation-1.40.0.tar.gz", hash = "sha256:a0beaae56355fb3e5eb4439d65a919a9e61f6ea2f69ffbf0a03fd6b45ad895f0", size = 57709, upload-time = "2025-07-31T19:38:23.771Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/2f/d20ad6e0113f982ea255fcb4ed94f70d0111757d7d03bfacebc2d9f60ba4/mypy_boto3_cloudformation-1.38.0-py3-none-any.whl", hash = "sha256:a1411aa5875b737492aaac5f7e8ce450f034c18f972eb608a9eba6fe35837f6a", size = 69607, upload-time = "2025-04-22T21:19:29.235Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/4a/73fe9b4f21afd24514be4365658cb59d253053c27c34a586437ff5b854eb/mypy_boto3_cloudformation-1.40.0-py3-none-any.whl", hash = "sha256:3daa2b10307f4763cb9479e541b1d45742a79a3c598f1a577389c5735fa8ad10", size = 69684, upload-time = "2025-07-31T19:38:21.747Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cloudfront"
-version = "1.38.12"
+version = "1.40.5"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/0c/11/92afd34a357030b1b1b3c5aa24bb9cb592063365775392932b7cd188ba84/mypy_boto3_cloudfront-1.38.12.tar.gz", hash = "sha256:da294f2032b56dd3249faf4f5ecd90e075217c6ebb5d68cf5991cfafd6725efb", size = 61721, upload-time = "2025-05-08T19:42:27.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/2e/89767a4e13944da84fa7663c7eb1facdef181f9d21bd3f19b8eacc0e5dfe/mypy_boto3_cloudfront-1.40.5.tar.gz", hash = "sha256:bee44131593a810fa67cd2c6fd057f123bf07d7de6337b6d80aff352c8b48210", size = 62043, upload-time = "2025-08-07T19:45:20.505Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/0f/cada0055d943bc6e9f3e10c27a09a2343e62082f865a55267f416a4e9c27/mypy_boto3_cloudfront-1.38.12-py3-none-any.whl", hash = "sha256:e20cbf4ec3e607b7b0fd74e21e903dd51769ce002a00b33e1ab49d347b224743", size = 68463, upload-time = "2025-05-08T19:42:24.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/23/1c54fb2a300564db3c91894ec4ad5b5ef69f5f735c0d7b5cd19ebecf3b74/mypy_boto3_cloudfront-1.40.5-py3-none-any.whl", hash = "sha256:7ab2ee3453ece2c8060d563649b4333a8e1b7ec509e58f97862d2b16e27b4ebc", size = 68982, upload-time = "2025-08-07T19:45:13.391Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cloudfront-keyvaluestore"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/86/3263c0294aa76ef26b536dd87c689d5781335ebd3d05c928e0ec4654751b/mypy_boto3_cloudfront_keyvaluestore-1.38.0.tar.gz", hash = "sha256:15d997926d53e00ff953b0e1d84128b466927fc41001a07cddec1a39b95ff0a8", size = 16567, upload-time = "2025-04-22T21:19:36.122Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/85/766b55d9ec0a17839413550feb20ea2c25fd3e5cf0ce6e4c3224b88d21c2/mypy_boto3_cloudfront_keyvaluestore-1.40.0.tar.gz", hash = "sha256:1875a12ba10e39b74509bda934ff0610c5dd3039b02398205abdde2a1a8330ce", size = 16577, upload-time = "2025-07-31T19:38:26.33Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/f9/0e5e36813790f9f1bc20ea07eaa3a082cb822076d0378338a568e4b7a118/mypy_boto3_cloudfront_keyvaluestore-1.38.0-py3-none-any.whl", hash = "sha256:e541fa3029b06e280b39b81e08f352e771474cdc46912d98a94090a65e44a3f2", size = 21688, upload-time = "2025-04-22T21:19:34.336Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/75/6982f6651e72fd916b9b3bcc2de738b04c9dcfd0095de00425e5caada6e1/mypy_boto3_cloudfront_keyvaluestore-1.40.0-py3-none-any.whl", hash = "sha256:6b80f2ab93c8189aff52e39fdca0f4f909f9ae175c75acfb4479d3c94f74dd28", size = 21752, upload-time = "2025-07-31T19:38:25.008Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cloudhsm"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/12/26/acaf2362da3fa389b33917599a16dbb3198e999d54b932b910a8e1d48b6a/mypy_boto3_cloudhsm-1.38.0.tar.gz", hash = "sha256:56252249303a6d33f721878a435087774c993b83215f6a2f003037947130b73b", size = 18384, upload-time = "2025-04-22T21:19:42.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/3d/d058cf6bbd966d0a2b5829b002938fd5bb7968828819fa1c9b7cfff734e8/mypy_boto3_cloudhsm-1.40.15.tar.gz", hash = "sha256:aabece91a9dcffb720adbdf56ba9b16f6dd2f27bf0de2ced09c6c634770c2219", size = 18433, upload-time = "2025-08-21T19:43:00.333Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/52/c1a4356fcd53b5e5a2c211e61c940d8c9b213bbb1dd1cda73e45f8231501/mypy_boto3_cloudhsm-1.38.0-py3-none-any.whl", hash = "sha256:5f6362fe84d92bc282707e7b6556836555a8bc0cc6984073ddb62b493d062165", size = 23939, upload-time = "2025-04-22T21:19:40.883Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/09cb42957d6430f5cb96fb6a3ca9d7cfb409875f44134c2db08f1e34ce1f/mypy_boto3_cloudhsm-1.40.15-py3-none-any.whl", hash = "sha256:a1450714ee2bef43270e13e5fda011f82700920165f85667fae8c6ee03548ef6", size = 24061, upload-time = "2025-08-21T19:42:54.096Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cloudhsmv2"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/5d/66/b86b8281aee394805fb17ef48f4c8ca0c32dbf8a41bc381439683c61c267/mypy_boto3_cloudhsmv2-1.38.0.tar.gz", hash = "sha256:9ad6ec44147ca2e93b26bd8a0e06c65a43216a04b59f29d1a62be17cf3d14904", size = 19110, upload-time = "2025-04-22T21:19:46.374Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/aa/e12acd9d9364a252162be8b7bba5b9a46fed6c7c59e37aa078a41a968560/mypy_boto3_cloudhsmv2-1.40.0.tar.gz", hash = "sha256:87f74c5937121aeec8b88d86d86fa0b7711b595d5203826939c62232d946531b", size = 19143, upload-time = "2025-07-31T19:38:36.241Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/af/5fed87359d95f2eda5ff124b862535a05ed3dc0b5f5660814c0ff6fc6372/mypy_boto3_cloudhsmv2-1.38.0-py3-none-any.whl", hash = "sha256:5c5cc22bb17ac0ab4d638a6e609195816ea4487888333bb6773de6648562698d", size = 25616, upload-time = "2025-04-22T21:19:44.884Z" },
+    { url = "https://files.pythonhosted.org/packages/12/6a/272edbb370794ae9ac2df4de04384a21ce3f850a241f242fcb7fc31a58dc/mypy_boto3_cloudhsmv2-1.40.0-py3-none-any.whl", hash = "sha256:8169bf79f8269f06a67f8f713bcd736267e4ef1efb09df2971116d23aae16592", size = 25674, upload-time = "2025-07-31T19:38:33.621Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cloudsearch"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/d4/59/dba7c3b6384f43de3b6e12b06e5c9a9e52d563226d42ae4607b473c3b93e/mypy_boto3_cloudsearch-1.38.0.tar.gz", hash = "sha256:ed51465d5c8cdd5c855e5828e85734b582d63394f417a428b4e4604d448de208", size = 19174, upload-time = "2025-04-22T21:19:50.037Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/a8/e4b53b8b45e4db96980b43f9d93e4c29faf61dbcc2d534add57205bca8b2/mypy_boto3_cloudsearch-1.40.0.tar.gz", hash = "sha256:b16196341f9d054452421a290c39b9ad7b2fa25843562f2846c85f1b9eef6f0d", size = 19227, upload-time = "2025-07-31T19:38:39.544Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/0a/74d531a7db492b41002e30e8cce38091dfae130cd499daf739ce78a65a4c/mypy_boto3_cloudsearch-1.38.0-py3-none-any.whl", hash = "sha256:aeee0171f96d78ac7c4df2825c2c72376d77aaf2bcceb9ca08bcd1c18058fe1b", size = 24655, upload-time = "2025-04-22T21:19:48.57Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2c/3f0350b95b7343718828b9f39a0e41c4d027cf6da9fca67f3880cd219206/mypy_boto3_cloudsearch-1.40.0-py3-none-any.whl", hash = "sha256:5de2f341af6073333e764eba10142121c38f2f1e2529bebb935fc7e8de40150c", size = 24714, upload-time = "2025-07-31T19:38:37.725Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cloudsearchdomain"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/9a/20/e9565ad66d95cb1e7c4d0e4f1bf3d426b26bc6b37fed852067ca7d5ccd56/mypy_boto3_cloudsearchdomain-1.38.0.tar.gz", hash = "sha256:62972248d5c62739d4a1c89c73fd98c370cf6c177be61cac462450cfc6823073", size = 15808, upload-time = "2025-04-22T21:19:53.72Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/05/d22797101ad52e12148808bc4b02131812788f14d25be2b85c5b025508e9/mypy_boto3_cloudsearchdomain-1.40.0.tar.gz", hash = "sha256:a712c38a44ab97c819b2f61ba6669f42de041bbda5b2bbf85444974c2b954337", size = 15833, upload-time = "2025-07-31T19:38:42.877Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/86/6f9a4eab662c1e8a99fbbdcf2a750d67f87c3d19290165aa972918df5e88/mypy_boto3_cloudsearchdomain-1.38.0-py3-none-any.whl", hash = "sha256:44e8197a1edf25aa54d8ec0386e6ee12003bbcbdd8ba527764b38a1ce47ac8bc", size = 19255, upload-time = "2025-04-22T21:19:51.823Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ac/b9bb8923dac09a4ba19199f540d5d46af099574d4765ba37152a9c9db0b7/mypy_boto3_cloudsearchdomain-1.40.0-py3-none-any.whl", hash = "sha256:479553c9ceab85dd52611f2db40c0be7e39d795bb14e3d0a658249d9f0a49eb1", size = 19311, upload-time = "2025-07-31T19:38:40.881Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cloudtrail"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e1/a8/ebeb475d6455789f07e9e5b881ef5307548d73d1da0950704e2eeb9f537b/mypy_boto3_cloudtrail-1.38.0.tar.gz", hash = "sha256:605e9bd46b8645c53163ee51202887e95d760e80f18cbaba972ae322da9f3509", size = 35318, upload-time = "2025-04-22T21:20:00.724Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/8f/56bdb3e833f57b3a96d8efbe209a9e8f62ad31fcbf0c6815cb334c1df286/mypy_boto3_cloudtrail-1.40.0.tar.gz", hash = "sha256:695f9fa5c51154c66fee33ac67f2c5e9e768e1da0d64fb42c1d1b860418a3187", size = 36048, upload-time = "2025-07-31T19:38:48.554Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/86/5a163b8b8d1ea5069ec2c7194dd79c8cee1995f1ea8d774186bf3b9539cd/mypy_boto3_cloudtrail-1.38.0-py3-none-any.whl", hash = "sha256:f8b93a849a2318b099fd576853a716ae5dc6197df41fa33c159b670599414cc1", size = 39630, upload-time = "2025-04-22T21:19:58.817Z" },
+    { url = "https://files.pythonhosted.org/packages/04/95/dbdfe2559c3244fa82dc8236a543cabafcc11dba3d83c5c1da70b8e152a2/mypy_boto3_cloudtrail-1.40.0-py3-none-any.whl", hash = "sha256:79977819aa0567f5d7924daad20dcfbfa20a179ddb3e0f9ae776dc2eb526b65b", size = 40394, upload-time = "2025-07-31T19:38:47.055Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cloudtrail-data"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/3e/05f5d26c4424fdfa37d8f592846ed9128cfe5c08cc42c395070add6cad20/mypy_boto3_cloudtrail_data-1.38.0.tar.gz", hash = "sha256:7c07f5fbf52a249dd86bcf3f1c7a1e45dfca6a57ce4c524a8e4db1ca91770e4a", size = 15305, upload-time = "2025-04-22T21:19:56.291Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/53/0ec0f8b32b29730efe315bad0029a29bb63975c5c5a375d0946bf3f5a1ff/mypy_boto3_cloudtrail_data-1.40.0.tar.gz", hash = "sha256:d547e46168dd10775841f7f7c424c7de341aa56cb373f2fda739c473fa394ad8", size = 15344, upload-time = "2025-07-31T19:38:45.903Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/df/614158f20c74ab35e7b63dd79819f36382296f04f901c5acab9bf467d5bb/mypy_boto3_cloudtrail_data-1.38.0-py3-none-any.whl", hash = "sha256:3dfc5cbc50de565535d2bb8551fbc3e6c21957ac669c3ab152b1252d8abb1796", size = 18234, upload-time = "2025-04-22T21:19:55.02Z" },
+    { url = "https://files.pythonhosted.org/packages/81/16/c53bebbf2a674738acb1ae2d1b9292e397e8dcf3c0f5bce07c6b78a016ac/mypy_boto3_cloudtrail_data-1.40.0-py3-none-any.whl", hash = "sha256:c3b13753a72dc66af5124bd2354437f195e92e884c6375d4df98374d6cb594ce", size = 18288, upload-time = "2025-07-31T19:38:44.726Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cloudwatch"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/a6/dc/c4e150c0df6007880a529c50374b33c8c4f1a9932441c1f75cbb34987701/mypy_boto3_cloudwatch-1.38.0.tar.gz", hash = "sha256:bb3492af66e94eb20322d73b793050ea54f1742118b18e36e798e4dafe3b167e", size = 32775, upload-time = "2025-04-22T21:20:04.901Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/f2/f5f85993e65cdaf2bce0723712939c34d96d69fa40861092cd4140a1a9ab/mypy_boto3_cloudwatch-1.40.0.tar.gz", hash = "sha256:49b10a6c65e392f93e8c85d01d3a138fecb38545f5a1bf15cd3e1ac1b594016b", size = 32843, upload-time = "2025-07-31T19:38:51.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/eb/fbfdd68cd000b3c915ac4c85fa3d8aa9e073d47591b19ed48f793ae888e0/mypy_boto3_cloudwatch-1.38.0-py3-none-any.whl", hash = "sha256:1976daa402ecc95200a9b641f733a5612e72daa883c8ac967443955e61cea6e9", size = 44146, upload-time = "2025-04-22T21:20:03.294Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ff/ebdd019210f01ee3874b3e0b6c3f6fe0012c86faef49165e6222d3d98416/mypy_boto3_cloudwatch-1.40.0-py3-none-any.whl", hash = "sha256:5be89084cfeed6d5bfc34b27b4312010e60e5d69cd584df57272acb122e5080f", size = 44265, upload-time = "2025-07-31T19:38:49.801Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-codeartifact"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/6e/d9/4d2447e22fc08077c96d961bc5b242490b3d89b9f7ffef55c4f949011f68/mypy_boto3_codeartifact-1.38.0.tar.gz", hash = "sha256:208e1622006c58adfe09793f5c5cd6a669445ec6c1b96b780b7a27131976bb4a", size = 31467, upload-time = "2025-04-22T21:20:07.787Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/f8/862ace9392d9dafcd59b860d9c29e052b8720371dadc21d7cef800d8e116/mypy_boto3_codeartifact-1.40.0.tar.gz", hash = "sha256:1728e570b9b1f1c998953973c48f00ba9c86257c0858487b38eb4a79403abcf9", size = 31516, upload-time = "2025-07-31T19:38:54.081Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/52/2a4111f733e3fe444a2619a3a8fb8002eca811a73f94a6845d7f32e8025d/mypy_boto3_codeartifact-1.38.0-py3-none-any.whl", hash = "sha256:2d22b8790c43664cbf9ee3468e3f2ac1a4b09960b5539e8b72ea259d3e38721f", size = 36045, upload-time = "2025-04-22T21:20:06.276Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/0e/c507af742533763ce029731b69e524a0e7d18d311e3686515ba678badf52/mypy_boto3_codeartifact-1.40.0-py3-none-any.whl", hash = "sha256:1f6f1185b32c236a13191fcf9a49e7994cc126c0d04cca3c52c16ef142979b5b", size = 36098, upload-time = "2025-07-31T19:38:52.773Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-codebuild"
-version = "1.38.2"
+version = "1.40.8"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/08/64f955d0b699ffaf27a5a09ddaa1211ff18ffb8074b026c026acb94a591d/mypy_boto3_codebuild-1.38.2.tar.gz", hash = "sha256:26c75593d9a66131749422e902c878811b7d129c4953428f44b840aaa07bab41", size = 41425, upload-time = "2025-04-24T19:42:31.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/d5/523cd4ab3a5f1b7998dd4f09c199af56b8b6cc602b291bc1463bd15603b2/mypy_boto3_codebuild-1.40.8.tar.gz", hash = "sha256:0f7b8d7692b8e566097f07f59abd76f9efbbbb0d1d8fb0a10a64837a5d1c370e", size = 41913, upload-time = "2025-08-12T19:28:47.347Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/69/cf0cb92cc00aa329371d1cf5385a70aa5e7567dd91a385a0e674d7a4a6f6/mypy_boto3_codebuild-1.38.2-py3-none-any.whl", hash = "sha256:08aad7498da27b4e18f59ac47d7a9e4c7a4e711f577fb0e48288cd3a8abff5e7", size = 47414, upload-time = "2025-04-24T19:42:26.842Z" },
+    { url = "https://files.pythonhosted.org/packages/01/80/c343579ca527f2eacbc1958314dcbc5c91079ca3f7e2a35fe837dc2dd761/mypy_boto3_codebuild-1.40.8-py3-none-any.whl", hash = "sha256:96f0922d6f9ba4aee9b34fc9602254180f9b569bab6d8b24311380ddb40a0fe5", size = 48093, upload-time = "2025-08-12T19:28:37.598Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-codecatalyst"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/a4/dc/fca599deafae9db7f5504bfe97fd4a8eadd305e892b871437c8f2d588f91/mypy_boto3_codecatalyst-1.38.0.tar.gz", hash = "sha256:29a4417ac8708be27b29f18623a2068d74521e887308a0d8b3522d89b0408d27", size = 26243, upload-time = "2025-04-22T21:20:14.145Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/a2/d2bdbe51eeecb49aecaa76714b085731d463fb82b96dff701aecc3bd36e3/mypy_boto3_codecatalyst-1.40.0.tar.gz", hash = "sha256:70f2f2942bdd6ba88759170f31568bfea1247a0ec4cc1b37f06da65f578fd192", size = 26289, upload-time = "2025-07-31T19:38:59.067Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/6c/d9870ec4f1c5e8412a50c05cacc4aa0a9b53f75a57735bd6e09edf72b278/mypy_boto3_codecatalyst-1.38.0-py3-none-any.whl", hash = "sha256:0bb54bb8103008b019031798b860962408cb7b127a7249296e4c4e2ef7930ba7", size = 33177, upload-time = "2025-04-22T21:20:12.765Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4a/5eff943625d6d18afea02fee49151e882ea799bd245d4ea57dd55238d229/mypy_boto3_codecatalyst-1.40.0-py3-none-any.whl", hash = "sha256:69133ecd87de994caf32096a8928dc5e449b5432584628d9df67af0d9e3f4de3", size = 33233, upload-time = "2025-07-31T19:38:57.777Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-codecommit"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/4f/17700fa77a60263d3edb44b0df82df82b3f2f71813582821f29c537c7665/mypy_boto3_codecommit-1.38.0.tar.gz", hash = "sha256:aea58a41d89372e630a9cfd663cf64fcc8837d88609d265691c5e72620fff7ef", size = 41084, upload-time = "2025-04-22T21:20:17.232Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/9e/b8789f65eef92e8efd069ec09addb4fa364087bcee42cbe5ffaf08a06e70/mypy_boto3_codecommit-1.40.0.tar.gz", hash = "sha256:6ee1bb7fb8797226a84bb3eaffcbbc3ecbc09aa689a98af8fab2225f1515a9a2", size = 41124, upload-time = "2025-07-31T19:39:02.01Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/b0/35095906207c65453d2924da119168060fda673b9675b8951635c0f7b9d2/mypy_boto3_codecommit-1.38.0-py3-none-any.whl", hash = "sha256:e0b4a4ac8a7dcf01591d2475d42d673d6cb2ff97012b41c252884ab8d76ecde0", size = 45439, upload-time = "2025-04-22T21:20:15.538Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/fb/e431919ff3beecc9aab5875ae583d3b61409074817a7180891a36dbc81ce/mypy_boto3_codecommit-1.40.0-py3-none-any.whl", hash = "sha256:41f052760e088bad643c0323866539881e812d175756ca55cd3376c5e089a888", size = 45489, upload-time = "2025-07-31T19:39:00.449Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-codeconnections"
-version = "1.38.0"
+version = "1.40.2"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/6d/eb/743ee55300a4a6f561f8f784a55ff5c42ffe3e07a08d97c8733a4279672d/mypy_boto3_codeconnections-1.38.0.tar.gz", hash = "sha256:a55884b190a6bfadd95d5a6847a978f270edc3804efd70eb63315516134ac2d9", size = 19093, upload-time = "2025-04-22T21:20:20.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/6a/ea9d3417c8834a5d176ed663d36f72d364bf020743149aa9c1e52226e5ac/mypy_boto3_codeconnections-1.40.2.tar.gz", hash = "sha256:d3697f3610ca0a4034aa7922e72f2520221ce769c5c4f4710dadf0b32792b118", size = 19103, upload-time = "2025-08-04T19:32:33.434Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/84/bae119f419211fe98ac4ecaf1fe1ed560dd679fdcd7a995c348a7f6568b6/mypy_boto3_codeconnections-1.38.0-py3-none-any.whl", hash = "sha256:d15d6f7ebb3293467b5ec2eadb4070284db8c228454154aa0d0e9508bd1234a9", size = 24866, upload-time = "2025-04-22T21:20:18.501Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b4/792fa01dd20bad3a9f1cbc33dedc8da7f6301cf2383a0e9225d620c6f774/mypy_boto3_codeconnections-1.40.2-py3-none-any.whl", hash = "sha256:ba40fe3ede6f4420b2761e7234846427129086dc2d2816e900d66902ca59830a", size = 24969, upload-time = "2025-08-04T19:32:29.485Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-codedeploy"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/f5/cbe1225293bd2f01061bd05b695dbf8341010ef9b84c8bb6b784a78c59c6/mypy_boto3_codedeploy-1.38.0.tar.gz", hash = "sha256:379386c578a229bd01930a06a7e52bc4112e148ddd84d72c09b95fa1a1070f18", size = 37162, upload-time = "2025-04-22T21:20:22.95Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/04/1a6e059380b74c50e541431978afe58c8059e8d3872291ee957cd52f3d23/mypy_boto3_codedeploy-1.40.0.tar.gz", hash = "sha256:8c21e3d331cf5e0437d3778cf67684e21afee863fc3a18d1f14797e8e7931085", size = 37197, upload-time = "2025-07-31T19:39:07.943Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/5a/608e0f11fd38839697ef876e56c60630b02d39cc7710c77ed5b87666819d/mypy_boto3_codedeploy-1.38.0-py3-none-any.whl", hash = "sha256:8bf33605e4432b97e7819f9d7aa43abcfdfb4a77df209adc22abbd66f97196f9", size = 43551, upload-time = "2025-04-22T21:20:21.342Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ed/f0fd29928e513f71e3cd87295a97c115fbca4f32bf406ecc66ab9a795291/mypy_boto3_codedeploy-1.40.0-py3-none-any.whl", hash = "sha256:faf09f02344b4d817ac40dcd94df322b1283b81c27ae460ac0f606963737e4ac", size = 43615, upload-time = "2025-07-31T19:39:06.497Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-codeguru-reviewer"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/cd/5fea6a58875724d86f8ba909c021c757682874fddbe084a1395ec0e16089/mypy_boto3_codeguru_reviewer-1.38.0.tar.gz", hash = "sha256:6cfb951a96313ca90e8cd4530f438d7244481a21d8061133f10191df5ac5141e", size = 20349, upload-time = "2025-04-22T21:20:26.862Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/4d/c751fac6ef9ef9c4499f702ededf4c6faed3aae5cc1f9487afadce24d342/mypy_boto3_codeguru_reviewer-1.40.0.tar.gz", hash = "sha256:0c6a699eda03c94630028d579091bb3904cafc4d01e05f72daa8e72106914fb2", size = 20383, upload-time = "2025-07-31T19:39:11.763Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/c7/df80d0e4a34f1bcac93cccdd2e7e2013fa9f3f3f136d326f5f72922c383f/mypy_boto3_codeguru_reviewer-1.38.0-py3-none-any.whl", hash = "sha256:f3c8baeae131bfb3d021d7c065eb31538f3d81154c3998e3a6ddb95cb68df665", size = 29107, upload-time = "2025-04-22T21:20:24.604Z" },
+    { url = "https://files.pythonhosted.org/packages/82/5d/cb811fab6088abcdc88eaab770e79caff41ed86f781212d821291b943e0b/mypy_boto3_codeguru_reviewer-1.40.0-py3-none-any.whl", hash = "sha256:1f036bb37ba08586669ec71aaf60d676f9518f8394824964a3af459bcd1f9aa1", size = 29160, upload-time = "2025-07-31T19:39:10.505Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-codeguru-security"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/46/1605a34e249fb8056808ecad573236d57b2554006b79f1f19f44f7afd6d3/mypy_boto3_codeguru_security-1.38.0.tar.gz", hash = "sha256:c293da8b3200e8d535117284ceb5b0c3aeb7ea25ce37642bd2feeff4ca219089", size = 19181, upload-time = "2025-04-22T21:20:29.904Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/c2/c229944f2ccaa883bdb9c9a8a3ab9bc84b0f496d95ea49eb132f6c7f15a0/mypy_boto3_codeguru_security-1.40.0.tar.gz", hash = "sha256:4fef8f660d50f4642976932b90e5e931a5b73597bd6ca809026a8b7e5bc95e07", size = 19186, upload-time = "2025-07-31T19:39:14.47Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/43/3aecfee9c4c9cfd994efd05292867d83a32b1922cfc76746b5857d0ad54f/mypy_boto3_codeguru_security-1.38.0-py3-none-any.whl", hash = "sha256:2c6c1f555480fb28a771f726bff5b55473f582b58d7c6666384b4fd9e3b8bc46", size = 25936, upload-time = "2025-04-22T21:20:28.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/39/b82dc02991e798a0383bd3320a48224a683bba88dfeaa0fe8a455c5ee6fb/mypy_boto3_codeguru_security-1.40.0-py3-none-any.whl", hash = "sha256:c2fb6e635de4bc917e2fa8101c896cddee84a86d2d6efb156c7feb54b3ed59f7", size = 25989, upload-time = "2025-07-31T19:39:13.345Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-codeguruprofiler"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/8d/28/b0db9653d364e36e42fe0ef0d41cbb61c6981aafdd83eecadea2e1d9d4db/mypy_boto3_codeguruprofiler-1.38.0.tar.gz", hash = "sha256:b7099d2206d5a5117051c46ed0aca8b62f98d4a08f99181a0ac7fa2a8ce19a0f", size = 20341, upload-time = "2025-04-22T21:20:33.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/4b/d2a638be6031c83ce8d098623357a9ff61638ecb08bee25bf35800827a33/mypy_boto3_codeguruprofiler-1.40.0.tar.gz", hash = "sha256:0bd819b138f874aedebf2028f2fd436d2a38bc89be1c8ced87e9bf17438f8a09", size = 20402, upload-time = "2025-07-31T19:39:17.191Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/06/086d1ba84d8d796bf597e22d83ac97b536dd8e3b413c2f94f276a6a0005c/mypy_boto3_codeguruprofiler-1.38.0-py3-none-any.whl", hash = "sha256:e3ca44c8e542ef45449ed2223942289f0188677c5f31381daad6ac7e76b82f10", size = 28147, upload-time = "2025-04-22T21:20:31.551Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c9/171bd6e498bea3ab02d98482bd6a6652b63db15d225a1ad1bb0446591f90/mypy_boto3_codeguruprofiler-1.40.0-py3-none-any.whl", hash = "sha256:f5030c6bfea3a31e09c27f51a573e36bea82386f0c246ecf50a69c87c20829dd", size = 28326, upload-time = "2025-07-31T19:39:15.867Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-codepipeline"
-version = "1.38.12"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/9c/3eb6c0a31f521cf04f49edaf6e4b357156f8d7c2fa0c2a1e0f0edaff51f5/mypy_boto3_codepipeline-1.38.12.tar.gz", hash = "sha256:1d364912348cd49fe540f1520c84434195bc0ddb244f82fd4deeb33d4a2a4fc7", size = 36733, upload-time = "2025-05-08T19:42:33.432Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/45/c3527b86c8d4385e4b2c323a7e1f7e64ec2e4001513fa06719270e01292b/mypy_boto3_codepipeline-1.40.0.tar.gz", hash = "sha256:c162555e195a4520660ecd2b03e52a6b7eb205284fcd4a85601eea9244c2b5e8", size = 37585, upload-time = "2025-07-31T19:39:19.875Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/b9/027d83218667d8b10dc857f8430725c0242fd0e34cb23d8492f148902d5c/mypy_boto3_codepipeline-1.38.12-py3-none-any.whl", hash = "sha256:7ce5ef85b842307eba1892922a34d86bad511b4df0fd780101a9c46f24cb0df6", size = 41373, upload-time = "2025-05-08T19:42:26.71Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/54/cef29eb35566d49c841d559be09cb603b335178a0dc7a5e121d266b8cf33/mypy_boto3_codepipeline-1.40.0-py3-none-any.whl", hash = "sha256:7837a92f2e679c3a2eb0b475b01e29019108fa7ce3378113ef9e1ae74d27b662", size = 42505, upload-time = "2025-07-31T19:39:18.357Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-codestar-connections"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/64/65cc6297114b1f91b2213afb425bc2403fabed2ef69bf34b6334f6f426a8/mypy_boto3_codestar_connections-1.38.0.tar.gz", hash = "sha256:c6ff392225283a9ae523b45befe767ebe268f68c6e059815e26e7c148611e989", size = 19206, upload-time = "2025-04-22T21:20:39.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/f5/5d77d9f6ea20f3cf30fd167d3e696bcf6eab18746d95de50fb7ad163bc83/mypy_boto3_codestar_connections-1.40.0.tar.gz", hash = "sha256:3097e12ed67b5c9c4ebdf9d8aeebcf1abeb297b0e0ef588a0bae5be7bb37614c", size = 19237, upload-time = "2025-07-31T19:39:22.882Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/83/14fb9687af19804b731f8df749ec9d1c9bde23c274b83b7ff23000661b68/mypy_boto3_codestar_connections-1.38.0-py3-none-any.whl", hash = "sha256:6f3afd814074546d80af2f8a30b9040eb7d673e1e36c1196f5bd34b21b95d035", size = 25196, upload-time = "2025-04-22T21:20:37.776Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b5/86767b5c7f1082f6f83ff668648946458d18aadf5516193dc93abc73c8e5/mypy_boto3_codestar_connections-1.40.0-py3-none-any.whl", hash = "sha256:791525d3ba510e2387907a923b703ede84ad3aaa2e1e4313f37737d0d8243f38", size = 25248, upload-time = "2025-07-31T19:39:21.072Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-codestar-notifications"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/2f/8b/5f67829ca6e1bf91b1f92484464a5564e6509716d784019d5ecb3d6b0377/mypy_boto3_codestar_notifications-1.38.0.tar.gz", hash = "sha256:5518d184a70f66b665e6d63aabb00c0632049e9f59723eb5fd992588d31bd5fd", size = 18571, upload-time = "2025-04-22T21:20:42.194Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/78/77a39a20016d56bad4f0dafaf383f7a6597c9fc203e6baf4e6859c68dc1c/mypy_boto3_codestar_notifications-1.40.0.tar.gz", hash = "sha256:02c0b4b4c6342db685c4980b2b740b0eb5cd3a32e4664be9eb4030c90124791c", size = 18578, upload-time = "2025-07-31T19:39:25.646Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/5b/f94806e35f4d0a0c1fa5589bd0b5da94c789bf203bfd87c91c313987d6b7/mypy_boto3_codestar_notifications-1.38.0-py3-none-any.whl", hash = "sha256:0b3594c73da17a6a6ef9a6efce2fb64787fe961e70d9d7d609d4ae9c2e18f20d", size = 24855, upload-time = "2025-04-22T21:20:40.661Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/bb/99c6d248e94b4d28c755985188337959699c4156fa56834264dbcb71748c/mypy_boto3_codestar_notifications-1.40.0-py3-none-any.whl", hash = "sha256:198eb96401e5b437f3dd76d2999af1e1712d94da787b26818e3fbe9bbeb98d21", size = 24912, upload-time = "2025-07-31T19:39:24.216Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cognito-identity"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/d9/df3cc1d44b74951ecb0bc683773196d3cba30407e8fa09be2611b300030b/mypy_boto3_cognito_identity-1.38.0.tar.gz", hash = "sha256:51e93ada134ad1e251c518fd622538478e30df7214cab5d9f40c866c47288b27", size = 19495, upload-time = "2025-04-22T21:20:45.607Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ce/1fa4aa90f1480957bebd6ee0d976ec8cce47ce272d919d6b04666fb59e0f/mypy_boto3_cognito_identity-1.40.15.tar.gz", hash = "sha256:75c471e8c1d3665dad76ba0d02abe44ed8fbe2d6cc50b025c39a645ace7b34e9", size = 19542, upload-time = "2025-08-21T19:42:57.686Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/f4/05b30dd04a961a7a64a405f3203ad03b6291b810f893709735d8a6893f4f/mypy_boto3_cognito_identity-1.38.0-py3-none-any.whl", hash = "sha256:e2b0afcc9657996add70e86ac202b06202a54d0a5fbba2fe060dbe29ce888151", size = 26424, upload-time = "2025-04-22T21:20:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e5/3b6a96f7b24c1f81936cd6cd1705792ca0e78339c55a3ebd9fdc692a2fdc/mypy_boto3_cognito_identity-1.40.15-py3-none-any.whl", hash = "sha256:be254c17646793b9ef8b3ed988fa04ade7f0eca7ef16b033d4a252ca2da8ecfe", size = 26569, upload-time = "2025-08-21T19:42:54.545Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cognito-idp"
-version = "1.38.0"
+version = "1.40.14"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/62/5b/a4e79076d5948dd700d398e19a4fcc804297de71e667e7a816537ca035f9/mypy_boto3_cognito_idp-1.38.0.tar.gz", hash = "sha256:cad448d93607b25f7453742d0f593c41586c77920b70907762358b2157fba87f", size = 51099, upload-time = "2025-04-22T21:20:48.733Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/27/315b11356b93b408fc1bd446b5329a290fe21484c8a559a43c99de66a154/mypy_boto3_cognito_idp-1.40.14.tar.gz", hash = "sha256:83bf63a6d7c16cafd6b947900cc9c4a2010d674cac7f550a7cc15ad5fce55a45", size = 52172, upload-time = "2025-08-20T19:27:17.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/4d/eb6632c7e0a7e3aa64eed8f5a1851ebd5745807ccbaf364602e943125344/mypy_boto3_cognito_idp-1.38.0-py3-none-any.whl", hash = "sha256:35780cee605314c23f65ae5fa43fbbca0c9e11df08439bf0589d0191054e039d", size = 56790, upload-time = "2025-04-22T21:20:46.751Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/1a/d2a57cff6c0e93c9f580ad1c903bc40d80c474b58f5b6414ffc4e3b7d830/mypy_boto3_cognito_idp-1.40.14-py3-none-any.whl", hash = "sha256:27ff55e982585b2adc40b24baeba9ac7c61dcd6ee5ca90466d461847e53e0d9a", size = 57994, upload-time = "2025-08-20T19:27:04.525Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cognito-sync"
-version = "1.38.0"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e9/18/24735a017d605b33d268943410fad97bb2880e94e776836b28ca39c13029/mypy_boto3_cognito_sync-1.38.0.tar.gz", hash = "sha256:b25a5ad968f73a7324a3cf289283fa791699f01cddb27aade0757930fbafb82a", size = 17691, upload-time = "2025-04-22T21:20:53.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/1f/05bc159caa78f4c2506ad05699d5fad0b27d626fd7ac74d7cc206c4ba579/mypy_boto3_cognito_sync-1.40.16.tar.gz", hash = "sha256:34569862c9d90f43250ca97bb7d14230b5767a8fd61f7e1a721e28e8dff1ae6d", size = 17711, upload-time = "2025-08-22T19:42:35.971Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/dc/96f3c80d486cab7ab5387afff6eef608b21d76bff0703ec7b8ff19fcf28e/mypy_boto3_cognito_sync-1.38.0-py3-none-any.whl", hash = "sha256:c8b4d36cc9d4455d984b30e99562d7997e21810fb860fc862f154a7c2a48532a", size = 22395, upload-time = "2025-04-22T21:20:51.48Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/be/1010956bc156cd966b739f1da74d4a2f93e82987e48bb71409acc673804b/mypy_boto3_cognito_sync-1.40.16-py3-none-any.whl", hash = "sha256:9eea026e077051de46a4a9656d43bc5b0183d1f3ced5912c96536383867ec49c", size = 22530, upload-time = "2025-08-22T19:42:30.184Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-comprehend"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e9/61/ee98d67adcf01a1f4eed0b780b27e028ab176ae89fc02c4cdbecf4cb2506/mypy_boto3_comprehend-1.38.0.tar.gz", hash = "sha256:27c7b98fb5eced6e07a5b0bb171175067b2c3c0d6b3a04c78f06474dd7a95254", size = 43675, upload-time = "2025-04-22T21:20:56.647Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/40/849dd7f95115f7c46f8752de67cdf2d81cc18a500125bddcbac4765fb271/mypy_boto3_comprehend-1.40.15.tar.gz", hash = "sha256:f25ae0dfc36b36377267ff2a2ac0f58252aa9f3af03ef910d51024dea8828b74", size = 43734, upload-time = "2025-08-21T19:43:04.577Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/75/7919a145f4f29bd7f8dd5e2c643886c43520688e6a45f4c9fa65ba7cdb7a/mypy_boto3_comprehend-1.38.0-py3-none-any.whl", hash = "sha256:8d6081586d84c7a55afe43daef22444a5db78d0e74d5567af35f4b7b0d8029fc", size = 48942, upload-time = "2025-04-22T21:20:53.373Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/fe/9e365e5a007cb784260d554deaa7f9d0364367e7978ab336785dbbcfc47e/mypy_boto3_comprehend-1.40.15-py3-none-any.whl", hash = "sha256:b5bbce46ea26824b8a63df93867cfcbf37314c1a0b6c60f5a4ae6570466b8869", size = 49071, upload-time = "2025-08-21T19:43:01.658Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-comprehendmedical"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/69/1c/ce967209d8e873b876930a2a9b3912536a10689cf81edcfa362d4bec5dbc/mypy_boto3_comprehendmedical-1.38.0.tar.gz", hash = "sha256:54f24ff256a226c342feec67fcada3687da3ad059f96d3f8eb12c9120d5eaf1d", size = 19986, upload-time = "2025-04-22T21:21:00.626Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/1b/75f459c08df23c36ba471a3365d0d32c4e907dc5a421f0e1ddbf025a3b94/mypy_boto3_comprehendmedical-1.40.0.tar.gz", hash = "sha256:a0916b05d528bf67699785d65771c61e280a4ef2c052d0f6c75833c7378ae680", size = 20002, upload-time = "2025-07-31T19:39:41.183Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/e0/b43894dfac716eaef6674a3a037e0b7d4dbcec689eeb811b84756798c49c/mypy_boto3_comprehendmedical-1.38.0-py3-none-any.whl", hash = "sha256:4b209feb664e815c3ed4974d97dd51d437c16797305a6f9be26c2ce5a05cb51f", size = 26271, upload-time = "2025-04-22T21:20:57.021Z" },
+    { url = "https://files.pythonhosted.org/packages/04/de/8f5a598c5b8dc9f78211e99ef2d68a56d40af4bad28bb180bbe2816f628d/mypy_boto3_comprehendmedical-1.40.0-py3-none-any.whl", hash = "sha256:8185568659f9f73d9acef48757edadf678a4a0a2266b73faa2bfba3e7290b478", size = 26326, upload-time = "2025-07-31T19:39:39.814Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-compute-optimizer"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/97/df/eb7046e9d2fa209f384f73db0119ed0550f53fbf68f3d68090361574f83f/mypy_boto3_compute_optimizer-1.38.0.tar.gz", hash = "sha256:0cda5c00e540f41bc90cafd99c2505fe25c9ad033b9f1401d18907d43916810b", size = 40214, upload-time = "2025-04-22T21:21:04.947Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/c5/9f3aeef4721ef7e59fbddb5167c212a3de5da2fda0e2b26acd38a0a9e9ac/mypy_boto3_compute_optimizer-1.40.0.tar.gz", hash = "sha256:0927c2f4a83bdcbc9d454e5a1f892a75cd29256a847fdf1e6eee8538113ba155", size = 40611, upload-time = "2025-07-31T19:39:44.275Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/6a/64b816d5ae10209cf030b1c21e83ea88a0da356a172d54e1a0692c031fe4/mypy_boto3_compute_optimizer-1.38.0-py3-none-any.whl", hash = "sha256:efc3cc93de9a54c50742ed8be3ebf8a543dca043cb2bdbfd15d7dc45d55c9df0", size = 43876, upload-time = "2025-04-22T21:20:59.151Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/0c/1dce12c13247fc53639547e179d0e0f2e6cbb1f460619b9b1741c92ea915/mypy_boto3_compute_optimizer-1.40.0-py3-none-any.whl", hash = "sha256:cac4b22fef91ce18461d9aa4fa79fcc69978899a62405b3a5b6d32ac9866596d", size = 44369, upload-time = "2025-07-31T19:39:42.532Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-config"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/d1/b7/661bf59f99eaa15451e5cd7daa098fd5f29fbac8f1c3696ec7def687b164/mypy_boto3_config-1.38.0.tar.gz", hash = "sha256:19a0b90a59d27e0f3ff230afdaba293e8512ed838884a93289c0e1b185143f09", size = 67828, upload-time = "2025-04-22T21:21:12.022Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/6c/c306cc830037cac6633666fdd4e60abfd2ec232326462a674891e7fc795a/mypy_boto3_config-1.40.0.tar.gz", hash = "sha256:7ae903ecbdc9ceabf32b9996f444aef4beb689dd441c6858772f9a7d8a30b407", size = 68561, upload-time = "2025-07-31T19:39:47.257Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/a1/218223605f1f02b717ba3e60721e05767a241cc780774bdeb511eddb2f3b/mypy_boto3_config-1.38.0-py3-none-any.whl", hash = "sha256:d86cc32f64bd04420c717421c5b649cd4dce7f2ca9b1e06830b616c1c6774feb", size = 68205, upload-time = "2025-04-22T21:21:05.445Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/be/aeb3825d1f71629ff5b789aa1731d601cb3006c4f606aa570dc4da9a7f98/mypy_boto3_config-1.40.0-py3-none-any.whl", hash = "sha256:3a6e5bc963b00e3f303b9283b3eb325219010568b7d598e4dc40333496ee22ab", size = 68733, upload-time = "2025-07-31T19:39:45.725Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-connect"
-version = "1.38.7"
+version = "1.40.12"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/a8/20/ebcc5467a4acca05b2946a9b9e4f4aab11eab8d4774865ac59da70f362a7/mypy_boto3_connect-1.38.7.tar.gz", hash = "sha256:02ad0989719a04748ddf567bd9ad0b2fc8c6db97fed1d048948599b827ab815e", size = 124962, upload-time = "2025-05-01T19:26:25.009Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ac/162b21eb5f5ee7d958d42c9d896b23240d074e14132822d8c5693643c98a/mypy_boto3_connect-1.40.12.tar.gz", hash = "sha256:2625052fbc8b5c249fad634dd3d6af8f9fe3633e5c18106042354cac58ec5880", size = 126120, upload-time = "2025-08-18T19:44:25.864Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/3e/dd07d0b0a0387f21f8074a0873ea9b3a3b06df83d533847238c9a2c16db6/mypy_boto3_connect-1.38.7-py3-none-any.whl", hash = "sha256:5771b23bd34f987696dd8b721997e9895a158f1fd34405d82569207ec01d4c8c", size = 125925, upload-time = "2025-05-01T19:26:11.428Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c0/9f232d1b3bedeb54a32e9aa63409e54838dd0a47833e909aae74a40c4313/mypy_boto3_connect-1.40.12-py3-none-any.whl", hash = "sha256:cab290c134e62e8fdb185d60224b4bdc33d814c0bb04f7dccbeebd00250311c2", size = 127220, upload-time = "2025-08-18T19:44:02.183Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-connect-contact-lens"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/5a/b1/b36256737bec4f015eef0025b92862cf37594a2ebf4c33cdd7fc597d6af4/mypy_boto3_connect_contact_lens-1.38.0.tar.gz", hash = "sha256:214a0e5932da7c8e1f421caf1390a824fcd3469f68e8dc4c6129b2aaa9339a7a", size = 15722, upload-time = "2025-04-22T21:21:10.355Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/c1/0f91854160af6551d6efdfbea9fbeb476498974ee9d5cc79790174ebb4f9/mypy_boto3_connect_contact_lens-1.40.0.tar.gz", hash = "sha256:b11b8d197d17cbdb10987a5666d8db3184d21600334c0b8d91ee2e1c8373f6af", size = 15725, upload-time = "2025-07-31T19:39:50.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/6c/e19aafa71e4cc7b8b1f13d9430ede6fafaa45d8271d14027bae593b4f1d5/mypy_boto3_connect_contact_lens-1.38.0-py3-none-any.whl", hash = "sha256:83dbe4eb9e719ad3e34e9d30fd901c5338d5cb9fa27c4f272fe9244a94bf7c16", size = 19249, upload-time = "2025-04-22T21:21:06.593Z" },
+    { url = "https://files.pythonhosted.org/packages/85/99/d57d24d6216610f619eca4dd64d5d8320145aa72578a56424e0c94166443/mypy_boto3_connect_contact_lens-1.40.0-py3-none-any.whl", hash = "sha256:b6d4d9cd38eb97ff23d2d406c9a35290374ded00b78a2b58ddc8bf057394d222", size = 19306, upload-time = "2025-07-31T19:39:48.718Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-connectcampaigns"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/93/8008cc295b40de61b016cdc8540e1cc870bc28ae3cd94cd06f48a37c27da/mypy_boto3_connectcampaigns-1.38.0.tar.gz", hash = "sha256:80776b7edc4d29aedb23d0330572962a2c0143990ad79f0b671f69793856cc60", size = 19041, upload-time = "2025-04-22T21:21:14.871Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/93/a2979a24069ed07cfbf7972fbfec7a01bc1a1ac3cdd8129bcc73be4db619/mypy_boto3_connectcampaigns-1.40.0.tar.gz", hash = "sha256:9c038a572f9a1f6830f0d67c70d498a90d2415657819be2853acb5bc7cf77e92", size = 19089, upload-time = "2025-07-31T19:39:56.215Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/f1/06050095bdd06aa5b2f26bd1332231f08d2ab93830328d8f7665e8429ef1/mypy_boto3_connectcampaigns-1.38.0-py3-none-any.whl", hash = "sha256:1622991447eb2068e5dacba0b745752057a594f8557ad8512f82563cc326858a", size = 25569, upload-time = "2025-04-22T21:21:12.532Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/da/4042b6ac0a835bfb96c18906cf62cc84d8daa7c18811f71e230fbc334cd3/mypy_boto3_connectcampaigns-1.40.0-py3-none-any.whl", hash = "sha256:ec310dd51b562f577fa2b104920eb337ab24af3eef0ba595804e2ec97f87d2fa", size = 25649, upload-time = "2025-07-31T19:39:55.031Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-connectcampaignsv2"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/fb/63/b0a4c1d3724e178c042f3119c64de3bde4621c7edb87db00e84f7938487d/mypy_boto3_connectcampaignsv2-1.38.0.tar.gz", hash = "sha256:b2f5c30d435990fa0e7c698f761338b67a99dd239387253b3390783d598d0c75", size = 22223, upload-time = "2025-04-22T21:21:16.091Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/c2/93b1e391697a56119a1f177c3550476ea14f9dbb344e265b43a6acab0b58/mypy_boto3_connectcampaignsv2-1.40.0.tar.gz", hash = "sha256:979b5a19f99c1232c71f9dc442218cbedf9892c6b640182a5ea25ae14d149734", size = 22531, upload-time = "2025-07-31T19:39:58.446Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/d5/8cf9d2bfd8f6a5b35f376cc1dfe9de63a38563bc0d08d4f7759dc8942124/mypy_boto3_connectcampaignsv2-1.38.0-py3-none-any.whl", hash = "sha256:e6428d24d1a6ee40d67fd05ceee99fbaaf9a3825a958d4ec9ec54de6ead7f3c9", size = 31071, upload-time = "2025-04-22T21:21:13.578Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/66/47a9e907549c1f9752360009b2b7a1b200c0061ca63de13587778e2272a0/mypy_boto3_connectcampaignsv2-1.40.0-py3-none-any.whl", hash = "sha256:0f6847d2f5140f421bbef1956e6a8108b5d1921548444ad64f44b8c0a9a4b625", size = 31557, upload-time = "2025-07-31T19:39:57.614Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-connectcases"
-version = "1.38.5"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/70/b1/4de236ed58c41495668899229d6ec9b935111307f816b2947293241fa913/mypy_boto3_connectcases-1.38.5.tar.gz", hash = "sha256:ae29d2eaaa4bd595c2aad170d9ab8fbacc3ae3ad0cdb35d839fabb076c79bd20", size = 23049, upload-time = "2025-04-29T19:42:19.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/7c/efd7bfb1815eeab5ddc6feac13a1ade0210de26f3a0e6a0ff6154d9c3536/mypy_boto3_connectcases-1.40.0.tar.gz", hash = "sha256:7431cf34cf875442015eef46151b679d8fa3e49df567480d7effdc77dd505f82", size = 23297, upload-time = "2025-07-31T19:40:01.205Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/0d/04d280af01f8add24e1a72322998e89e978ca1c74c1b1d390ab49d331e11/mypy_boto3_connectcases-1.38.5-py3-none-any.whl", hash = "sha256:94d913e23e3351b54483bb6d5310da6c49b1a8e2ab936b888fcd07289a62111a", size = 32137, upload-time = "2025-04-29T19:42:18.126Z" },
+    { url = "https://files.pythonhosted.org/packages/96/dd/7a46d58adab0b027c536bf475f7df53d4c7463b1185d7f673f4db2c8bb4f/mypy_boto3_connectcases-1.40.0-py3-none-any.whl", hash = "sha256:73ee3381b306d52ba5d0810219a1ff5fcbb7641272e287ba98d72d3e277fd406", size = 32477, upload-time = "2025-07-31T19:40:00.061Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-connectparticipant"
-version = "1.38.0"
+version = "1.40.12"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/55/9b/b168f64a31a0adc24432c9db527b89c3fcd6ef1f33976e318672b3fd3d94/mypy_boto3_connectparticipant-1.38.0.tar.gz", hash = "sha256:0014480b9f666ade1e934cab5b170752beb6c215e669979fe3bc8347b036ae5d", size = 17347, upload-time = "2025-04-22T21:21:27.414Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/9c/08cd419becddaf79f130a0bf12831216da06bc54a63ff257d227094a6200/mypy_boto3_connectparticipant-1.40.12.tar.gz", hash = "sha256:6fed3025b73f2ee3cbec2995cbe13bd1ec9f15ea6f85137eca60301029bf8fb4", size = 17658, upload-time = "2025-08-18T19:44:24.555Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/bf/88addc0a5cbb8f9cb2487eabf7fce58ab0ba2d0d65002aca99d0dafb1562/mypy_boto3_connectparticipant-1.38.0-py3-none-any.whl", hash = "sha256:5449c946c6c5b5220f93ecba249fcfde2fe5c205912acec665eac3fe392ad7df", size = 21994, upload-time = "2025-04-22T21:21:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/1f/a4f71ffb2e82debad2ecd443464baf9dd828d3f28246dfb184cd47d1be1a/mypy_boto3_connectparticipant-1.40.12-py3-none-any.whl", hash = "sha256:0fa730bdae55f548abf67886c57d5c6686ca7e3963683d349e41d841cb66a7cc", size = 22632, upload-time = "2025-08-18T19:44:21.414Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-controlcatalog"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/55/06/b447873747a7425b1e213cfaf17c4d227d4879f53912d312a6204af4f51d/mypy_boto3_controlcatalog-1.38.0.tar.gz", hash = "sha256:d547ff1d60bd08bcdbf2db1cc605748551623bc21e7d511e681bc37a8b395368", size = 17573, upload-time = "2025-04-22T21:21:28.969Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/a1/b0db52dfb2a72e6f18db12959e266171d83ef979b57cdd4eb5a8fd09a89f/mypy_boto3_controlcatalog-1.40.0.tar.gz", hash = "sha256:d93f4c37d5faf9a65389b72479716576dfce173952b9cf5b1bc0cf944e9ca873", size = 18292, upload-time = "2025-07-31T19:40:06.257Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/e0/99f0e1a012c29f2a9fc10c26a51b26867672d38529f6c09504662f92d865/mypy_boto3_controlcatalog-1.38.0-py3-none-any.whl", hash = "sha256:844451454b6160a9925631c53c7a893ef1f530705338ea9ceec4ea4b110a343c", size = 22939, upload-time = "2025-04-22T21:21:20.575Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/29/ff64c42f99d03e8cc23a43e83038fcfd6ca5384bf68d0aab007d9c182f47/mypy_boto3_controlcatalog-1.40.0-py3-none-any.whl", hash = "sha256:4719399594b9199ca5a0038f7e85a845c2acec23b4782b0e5192ba267fbf6604", size = 24062, upload-time = "2025-07-31T19:40:05.085Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-controltower"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/de/f3d0ec78e17c672e7761029263e03f110a3874a4590bb18af61809c3c1f2/mypy_boto3_controltower-1.38.0.tar.gz", hash = "sha256:df222889a3e681804e4c2624d914321d6ca1525034a995d47cb9e128449e5165", size = 21351, upload-time = "2025-04-22T21:21:28.242Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/3b/314b0864075814df6b17c09f6a2ebbbdc652d7e0dfc8857b9745af2ce808/mypy_boto3_controltower-1.40.0.tar.gz", hash = "sha256:6e846b0d6898b72296522989ef26f7b983c6481fed988dac11734569c00f0e27", size = 21493, upload-time = "2025-07-31T19:40:08.8Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/d9/8f7454f23ea8d7f64bf6344b7315eadbab3e79322e40f7558c96c8013449/mypy_boto3_controltower-1.38.0-py3-none-any.whl", hash = "sha256:13ff9109e282512482080753fd4ca07f827e378403a3a0c35a0679963f50075f", size = 28948, upload-time = "2025-04-22T21:21:23.193Z" },
+    { url = "https://files.pythonhosted.org/packages/84/82/37c3268eb27ac07b9c365cd09bc98058bdee209904891250e902129566ec/mypy_boto3_controltower-1.40.0-py3-none-any.whl", hash = "sha256:caed5d7bd5b0411ff4c8e510e6b9ea805dd1f5e00867922f111a07708d5b770f", size = 29209, upload-time = "2025-07-31T19:40:07.565Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cost-optimization-hub"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/2f/70/361ca3d32a9c40daa6ffef5e93868ebacb98cee76d5f76eeced0202504c8/mypy_boto3_cost_optimization_hub-1.38.0.tar.gz", hash = "sha256:ffaf6842c51d957c8ae541274b21a05a7e883689dc2cdd1b496ef5bc28de2c99", size = 20306, upload-time = "2025-04-22T21:21:32.135Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/de/98649a35323d727151e6ea9aeca9eeccdcf8b41c010fe041610563f6a17a/mypy_boto3_cost_optimization_hub-1.40.0.tar.gz", hash = "sha256:e2c74d6b4bf8f7f924155eb96cd6f1cd8f19da6f285f7769f1173b43fabee71f", size = 20555, upload-time = "2025-07-31T19:40:12.645Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/07/aa9478d0fd818f77444cd9f0e050632057624e76a1dfd2589e8cb8590a0c/mypy_boto3_cost_optimization_hub-1.38.0-py3-none-any.whl", hash = "sha256:b6f0df9e580d0bf50c79b96a19bfc8a682382a4edc1acec4fd9c05e89dd5f4b6", size = 28244, upload-time = "2025-04-22T21:21:30.44Z" },
+    { url = "https://files.pythonhosted.org/packages/86/de/f67f11e3d423290fd07a7f6ab1231d57f321ccedbd71fc1160757c78360a/mypy_boto3_cost_optimization_hub-1.40.0-py3-none-any.whl", hash = "sha256:098ce20140a2ae748e9455592c841e94d22839e25fdc189a697ddae3eab51a6c", size = 28636, upload-time = "2025-07-31T19:40:11.008Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-cur"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/67/4c/e75d8bd696036ba3e2804a7f21cea99ecaa78e682df35565876dad4124a8/mypy_boto3_cur-1.38.0.tar.gz", hash = "sha256:96eae99be49f2c564a44e01d3223e1b614676a28710d74cb3b6f7a2544126d87", size = 17241, upload-time = "2025-04-22T21:21:37.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/21/e5e69ba0008c0688b8b9463fe8b9527b9ca7b364b5f465d07fe36091a83f/mypy_boto3_cur-1.40.0.tar.gz", hash = "sha256:b3014e38607f8953fdf0450e7d3a211c2c73acb35fd5b9d7fdc6d0582f373d5c", size = 17245, upload-time = "2025-07-31T19:40:13.597Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/3d/b06caf057323669bc8bbccababd79bab49b444a8723ff7528026518b0e76/mypy_boto3_cur-1.38.0-py3-none-any.whl", hash = "sha256:f94976bd3365f395be8847f1f5db2131fdd19f111888510cbfb9c6cea21658e2", size = 22216, upload-time = "2025-04-22T21:21:30.85Z" },
+    { url = "https://files.pythonhosted.org/packages/91/19/55dc82218cdd6111224818ecb9f6ddc0b5481db298337997a69b73a6c818/mypy_boto3_cur-1.40.0-py3-none-any.whl", hash = "sha256:12cbbf37c417d1238d987038e9415b586f7f2f2ddfb6ea5afc2ef660d40d043e", size = 22274, upload-time = "2025-07-31T19:40:11.497Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-customer-profiles"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/b9/8b0a35dcba21eab45e1dee8bc2c0577f18e9bd97e064bb4cb0ebcb99f9aa/mypy_boto3_customer_profiles-1.38.0.tar.gz", hash = "sha256:12e4b868b7a34ce7f5c359a4c75629f518f60f2d7445cadcaf09df7b6e7fe5c3", size = 42928, upload-time = "2025-04-22T21:21:35.551Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/5d/fe8e4917240acfd9f5f0ac020bc8650698a2c62210a0e6b5a6a61da14902/mypy_boto3_customer_profiles-1.40.0.tar.gz", hash = "sha256:7cc59d5c39538d291fe51e54f9c77ce44e6a1041c0ca5e0c734bf55b6ad6e160", size = 46680, upload-time = "2025-07-31T19:40:17.274Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/d7/d93db17dde44d240244f9d4db2581743e6cffd62d850038083ce3c24202c/mypy_boto3_customer_profiles-1.38.0-py3-none-any.whl", hash = "sha256:5f74da95ad8c06efb80fa41935e83ae870c11d8c0b099ee638583cf01a836687", size = 48343, upload-time = "2025-04-22T21:21:33.224Z" },
+    { url = "https://files.pythonhosted.org/packages/00/9e/32982b7c5fcbde99a3ab1da817364af5b02418a854293bc1ce573f5b62cb/mypy_boto3_customer_profiles-1.40.0-py3-none-any.whl", hash = "sha256:befc1ab49bad07ecadea383fde03dbae38a8a93d7ff97d5e38d351aa6140f2b1", size = 52784, upload-time = "2025-07-31T19:40:14.92Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-databrew"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/d5/53ec1847e25a715691ad66466e2fe1f3c3b53bc33fd2da7263ba627b45a6/mypy_boto3_databrew-1.38.0.tar.gz", hash = "sha256:76ee5c663c17cc85bc14fd8dedef4e6fd0a6f693e545e498eb911091fb1af9b8", size = 32137, upload-time = "2025-04-22T21:21:38.127Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/54/56a268d15e47068383ee000c4a9459e8784d0330434d2a1e5c7f671eb5f0/mypy_boto3_databrew-1.40.0.tar.gz", hash = "sha256:a70fb5c2f18baf8b98754b809c3c1241e27428b7bd24dcdf4589d92534cdac85", size = 32186, upload-time = "2025-07-31T19:40:18.181Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/0b/c65ebb9f0a556726a64020ba910d703cfa5a4c99fb5eab1783a7dd7f77f5/mypy_boto3_databrew-1.38.0-py3-none-any.whl", hash = "sha256:2eff74be437bf3c869bc73bc7cfbf789c4e9325b82b4b9f3e660991da47e94be", size = 36224, upload-time = "2025-04-22T21:21:34.54Z" },
+    { url = "https://files.pythonhosted.org/packages/86/21/41539ecba9b799b279913525fe60eaa02e32f1b4d0413f11dc5ea4a7f6e3/mypy_boto3_databrew-1.40.0-py3-none-any.whl", hash = "sha256:41df1ca79df912659a965657b9d8576465ed6a58812853a2fba6f25b1554bbff", size = 36284, upload-time = "2025-07-31T19:40:15.809Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-dataexchange"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/cb/c7aa3374f88c9a69ade4a78da1bccc8a701c2b970325a464b221476c55be/mypy_boto3_dataexchange-1.38.0.tar.gz", hash = "sha256:d32b3cbff01327b734f8c2680224aa201a027203b4db61c1f42fc983bbc580d7", size = 27756, upload-time = "2025-04-22T21:21:42.144Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/a4/a1eab1aa35e280d2708e28945fdc49e95f15793daae9365fd25ba2ffa046/mypy_boto3_dataexchange-1.40.0.tar.gz", hash = "sha256:555986d66c861fc149a6a43adc60cc607e4a5403ecbfe3e69dcfd6c47a53707b", size = 27771, upload-time = "2025-07-31T19:40:21.763Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/03/7048878e2486ff1edf7b8eee7f86c8b80b4db0eefcf2449b31915c08c692/mypy_boto3_dataexchange-1.38.0-py3-none-any.whl", hash = "sha256:5fe220bf8ce341c013a23607d402e732b4b429e489564ebaeb8f48710db29d7f", size = 34326, upload-time = "2025-04-22T21:21:39.829Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/b4939a68a3dd33cfcc27031ee765021803d6be10d18f819204f81f31c64a/mypy_boto3_dataexchange-1.40.0-py3-none-any.whl", hash = "sha256:57b2132145ad1fb0990a02dc584462c29cbf868db1bd468d79529265493bc940", size = 34393, upload-time = "2025-07-31T19:40:19.798Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-datapipeline"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/7f/0eeb6ddd434b42411d9b5d386ced673c8809abedcbb1878c0a04e2031230/mypy_boto3_datapipeline-1.38.0.tar.gz", hash = "sha256:06932460ce7e71c85f860fb1251f7f71777be5fce5e38af0b175c47b9a1fa305", size = 19395, upload-time = "2025-04-22T21:21:44.227Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/f7/bf59c79f006808191212a65db8204859f26bb02de6a521df12848faf3628/mypy_boto3_datapipeline-1.40.0.tar.gz", hash = "sha256:4214e34356595fccd0ce76b6ad4bb6cc5e63779d44e2627ffafe39b1df69de50", size = 19426, upload-time = "2025-07-31T19:40:25.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/0e/bc22efae02286ca649af4e21ad965f3e6a0b2160653a9adbd74114d3b540/mypy_boto3_datapipeline-1.38.0-py3-none-any.whl", hash = "sha256:5e3ea713f205c6f6208bb708d82a2065c961fe246311878929425298406de39f", size = 26094, upload-time = "2025-04-22T21:21:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/de/bc/b653996b36ac4017fcfa75770983463c122471c06ca34b6b7fec9330e61e/mypy_boto3_datapipeline-1.40.0-py3-none-any.whl", hash = "sha256:a04e9ee0e241d53d93434bc578e1941926d22f56885e7590d5fcc333d422d52c", size = 26150, upload-time = "2025-07-31T19:40:22.728Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-datasync"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/f1/8ba6a1df9ed1d1b47e5eac9c8cd3d46635e21ae572b9ee763baebc750dcc/mypy_boto3_datasync-1.38.0.tar.gz", hash = "sha256:4a4fd7b4e8dcd380daead7e66c68347de41a8779a7b170e35f02b00ab2d9f26b", size = 37220, upload-time = "2025-04-22T21:21:48.805Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/2c/c54bb748f2f9b7165ea1eed39911fea05375460f6f8dfef631f84aa22aa1/mypy_boto3_datasync-1.40.0.tar.gz", hash = "sha256:239c6fc79502a758761f5736c48ea6488e19697b0e36cff4f7f0497d15c2af70", size = 32314, upload-time = "2025-07-31T19:40:27.118Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/25/f5ba646825435ef96dc0ab46f15c00b53520ba3be79d89447f6b14179863/mypy_boto3_datasync-1.38.0-py3-none-any.whl", hash = "sha256:0d64474ee35fa086f5063a8b979ad5dbe42df8366ab8575f0462e2ad2d2e1748", size = 42435, upload-time = "2025-04-22T21:21:44.776Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6c/4dc3a71bd65b6e764fddba3b3eb07122054aec41c05744bc4d32e8067483/mypy_boto3_datasync-1.40.0-py3-none-any.whl", hash = "sha256:dbe1a1054c0c6dd50955613b0569ae8b27e57919195ab7c02ef57171f44baeab", size = 36870, upload-time = "2025-07-31T19:40:24.665Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-datazone"
-version = "1.38.9"
+version = "1.40.14"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/99/75/ae0e492c59c8991724e36fc62db7ae5c0b87707183a4b7dc43dd6917bd1e/mypy_boto3_datazone-1.38.9.tar.gz", hash = "sha256:070e3159e74adaee66a3384f71877a124a2177239a1ffac0c5e7c33cc42b8767", size = 82721, upload-time = "2025-05-05T19:47:04.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/cd/78531ad49d59c8a6211c20be77ef6aed8e802f43e23aba112e083f61ac94/mypy_boto3_datazone-1.40.14.tar.gz", hash = "sha256:da31ceebb1bd42f7e2b7d34352c422f232d30d422f76ff1fa49cc46ca22ec6e7", size = 86361, upload-time = "2025-08-20T19:27:13.668Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/d5/08d1ad6e5c43c9069d2c6f88b73cd1aa7797e95283b4d49324c480417f05/mypy_boto3_datazone-1.38.9-py3-none-any.whl", hash = "sha256:8c4e8265124d8b94654a043830734950934b49ee5d498c913d596d392baa3114", size = 88731, upload-time = "2025-05-05T19:42:09.016Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5a/a11249520efc6957faa0df1c01224f473085668bcd5cd82659ee5b3f7549/mypy_boto3_datazone-1.40.14-py3-none-any.whl", hash = "sha256:c2da0fbd22b1d247b9ba08ec09a365083f8d664091979cf07f7a9c0bde084f37", size = 92646, upload-time = "2025-08-20T19:27:08.615Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-dax"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/a4/61/4f00ad28e061981e1c7568dd3ed7f3dc5209bcba847e1185ef390f361a69/mypy_boto3_dax-1.38.0.tar.gz", hash = "sha256:b962f8e27ec58d3f812ae889dab6ec83ae71d247f157821d380a0b9ab6de2b91", size = 20635, upload-time = "2025-04-22T21:21:52.704Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/30/4272467febffc868a82f16a63750c75be6392d6184a668444cb95545afee/mypy_boto3_dax-1.40.0.tar.gz", hash = "sha256:f162104f76452d2729e3381ed42bb93a4c5e5d2f460823dd625c093f0c33d465", size = 20674, upload-time = "2025-07-31T19:40:29.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/16/c4cf67b4f87c8074aef111adf59c59a71246466ea45f0c583ed4e7887fd5/mypy_boto3_dax-1.38.0-py3-none-any.whl", hash = "sha256:94b567fa6931c4890a9e20dbab3b95e95ab90f5443cc775150e2798e9725bc23", size = 27660, upload-time = "2025-04-22T21:21:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/31/c0/944c79ed4ddd1d480a2ef6504a5ed308cd9ad1add5a8c48dc5b09a152e13/mypy_boto3_dax-1.40.0-py3-none-any.whl", hash = "sha256:0954b25f233eb1bd723d820294c71be44a306f5ae4c902afe982692ed56b00ec", size = 27707, upload-time = "2025-07-31T19:40:27.711Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-deadline"
-version = "1.38.6"
+version = "1.40.7"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/7e/990fda16cf1657886a7b7106906dae0745e6c6118961d8f150e1b4f5a6fd/mypy_boto3_deadline-1.38.6.tar.gz", hash = "sha256:1264ba20034235870982329498ddadd0259e507fc5008a02c264230a3c80b0a0", size = 57551, upload-time = "2025-04-30T20:12:49.502Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/d2/e925a14d06d85ef904dd04e169728d499f8d7f01e159c2748891cb06af7b/mypy_boto3_deadline-1.40.7.tar.gz", hash = "sha256:88b04c22285647965c5a9752eb99ecf3d14509326367ca228da4055348f2973f", size = 58042, upload-time = "2025-08-11T19:30:42.801Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/76/1f7b9bf7abb6ad13da2e0d365548e895301308793744c6da98e3d5b71396/mypy_boto3_deadline-1.38.6-py3-none-any.whl", hash = "sha256:9745db901f05af06c9b05fa5d68daec1ee80ced5130062a03b80fa1d2099208b", size = 64259, upload-time = "2025-04-30T20:12:43.823Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/cd/dbc56ae9b12f8b1a514f72433196a6c8c8cf187249b2ae11e12eaa396abd/mypy_boto3_deadline-1.40.7-py3-none-any.whl", hash = "sha256:d9ca9ff2a92c2e22049a82127134accf89b5d36cbb18fee7c227141eb3b9cefd", size = 64843, upload-time = "2025-08-11T19:30:38.376Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-detective"
-version = "1.38.0"
+version = "1.40.14"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/a4/75/60ae28f780981c41fa64aca544366eb5e060065b98481fe1d86b457f3634/mypy_boto3_detective-1.38.0.tar.gz", hash = "sha256:be444954a720bc6d2c641a1102e1df481dd788e022e7236a2c7d054518d34618", size = 19801, upload-time = "2025-04-22T21:22:03.89Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/0b/986db6dc6408364e4bf201597ec6d7c1c559eae2f21c884f7fb091ea785d/mypy_boto3_detective-1.40.14.tar.gz", hash = "sha256:40334b22035e920b9e3fc5cdc816d1a53d4d6c3f99c314363b3594e1a17dfc63", size = 19857, upload-time = "2025-08-20T19:27:15.819Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/b7/86b74d0ca88ce7455064ec11ff33fa6bcf62c0902121589f9e59710a8520/mypy_boto3_detective-1.38.0-py3-none-any.whl", hash = "sha256:de31deb54ac6a7ddbad199e9adc022680a1cceb6a563873ffdf16e657af5a8bf", size = 26007, upload-time = "2025-04-22T21:21:55.041Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/05/3e1587b22cf3310a92dbd1607191d4a6fd1566168f7df42dfb8401cd76d8/mypy_boto3_detective-1.40.14-py3-none-any.whl", hash = "sha256:232e820ec58ef8f948d41095560b274200dfac49b57e81e121a9c8fb03847365", size = 26130, upload-time = "2025-08-20T19:27:11.104Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-devicefarm"
-version = "1.38.9"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/26/de/53ab6a4ba2973ba4f803f0b6ed074269ba7e7cebe6f74cb11caef8cfae1a/mypy_boto3_devicefarm-1.38.9.tar.gz", hash = "sha256:9dbf80886db8b35bf24d7c1fdb0c0996eb0c775aaf8a540e77598a636b4ed0b9", size = 41425, upload-time = "2025-05-05T19:42:14.871Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/1c/1db2e208342600cd4ab9f31ad6cda3e98060e2c634a572562b112b0a6593/mypy_boto3_devicefarm-1.40.0.tar.gz", hash = "sha256:eafeb97e5384c56ed5f147e8c8f681714403623849da3cae4295cc656f9a8c22", size = 41463, upload-time = "2025-07-31T19:40:36.14Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/b5/7a2a82f5c9fe2671b51028e55c294cc2ad32268ab5400e64ea1bfd485312/mypy_boto3_devicefarm-1.38.9-py3-none-any.whl", hash = "sha256:b8d427560e957176da5954a068bd4704ffe09accd1814a6e2ec913c3aef65d87", size = 47572, upload-time = "2025-05-05T19:42:11.161Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/27/c7564e7734a795e66a4effc19b5f59e1ee021c70105fdc9d8ed5fa46ccb9/mypy_boto3_devicefarm-1.40.0-py3-none-any.whl", hash = "sha256:2a1dfef1363cd19ed010bd38ea4709b5071c9154fb574cc22b26363ad9c611b9", size = 47623, upload-time = "2025-07-31T19:40:33.352Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-devops-guru"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/61/00b015b018ede9cce470e60c2729ab91a90b65c3dacfadd6615b70dcfbad/mypy_boto3_devops_guru-1.38.0.tar.gz", hash = "sha256:0261a3a2f46b4fbd8cde3a60a8026d0c1607ef2d0d3058fb5a6fc27df68364f0", size = 33807, upload-time = "2025-04-22T21:22:02.833Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d1/6145d0e52cf81ad8a647b50bba7c3de2ef332a8dd59827ff92c4844fa4a5/mypy_boto3_devops_guru-1.40.0.tar.gz", hash = "sha256:6904750ab09b8ac7f4bc0a488c55dae7fa0a0b8435793d00b0b4e0d040688c0b", size = 33898, upload-time = "2025-07-31T19:40:40.223Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/0e/133560df8a325d62aa5d17a9c68cf05c91bef0ccf6e7c50eb8b4d0468b0b/mypy_boto3_devops_guru-1.38.0-py3-none-any.whl", hash = "sha256:5ecd36cf5cba476e92b00a484454d8201eb68bd5484e265bf4b0d8c591447a6f", size = 40275, upload-time = "2025-04-22T21:21:59.412Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ff/025c540bc5b299d96c765da8af3744f5656f1267785965d0ccd51ca594e6/mypy_boto3_devops_guru-1.40.0-py3-none-any.whl", hash = "sha256:e023aacde234713efe599b0663784af1ac16e5b96eaea9a9578518d30400c6a5", size = 40330, upload-time = "2025-07-31T19:40:36.601Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-directconnect"
-version = "1.38.0"
+version = "1.40.10"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/f0/2f4fd737ee06c5e5b15d157409628e4d1a7604383c1e46b64a3fb61ccfb5/mypy_boto3_directconnect-1.38.0.tar.gz", hash = "sha256:2238f0518b1e747b36a34d85af3051a1750374aa68f513e937496e3934e66df0", size = 31997, upload-time = "2025-04-22T21:22:07.64Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/f1/042e678c67f5d1f0fcb3c5e0db5a61a001035a046b50275d70c2b9ca2877/mypy_boto3_directconnect-1.40.10.tar.gz", hash = "sha256:64cf670924b3326463cb19f2a5071a391c185e25cc5f3db91b0d9d26539571cd", size = 32186, upload-time = "2025-08-14T19:27:11.987Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/9a/208b8107f943a8cc8ba86b044acf3c962aee2976e7684b309f9d79f99861/mypy_boto3_directconnect-1.38.0-py3-none-any.whl", hash = "sha256:58e88c6006f443ae3f562810831f28b5388b2a5200d15051252e65d5ed203154", size = 35674, upload-time = "2025-04-22T21:22:04.871Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/11/01201c1ba51d45435aa8b05c30fd9b37aab31b21397a931afe25c9e1102e/mypy_boto3_directconnect-1.40.10-py3-none-any.whl", hash = "sha256:42779ffcffd4aa4451602fc921e1d18d080ecd99d050bc67cddf13ec7fd35f87", size = 35866, upload-time = "2025-08-14T19:27:03.411Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-discovery"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/00/58817980063bc13af524328200ce9b79fe2d5e9df5bae2c439ab5382eccf/mypy_boto3_discovery-1.38.0.tar.gz", hash = "sha256:4713249df15cd27e126ff759f427c4eff07b8dee38800a0e6d914f6e1a3eaebf", size = 23206, upload-time = "2025-04-22T21:22:08.606Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/52/89fc4ca28e80792363c5cc392b89fe0161bf233477b6b57f7fb5f952680b/mypy_boto3_discovery-1.40.0.tar.gz", hash = "sha256:ec1febde19b075ed94450177cedbf746ebdafb420fab6b8d0286389401e06bcd", size = 23206, upload-time = "2025-07-31T19:40:47.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/ae/4c256744dcdeef0cae10648f7d5e4d2c57e354cdaf0f262d52e2b813884a/mypy_boto3_discovery-1.38.0-py3-none-any.whl", hash = "sha256:60caecd8a29bfca3021682e9cc27528fa48e5991543d666539cf267d1e7e759d", size = 32382, upload-time = "2025-04-22T21:22:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/2f/9ca732a1293ede98359c8edfa2cae23a4e7a7f60109c233c1749caf052b1/mypy_boto3_discovery-1.40.0-py3-none-any.whl", hash = "sha256:c318b490629a1429409616da877882b7a9b52b26f0736a83a92e46ee8666b92c", size = 32442, upload-time = "2025-07-31T19:40:41.748Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-dlm"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/0d/0b105578eba00488ab3377ec687ddca149b9bddf11e4b53131fcb4a54bc6/mypy_boto3_dlm-1.38.0.tar.gz", hash = "sha256:985164137efffbc93e619e1925d83742214dd9b92a02b9d29a3a0259dc4c2787", size = 17836, upload-time = "2025-04-22T21:22:10.395Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/45/44ef7deea727246bc786eb9302aa999e43abced46d377be28ec4a4d1b6cd/mypy_boto3_dlm-1.40.0.tar.gz", hash = "sha256:b7e68ac5968ad99c7a410d809a5094a635e116d7266be9ce28c5c5d5b9117c16", size = 17856, upload-time = "2025-07-31T19:40:48.484Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/d0/dc2d419033e458d7c5fcfade465761b566a5afc42408930b85f48bcc7c62/mypy_boto3_dlm-1.38.0-py3-none-any.whl", hash = "sha256:03ff5758262539d26e3e9857061749af28d381194e55661118d5209bf5facdb5", size = 22373, upload-time = "2025-04-22T21:22:06.748Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ac/f66ed396eb24ddf9e665955cf9630801a466d9b3c0997daec92fa41ba488/mypy_boto3_dlm-1.40.0-py3-none-any.whl", hash = "sha256:b818c797b6f6a8ad9d70717850710116d095215af5895fbc3567a834f3b8da80", size = 22434, upload-time = "2025-07-31T19:40:43.17Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-dms"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/8b/274b50a5627b4746bde281b596e939dde17ab3ca240e46cfec9678d800c8/mypy_boto3_dms-1.38.0.tar.gz", hash = "sha256:47565f99e34c3e490283f3bf9c347456a6bba0d5e587160e506e631d6d39352a", size = 60474, upload-time = "2025-04-22T21:22:12.569Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/01/f5ba4c7b1102b7248d02e1aac425b93abcf363912ba862064aaf45b0e754/mypy_boto3_dms-1.40.0.tar.gz", hash = "sha256:253fbfb56cab7045c288f85f7094185ec3c0c0a08a2cfbbe73703eaf88892158", size = 60456, upload-time = "2025-07-31T19:40:52.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/f6/14e73888cd60195e5250ea7d097fbd5e375d53653bcfe003e1f6f4aa6704/mypy_boto3_dms-1.38.0-py3-none-any.whl", hash = "sha256:47e084dbd7c5e974435a38c708d32604d292c4094d09e282eceb0cf7c4d83899", size = 67428, upload-time = "2025-04-22T21:22:09.16Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/36/e4ba14cb6da7694f1e47892c671c9bac30ee1a18beecfab90acf909a051a/mypy_boto3_dms-1.40.0-py3-none-any.whl", hash = "sha256:86a46cc997127e73762850a26ae36a4505174eb69cabb0a8693953149c2abdaa", size = 67458, upload-time = "2025-07-31T19:40:50Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-docdb"
-version = "1.38.0"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/35/48c7c8122e5d2d5362d4b536071e412e49a4c809f6d65e0eceafc9008dfe/mypy_boto3_docdb-1.38.0.tar.gz", hash = "sha256:47c4840458e5959711ed488781774895d4e8463a7e605e05eb1b61682cef8b96", size = 35864, upload-time = "2025-04-22T21:22:17.717Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/02/27eb7dee1d190b37be74a52ee0dd27cab2e419c91a42243ee12374fc1424/mypy_boto3_docdb-1.40.16.tar.gz", hash = "sha256:aa9c5073c66afd700924129a015167a0695f54bff4f2587e1ea4f68b1fd40ce7", size = 36143, upload-time = "2025-08-22T19:42:32.736Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/19/d1fefb35d7305dc6d007e6ccc1976b786fff3fd1883add6490bcff668c83/mypy_boto3_docdb-1.38.0-py3-none-any.whl", hash = "sha256:37c68708e9c4f45ae628b33f240ee9ef74b52cf5ede0623205b8630908990799", size = 41525, upload-time = "2025-04-22T21:22:14.475Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/bc/59324a7c48ce23f97e1d95a32cdb7f45059a35992e62403cb0541cf9b306/mypy_boto3_docdb-1.40.16-py3-none-any.whl", hash = "sha256:62a8ca1b0737ac9046ca67b75f888eb2469537ccbf2ad399e2a3b52e06a1652c", size = 41867, upload-time = "2025-08-22T19:42:30.21Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-docdb-elastic"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/cf/112743ee54d64304f40fa828826c39739c6d860845fcbe397b048e345e4e/mypy_boto3_docdb_elastic-1.38.0.tar.gz", hash = "sha256:25e40a82d86c16c576836e2438d644b9c11f67bbd8f140b884a37014eda8e4b2", size = 19098, upload-time = "2025-04-22T21:22:15.009Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/cd/f23d9d2e25adc0271f8d67a25ec3ea7b77a84c3eed8b47489768a4cbe99d/mypy_boto3_docdb_elastic-1.40.0.tar.gz", hash = "sha256:4ca55a55df7683ed9b57934d4672ee559430d25672713c9eca307a52057e8877", size = 19143, upload-time = "2025-07-31T19:40:53.851Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/aa/04abb491068459fb30acea8ba683cc3d1d0ae73deeee9445f700b564ca26/mypy_boto3_docdb_elastic-1.38.0-py3-none-any.whl", hash = "sha256:33be0d62f75d34b100a75fc591b8706d3f7743139556573d1983e3ca3ada24ea", size = 25590, upload-time = "2025-04-22T21:22:13.085Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a9/99667fb414ecff75e9d41d1ca7d94618779677538005ce140c9bbe1aa8fc/mypy_boto3_docdb_elastic-1.40.0-py3-none-any.whl", hash = "sha256:67130604fa1506ec143cfe76a88ef6b959e766883d337285e8b1c04f2badead8", size = 25642, upload-time = "2025-07-31T19:40:50.706Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-drs"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/b1/5cb0eb08b493fb21b91831b63073b90e19c22a25f2e917d4ae346fbbaf03/mypy_boto3_drs-1.38.0.tar.gz", hash = "sha256:31925145d6769d35fe11c7a25b9804ae807e15c18d0701ee835e8845693a9616", size = 36306, upload-time = "2025-04-22T21:22:20.737Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/c9/a1a53af0442bb1e91c454b5a0f4311f4dca46d98141f84b77c68a30aa0a3/mypy_boto3_drs-1.40.0.tar.gz", hash = "sha256:76dc39e330333f81dd756c74919afb4b3c665a22828a23fa838f9a0d14627769", size = 36325, upload-time = "2025-07-31T19:40:58.201Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/07/f782cc4d0b096b58459ba935bf309e597a21f21c718ede4992a34ff57924/mypy_boto3_drs-1.38.0-py3-none-any.whl", hash = "sha256:cdfb908e50a1f4df6901bbb25a746a0dc7c6ee897b8e445f601b34b9ba674391", size = 42100, upload-time = "2025-04-22T21:22:18.463Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/a9/e1f92fcbc3cd0e036a147f19898a48eb10386ea7ec66a3fb5077508ba4fd/mypy_boto3_drs-1.40.0-py3-none-any.whl", hash = "sha256:b11127d69f4ce9d86434dbd69a396d7468e32cf10e97f73f663b7e16b0d143ef", size = 42159, upload-time = "2025-07-31T19:40:55.683Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ds"
-version = "1.38.8"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/ff/f9/57f4631e21feac59517c794533e63645688161d6a5e8b4aad3d09238e31a/mypy_boto3_ds-1.38.8.tar.gz", hash = "sha256:c437be91697ffa3f6bb8aae534b4f6d23bf659b26f0a132422bae41f72485ce6", size = 37478, upload-time = "2025-05-03T00:52:24.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/b5/38d85aca54fcfa79d6a56bb9b7c626f1e443797145a78a5511c5ef693f11/mypy_boto3_ds-1.40.0.tar.gz", hash = "sha256:323b4488c88a82ebf5440798e028e4fdaa499608b98c7ffa6af80cb5d729fb64", size = 40849, upload-time = "2025-07-31T19:41:05.713Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/c3/df364d16df677bd999e352d22899a7b873373b083c31636008e8e77d0f54/mypy_boto3_ds-1.38.8-py3-none-any.whl", hash = "sha256:a84ebab6ad25bc3e0949d730c5731b627db1f7c1adfa3a529956f5dff18292eb", size = 43111, upload-time = "2025-05-03T00:52:22.061Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/71/0e3ac2fa4c713c2e2a6cf85dd54af2346f601092bdb8736c8d8eeff7eff9/mypy_boto3_ds-1.40.0-py3-none-any.whl", hash = "sha256:07009d592fda56e7b0a5b8e7098fccbb667856826ea5af8783f9442e924e89ce", size = 47736, upload-time = "2025-07-31T19:41:00.629Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ds-data"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/91/2e/d3497e916d2a85c331a62f2bac714701d7d8a01fe53cafc7f7a884fcf778/mypy_boto3_ds_data-1.38.0.tar.gz", hash = "sha256:6553d3cf252a860de49a6df61cfd0adb2905d2c5a9e9921be38b041df7a614bc", size = 18881, upload-time = "2025-04-22T21:22:22.447Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/0c/16904a821b484ab39fa37444235564d8ccbce461d546826520ec98e539db/mypy_boto3_ds_data-1.40.0.tar.gz", hash = "sha256:9ce867230d7c73b0b219583e60fc4ff496dd52a8b787b5d30eaa9e1b36e13817", size = 18926, upload-time = "2025-07-31T19:41:01.029Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/68/c2918c91fbd2e1853947a9e617cbc9d23ee676efb4c5ae59f5f5ca422ce8/mypy_boto3_ds_data-1.38.0-py3-none-any.whl", hash = "sha256:7561cc37a9d5c07c64cfa704d42a8bc74bd973062e5384c99f70716d35826179", size = 24738, upload-time = "2025-04-22T21:22:19.899Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/78/ab55f3eae33fffcf25983cd1ff4ef94fd7fc8ff4558e47273f4da5809e1b/mypy_boto3_ds_data-1.40.0-py3-none-any.whl", hash = "sha256:14c5ea13545a69e237e269780892d06569f61add08d703ccbeda8feb8aafe6ea", size = 24794, upload-time = "2025-07-31T19:40:58.679Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-dsql"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/6e/5915c94d6b50e0f65ab149ecf42301e4e76b5e807243dcb0e9752b4c9210/mypy_boto3_dsql-1.38.0.tar.gz", hash = "sha256:aa7779511bc958d241c91f7e1e507e137c6c947c43c692365370f01024626dc6", size = 17803, upload-time = "2025-04-22T21:22:26.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/ce/942fd90c700947b5459be84eac26a876f7a7c37f7604b837b75af085cc33/mypy_boto3_dsql-1.40.0.tar.gz", hash = "sha256:cc7aae9d7ebb41b0d39ee28f8fec46f21ef138b9d8b8cdce3c40554e8f0105d4", size = 17989, upload-time = "2025-07-31T19:41:04.358Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/25/291421342a329d85a6ab351e5c2e2398375566bd3f326ca032788c0544de/mypy_boto3_dsql-1.38.0-py3-none-any.whl", hash = "sha256:ead971fc58f35eb0f6f96333636d6b5a2c7f4e1c0cf794e73269fd2f2589198d", size = 24015, upload-time = "2025-04-22T21:22:24.153Z" },
+    { url = "https://files.pythonhosted.org/packages/18/4c/8821980e951ae515fbd42193bf67207170430cdb1d0f44c4533729137619/mypy_boto3_dsql-1.40.0-py3-none-any.whl", hash = "sha256:b3fad00079d15eb382af0da566baceebd1fac1571d5edf78a4c337039adf20dc", size = 24441, upload-time = "2025-07-31T19:41:02.189Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-dynamodb"
-version = "1.38.4"
+version = "1.40.14"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/7f/72b68d275a80a42675c36249b80dd79ec5c7d9bd1f5cc93cdb572f866722/mypy_boto3_dynamodb-1.38.4.tar.gz", hash = "sha256:5cf3787631e312b3d75f89a6cbbbd4ad786a76f5d565af023febf03fbf23c0b5", size = 47461, upload-time = "2025-04-28T19:26:22.728Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/85/f5d4261c084cac14e4f19bb074f9292f68e18493174289fb21e07339f25c/mypy_boto3_dynamodb-1.40.14.tar.gz", hash = "sha256:7ec8eb714ac080e7d5572ec8c556953930aba5d2fbcc058aa3cbb87ccce4ac79", size = 47978, upload-time = "2025-08-20T19:27:30.166Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/35/3d0ceabb0a9f3765f509cb9dce6ddfa939114682b1acc442f52a755e9bc8/mypy_boto3_dynamodb-1.38.4-py3-none-any.whl", hash = "sha256:6b29d89c649eeb1e894118bee002cb8b1304c78da735b1503aa08e46b0abfdec", size = 56395, upload-time = "2025-04-28T19:26:16.947Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b3/6f2e15a44e66a8cc98fd1032f3aba770f946ba361782a0a979a115fdf6e2/mypy_boto3_dynamodb-1.40.14-py3-none-any.whl", hash = "sha256:302cc169dde3b87a41924855dcfbae173247e18833dee80919f7cc690189f376", size = 57017, upload-time = "2025-08-20T19:27:20.701Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-dynamodbstreams"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/ae/5e199d7161c9e90f5cbab34b5b91a51abd6fe81d69911fdd3756dfe22e94/mypy_boto3_dynamodbstreams-1.38.0.tar.gz", hash = "sha256:bd441b2b11f0829cf36551d5864c6ce45d36a866a39e0b373acc6a043dec18c0", size = 16341, upload-time = "2025-04-22T21:22:31.532Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/32/85a869df1f9f7dff9f17046eafb67561f8ba1ac842dc02ac317e5802598d/mypy_boto3_dynamodbstreams-1.40.0.tar.gz", hash = "sha256:c7fd1271cdb9f55378e6bc7de184f8f10dcd4bb9e7776a0d460c50026cb79d24", size = 16447, upload-time = "2025-07-31T19:41:10.17Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/90/dde924b7beb2ea1b76febdb1d9dbff6438bdc75577c93592ec58ccc7d298/mypy_boto3_dynamodbstreams-1.38.0-py3-none-any.whl", hash = "sha256:1dbc3b5fd8f2eec27f669555cb0b348a5d02c9fb0eb35e77d1779b39e56f5694", size = 20220, upload-time = "2025-04-22T21:22:28.335Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ea/55e9fb74a0908b5769704c30ace8fd6a012c1fe86b9ce6030e88fe49e126/mypy_boto3_dynamodbstreams-1.40.0-py3-none-any.whl", hash = "sha256:1cf76eb58c06cbbe825edfb07833dde5d9d21b950b472421b3db926c8921c3bd", size = 20448, upload-time = "2025-07-31T19:41:07.501Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ebs"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/8d/fa360ce1fb00a76e54b27d7d500ae9cae470bf3252a7ff079b5fa82b8f6e/mypy_boto3_ebs-1.38.0.tar.gz", hash = "sha256:450878ea3ad7aa3e1b5d3449fad3d1f6caa5ef2527ec493dbb8a74394d00edbd", size = 16114, upload-time = "2025-04-22T21:22:34.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/28/51068d931dff8a3f99accca94c39f20482d4fb871f5ad401a50b928b9481/mypy_boto3_ebs-1.40.15.tar.gz", hash = "sha256:8ed931d246c8ed207be14e6e5b219d56128c96ccbf4fcda5cf73fcf64f0b30f0", size = 16192, upload-time = "2025-08-21T19:43:08.361Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/58/b0020527eb3f5a76c0f07748320aa3a64efe3f759f06abef936f0df11305/mypy_boto3_ebs-1.38.0-py3-none-any.whl", hash = "sha256:06ed6b1b31d263f5482b5f039781c6a8749b84ae59114d63449beb1ac2e9aeb5", size = 19546, upload-time = "2025-04-22T21:22:32.156Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f1/984f8effa750d2fc8669e35deb2874ba44fa3463c278119c1c5c1fb9c4b5/mypy_boto3_ebs-1.40.15-py3-none-any.whl", hash = "sha256:e6f2f6fe8f1f5a0c8504c8f49e7e056b10457cd460a11ae313a47132d46794b5", size = 19682, upload-time = "2025-08-21T19:43:02.163Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ec2"
-version = "1.38.12"
+version = "1.40.13"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/06/b0/0f6105e3dbf45c061e096d80593b5cde6a3a010755941711e74a0a4b5b2e/mypy_boto3_ec2-1.38.12.tar.gz", hash = "sha256:3693a46050a053151b93a4895d8598379fc5306b3c688cc155efcd8642d4a11d", size = 395959, upload-time = "2025-05-08T19:47:22.153Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/71/2a4d8a80283ae2716788bd85484cd2d2a391e14233b35ae40480322be773/mypy_boto3_ec2-1.40.13.tar.gz", hash = "sha256:c3d686f52d3bf6a823119e4225c3b344eb1828425570f9d954c9efa5811a837d", size = 404597, upload-time = "2025-08-19T20:45:16.117Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/f8/a50f138387d090c0883170c185a67b219f39cd11b73bc336909f15982ff9/mypy_boto3_ec2-1.38.12-py3-none-any.whl", hash = "sha256:144bbc0cd7350b4c7f96fa316084084076ddec93ab483b7f670068054915e5e4", size = 385492, upload-time = "2025-05-08T19:42:24.664Z" },
+    { url = "https://files.pythonhosted.org/packages/40/18/dd879a450f40215d6e8825578b51f41fadd12f116fef3543d8568d0c2f4a/mypy_boto3_ec2-1.40.13-py3-none-any.whl", hash = "sha256:22b4f486d66a30976842483ce40c38ffdaa6fdf1f94a163e5fb2825aa6386ca4", size = 393810, upload-time = "2025-08-19T20:45:11.025Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ec2-instance-connect"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/65/b99683941877dda6217b65de3a0ee44b130d4fa06535071cf023596051e0/mypy_boto3_ec2_instance_connect-1.38.0.tar.gz", hash = "sha256:d73839570f95f9ba69e45c53c340927f148dec935507063823cb831611092f7c", size = 15266, upload-time = "2025-04-22T21:22:36.174Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/4e/f97e1cfc2c9dfe8c15bf0fffef94395da59fd6f5215fd43f4d80b140079b/mypy_boto3_ec2_instance_connect-1.40.0.tar.gz", hash = "sha256:6260f64020faa1cf07077c8da63fee717adb177295b953625bcacae14ccfc46c", size = 15265, upload-time = "2025-07-31T19:41:15.26Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/ab/ce561d166c150337b8caa08c93a0b3b4bb5dd260bea2f75aba5ef0a73c9c/mypy_boto3_ec2_instance_connect-1.38.0-py3-none-any.whl", hash = "sha256:f639d1007f918f09504e25cd6d26861225380f761764b498c8bfbe493cede5d5", size = 18242, upload-time = "2025-04-22T21:22:33.272Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3e/e75da74e47076dea294ecffc270905be3f7bfb8d73c606d04299336a5d08/mypy_boto3_ec2_instance_connect-1.40.0-py3-none-any.whl", hash = "sha256:cf686fa61e885525ba49fd908e73e39afbabdd091caafbad54695a143a20f0ce", size = 18296, upload-time = "2025-07-31T19:41:11.152Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ecr"
-version = "1.38.6"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/e9/3744b4262a82060f17dc2133107d2d3ea3c347906726f69740989f708321/mypy_boto3_ecr-1.38.6.tar.gz", hash = "sha256:09322f94861195a93a1678e16f2c9284d1ad61b464e39fc449710a22847babf2", size = 34121, upload-time = "2025-04-30T20:12:58.996Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/10/076d964b9aa733ddf2e1a60e0ebd1b46afe2d9ce56eea29ee7e60f0eaabf/mypy_boto3_ecr-1.40.0.tar.gz", hash = "sha256:7733e42bc8a92ffd93bebf0343af133fd52698ffebd323d82ffde755ce28687f", size = 34328, upload-time = "2025-07-31T19:41:17.442Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/a5/447c8899786218844de22e1c65cd292fd2076b8cfbe9e82167d74e013fa6/mypy_boto3_ecr-1.38.6-py3-none-any.whl", hash = "sha256:044ade53373c820ea7087cf280f76c1fa5b84dedd3bc0d453f36c2d40ef11b4f", size = 39960, upload-time = "2025-04-30T20:12:55.082Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c7/d02932049bac4b7c7dc3d1b5eb9edfe1a5fa7b094449f1d2cf6abd8aaf16/mypy_boto3_ecr-1.40.0-py3-none-any.whl", hash = "sha256:d887c00f908d2cac911723b1f170d8561d8d4325c8280b0fe04fba399199cafe", size = 40250, upload-time = "2025-07-31T19:41:14.074Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ecr-public"
-version = "1.38.6"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/56/593d8e4bce4aacb88f110f19e12c5c739affacc081a69842a64676e56aff/mypy_boto3_ecr_public-1.38.6.tar.gz", hash = "sha256:69266ef26c6c4e1a38a6f5966cdc2525fd0844e8ea8d39485041390c99008dee", size = 20036, upload-time = "2025-04-30T20:13:00.27Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/22/f806dc4ed267a273026cc65ca78c4802f59b9f072582dba10c7d686d1acd/mypy_boto3_ecr_public-1.40.15.tar.gz", hash = "sha256:9a46819879f72ec3879c7e244d69066c2b0be30fd3acf06dfe90579e3fb5022f", size = 20098, upload-time = "2025-08-21T19:43:06.572Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/98/a0de078bee6f3cd163835cb7d0e132acfca6ee3509ba30f25c1702faf91c/mypy_boto3_ecr_public-1.38.6-py3-none-any.whl", hash = "sha256:8db4d85432fa09d70af926596d4439041a2bbad07bf19fc11589214596a37bb0", size = 27168, upload-time = "2025-04-30T20:12:55.718Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/a1/a7510dff338e62b5eddba4cd74724f279c4fa9c9dbd4b821834661966b6b/mypy_boto3_ecr_public-1.40.15-py3-none-any.whl", hash = "sha256:da7a9ca9336da7f10a9ab78d6226d3e28c70bf6ac2c0d7540cac822a62900b66", size = 27282, upload-time = "2025-08-21T19:43:03.02Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ecs"
-version = "1.38.9"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/2f/97/cf05de6b7b30294789328d13f105373de49a7dec35be6e60d9ebdfb2c9ab/mypy_boto3_ecs-1.38.9.tar.gz", hash = "sha256:2f180b1beb8da42855f4c67ff71b05e516b2554e62daa8d8a7bde301014103ab", size = 47603, upload-time = "2025-05-05T19:42:18.281Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/fb/919b081e5855ea00fe55feebdf488ae0dd11e309864a74ea35c8cf216284/mypy_boto3_ecs-1.40.15.tar.gz", hash = "sha256:66ab30919eaa1ea169c4972d5632bb6d99d4cf8904f40e71fb59808f1b9c3f13", size = 48522, upload-time = "2025-08-21T19:43:13.442Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/24/43965de5fbb755a2cfde652aac047140ee2e06d4e0cee7e00afed8aea985/mypy_boto3_ecs-1.38.9-py3-none-any.whl", hash = "sha256:3bd56ebb1ac2f9ff4d2da94109601fb448467e7072d1d079db836beed5d32900", size = 54561, upload-time = "2025-05-05T19:42:15.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/44/630c9446d17a185dd136acb421799f00f280e4c9880825e5700d8fc9ff91/mypy_boto3_ecs-1.40.15-py3-none-any.whl", hash = "sha256:c9ab304da231e40c132d0db2c4711615452cefa59430702a731a456edd156431", size = 55726, upload-time = "2025-08-21T19:43:09.834Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-efs"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/67/c1/2ebe0b97d05c4ca3696f41ac0760ea4bfc78513b78b60d94b4f583f9b866/mypy_boto3_efs-1.38.0.tar.gz", hash = "sha256:6762cc405b5c4cdab1b2858a1a0e22045b5bc275c65555d0ad16bf6d9767978d", size = 21868, upload-time = "2025-04-22T21:22:55.87Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/07/f2a093f033f0a08d96363be6f16df1fc47e2f6e24741b66b09ef9996873e/mypy_boto3_efs-1.40.0.tar.gz", hash = "sha256:0d065423bd9c9d1b786301cc422bcc74be32f41f443761fb748326c9b717fd49", size = 21974, upload-time = "2025-07-31T19:41:28.097Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/3f/948a0b5feb65b7e43182304d7f331bfbb0b5f7478b2ba97f0ebca685f1a6/mypy_boto3_efs-1.38.0-py3-none-any.whl", hash = "sha256:03f0ce6f9a6b350e05a2382401c5eec1ee5a348b142850391fc313555b7d7d89", size = 30141, upload-time = "2025-04-22T21:22:53.838Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d1/9e99b1ecd486f16fa223c3987daff1af0e71bd793991eaff28e0cedf109b/mypy_boto3_efs-1.40.0-py3-none-any.whl", hash = "sha256:0358f0b25fca78b203277af978e89a1dad6555c7d30db6418cc160b629e3f0c6", size = 30324, upload-time = "2025-07-31T19:41:25.744Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-eks"
-version = "1.38.0"
+version = "1.40.14"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/f9/8a7f2feb2c4e4ad4cc8b3d02daae58447538dfe0cd91d677df46b4d05b83/mypy_boto3_eks-1.38.0.tar.gz", hash = "sha256:6764df087dcfadde84f529145d12ab1c0a70daec279926561b196985c2398b65", size = 42433, upload-time = "2025-04-22T21:23:02.114Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/71/8e56f6dc991fababf66c90e965fa71220af57740ad7b95fa22ffff93f5e3/mypy_boto3_eks-1.40.14.tar.gz", hash = "sha256:87df7b634aaba46b562afc03317e52f709a6f890c4a5aff36f92d3616649ca84", size = 42795, upload-time = "2025-08-20T19:27:31.984Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/a0/68f650c2a081852550b971b625a1a5d6b4282090502b8bf4237f258f2457/mypy_boto3_eks-1.38.0-py3-none-any.whl", hash = "sha256:4473e9bf431ff759786f8a7240352e5af7a87f7dee801880c778c9e8fb7cab3a", size = 50078, upload-time = "2025-04-22T21:22:59.985Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/43/1f0d561fe7559926e86e50322668e942c23d1e519e4f5deb75dc6533bd52/mypy_boto3_eks-1.40.14-py3-none-any.whl", hash = "sha256:06b1b13a7ec15bc217d236c9a576f35b6e3475a79db889c47f027f9f022c6bb3", size = 50479, upload-time = "2025-08-20T19:27:21.271Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-eks-auth"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/7b/be1f89595a7faedd9c3fbc3f69c48881ad226120ed9f8f8c06c85bf594d8/mypy_boto3_eks_auth-1.38.0.tar.gz", hash = "sha256:2e9f8529fd31669ca81bf6c2946c38304fb2391130c3e298feb75895300ad0c9", size = 15319, upload-time = "2025-04-22T21:22:58.599Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/62/44f9610953940155261a1480df52e38c18eda67f6d9ff31020012c110a63/mypy_boto3_eks_auth-1.40.0.tar.gz", hash = "sha256:d87f67da3cc14a251859f3567388ecf00733095a33c0e9889e91ba0dd1d9557d", size = 15345, upload-time = "2025-07-31T19:41:30.88Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/cd/6ef53c17a5b5527983803638681bc2a155e068499b57dd010c202dae008b/mypy_boto3_eks_auth-1.38.0-py3-none-any.whl", hash = "sha256:35c958a6f5c164390f0374c809585b6c958bd2304541ee31debfb709be1cf402", size = 18069, upload-time = "2025-04-22T21:22:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4a/724bd31ea3f52af64f1cfa69b3989478db185dc8c03bbaab4202a92ddad1/mypy_boto3_eks_auth-1.40.0-py3-none-any.whl", hash = "sha256:50263a86671ca93415b8ada33d0f26d24977961ae17b5a8c5dfb4711fd988c63", size = 18135, upload-time = "2025-07-31T19:41:27.149Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-elasticache"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/9e/1d/2bbe6d1e383190973c740d092d0d77541dcd813cedbad7ee5e9f06447c81/mypy_boto3_elasticache-1.38.0.tar.gz", hash = "sha256:b224240eea9cf2a6290fb3a4991c2c2831f54f939021f4b1beb6a4fd57efc10e", size = 46619, upload-time = "2025-04-22T21:23:05.433Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/e7/4266ab114b805962ece529f0e62eaa381d6a2079aadcb8865e38ed606c5b/mypy_boto3_elasticache-1.40.0.tar.gz", hash = "sha256:c0ec524452c91dc3b555cdbaac529ac5ee3d979fcf280c4307272f574111d42a", size = 46643, upload-time = "2025-07-31T19:41:36.517Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/cb/7c6972d0f606a04a0e9b6bcfec45fe7f26efa0f6bab9e8de6ab634cd6cec/mypy_boto3_elasticache-1.38.0-py3-none-any.whl", hash = "sha256:4a1fbf75ebaa2780962a2a99b2523b4b578aa70ff4e089762efe218adc0ae3dc", size = 53328, upload-time = "2025-04-22T21:23:03.444Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/c4/fae2c991738325eed50f807541be496c76186272bcbc64912c654a22feb6/mypy_boto3_elasticache-1.40.0-py3-none-any.whl", hash = "sha256:03f1d210a3c2001f6fe1c62911633d1f2019a3ae3207036b99d3439a064bbc47", size = 53388, upload-time = "2025-07-31T19:41:34.504Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-elasticbeanstalk"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/f6/3546ac66d0405feefa329191b366ea76439a9f238719f770b822acc423df/mypy_boto3_elasticbeanstalk-1.38.0.tar.gz", hash = "sha256:a2a8f20fe3a54c7c6b51e9db79c198b7c1a35c7a22a74ef3b206dbfac88252ac", size = 34598, upload-time = "2025-04-22T21:23:08.302Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c3/b17198ed12034dd77e5a4a0b7c03c434da442b12f398ce5caa9f8bedd54c/mypy_boto3_elasticbeanstalk-1.40.15.tar.gz", hash = "sha256:4cc7d0b77acae1a4fb0e794909b263eec16b0cbf4da907389104bcb1d4dd0d2d", size = 34675, upload-time = "2025-08-21T19:43:14.827Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/44/96d8bfe6b3b34f89a22f8ff58649a2cf961822b97032e93fadac773f5e65/mypy_boto3_elasticbeanstalk-1.38.0-py3-none-any.whl", hash = "sha256:8bff9efab5e1c169de0e5dd041074c9ed34081a5588e4396bd2477d42dfb2140", size = 40660, upload-time = "2025-04-22T21:23:06.724Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/0e/2fe77cb742dd4d6811bf770a72aba1a1db05153b8f0bbdc0b4e1875d7bb2/mypy_boto3_elasticbeanstalk-1.40.15-py3-none-any.whl", hash = "sha256:91a841ced1d8892bc0e935789afbf728ad1521b54017daa6d3719217f3438d2c", size = 40787, upload-time = "2025-08-21T19:43:10.274Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-elastictranscoder"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/77/6c/e26bf08cb606abf52cd590d3bb357c4a5fba6463edb8694a053d6a006714/mypy_boto3_elastictranscoder-1.38.0.tar.gz", hash = "sha256:4619c48b24016333919f3bcf647e9409f65aeb33dff363fef40a2f11e7dff463", size = 21191, upload-time = "2025-04-22T21:23:11.095Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/4b/31b7aadfbdd546af79837a03f0bda9a86396cf96e6c5f26a8ca5ff34771b/mypy_boto3_elastictranscoder-1.40.0.tar.gz", hash = "sha256:e31a630203437d83f767cb8fc4836c2ce435bef6a75d6d7f4036d4719e7b7b46", size = 21205, upload-time = "2025-07-31T19:41:45.26Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/bf/4889e3218e6cb922908a380ecc36570396fc5cb5e48b49a8ddaf3957787d/mypy_boto3_elastictranscoder-1.38.0-py3-none-any.whl", hash = "sha256:e6c91722f630db37274185cb4d17b340fb38bafcce04ce987a7f656b73212891", size = 30078, upload-time = "2025-04-22T21:23:09.373Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/8cd989eaa057a7011ba3634a1fea3d6042e8308b4ef636f0f14f684a94a3/mypy_boto3_elastictranscoder-1.40.0-py3-none-any.whl", hash = "sha256:d3f90581eb8bfb79616690ca4a79269e055c7036658e8b089f8e222e3c2e8921", size = 30130, upload-time = "2025-07-31T19:41:40.668Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-elb"
-version = "1.38.0"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/33/ccc97c9cd5ee765faf368487b869b46efdd03ce0bad1a2bf25fdc2c791f7/mypy_boto3_elb-1.38.0.tar.gz", hash = "sha256:befdcf0f2b30688f6c2ca94fa171a7803321dd2200cbc71608a695cc45026fba", size = 21580, upload-time = "2025-04-22T21:23:14.334Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/25/e7d977218596c045f48c7ed48b4555492bd1fb2d3b61e7d22aebd45ed2e3/mypy_boto3_elb-1.40.16.tar.gz", hash = "sha256:f4b28ab75a86c3f8164be5ed3739a78e4d163851c0993bb3923f43ded62e32d5", size = 21628, upload-time = "2025-08-22T19:42:40.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/cf/7f5fef8078609f25c7c66876c2ce5a0c3262a01ced3d7e6dd50ddced3e90/mypy_boto3_elb-1.38.0-py3-none-any.whl", hash = "sha256:f35682c9d731021e97c0b57a5d87becdcfc6c9bed931248a29605995a2311295", size = 30180, upload-time = "2025-04-22T21:23:12.263Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d0/15ef7c120749bce4d4d462ab82abfcf076e0017af68d6ff63c63fd1eafa9/mypy_boto3_elb-1.40.16-py3-none-any.whl", hash = "sha256:326163ba037f3d3c0a318a711df8b2b2672a62eb579e10ad4b2e6ff2e40fa46d", size = 30316, upload-time = "2025-08-22T19:42:37.373Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-elbv2"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/1c/d7c055bb5b7ba57ed7a8ef194ce93f798950ffaf2cb01216d98742f3a67c/mypy_boto3_elbv2-1.38.0.tar.gz", hash = "sha256:6c65cf4814547e489173622cc7bf7de77815daabf6ac213d37e2f5d4211c7ae8", size = 36216, upload-time = "2025-04-22T21:23:17.213Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/8f/9d29eac2c6bab5bfd6bf8bf460baa7e2807359c19e5e3e7caa498900c6ae/mypy_boto3_elbv2-1.40.0.tar.gz", hash = "sha256:cf1a4073b678566e81cddabb6e175e920e8701429eff73d746f890d1ff29ecd1", size = 37011, upload-time = "2025-07-31T19:41:48.15Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/d1/d78b160bb724d91e12029bf5a471d84fa99fa7c95da15b3387a8b5eacdbf/mypy_boto3_elbv2-1.38.0-py3-none-any.whl", hash = "sha256:b03765e7a1ab912558cde3fad3d41d09bc4c3a5126fb9722bb931eb77b5e8dcc", size = 42307, upload-time = "2025-04-22T21:23:15.402Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c9/d76bff7eb969611f08d65e69015ead86389d867fc314883d0a720c187472/mypy_boto3_elbv2-1.40.0-py3-none-any.whl", hash = "sha256:8f80ce7c861d3bb7975a736a80401cc0e6deaf5230fc0089531be7a587702b9f", size = 43413, upload-time = "2025-07-31T19:41:46.107Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-emr"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/57/153e4cefcc072fe459d236abf854bc486ec1e4611612184cd02cea376f9c/mypy_boto3_emr-1.38.0.tar.gz", hash = "sha256:106fea9697e919a44926160f50008733e4e51d2c18f9b629806e55c410184e1d", size = 43072, upload-time = "2025-04-22T21:23:23.326Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/32/81171be52dbdf663b8a0b0e44b142093e8c1edca5f1c7888b3ef9a3a47bc/mypy_boto3_emr-1.40.0.tar.gz", hash = "sha256:72b35a6ba6ea48fedf0ac155e429c01dacc3a57ac59246f8eab89ad8b5930ef6", size = 44419, upload-time = "2025-07-31T19:41:53.19Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/f0/439f22c8baafd7da4f74ac07f9756dbd447d4214efabdcc8f1268381ec4b/mypy_boto3_emr-1.38.0-py3-none-any.whl", hash = "sha256:79d92c62fa819baad1ae975ef7e998f9c33b2189006551079449f30ac6007124", size = 49863, upload-time = "2025-04-22T21:23:21.141Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/db/11dbf55f7f5a536cc65f29668cc66d839c01b09b0e79c404f8ae9194122b/mypy_boto3_emr-1.40.0-py3-none-any.whl", hash = "sha256:3ba0cb9a2f13900037febff2639c14b6685e2bab9373c636def3b7986390510a", size = 51362, upload-time = "2025-07-31T19:41:50.505Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-emr-containers"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/21/dd9ae9b35d08b26465c1a71f16bae18ccdae61a55af1ebcae6aa2e9d543d/mypy_boto3_emr_containers-1.38.0.tar.gz", hash = "sha256:2ebd9ca520645a5df48884b77dce2a88e5814db22ee4bd0c316e4ef40bbe08e3", size = 22141, upload-time = "2025-04-22T21:23:19.988Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/39/49cea7313c0f69a54d29f430acb783418be9d5421d5bd3acac2e057afec0/mypy_boto3_emr_containers-1.40.0.tar.gz", hash = "sha256:ebd15e99302c88031811c21373ee71ae0facc2bc6020b763dc2c2680820c8b47", size = 22165, upload-time = "2025-07-31T19:41:51.713Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/94/dc845a0b4d751fd44fdbfbe40253b5fc39fa83089e75a0cb6f8e1e0ad618/mypy_boto3_emr_containers-1.38.0-py3-none-any.whl", hash = "sha256:a3276822173aea974b3587fa0c8b70cca266c16732d86dd91a8d54d3bd281718", size = 30768, upload-time = "2025-04-22T21:23:18.274Z" },
+    { url = "https://files.pythonhosted.org/packages/90/0e/f2558d2be366f41172b2887aa5b9800261a43b848178407f5e1a432c2dd9/mypy_boto3_emr_containers-1.40.0-py3-none-any.whl", hash = "sha256:8dc0b44c7a89f353cb9d92708cfd24b17b4e3f5a18ee7092814db8a3f4c4d1b6", size = 30821, upload-time = "2025-07-31T19:41:49.347Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-emr-serverless"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/b7/43/5645acca2df66a2e0a27f1588096b22da346c5b66ceff47cbaec6aa0d3a0/mypy_boto3_emr_serverless-1.38.0.tar.gz", hash = "sha256:5b12e4da46baaa7a329d16ce41c5c012ff38f3de9e14e638018029c3773e6650", size = 20229, upload-time = "2025-04-22T21:23:26.229Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/3f/cd41d46059eb5666df1bfb64ca3bd0fdaba47ee0b63f15aacb4a97c750e5/mypy_boto3_emr_serverless-1.40.0.tar.gz", hash = "sha256:f48cfd15aa5440259af5b8e61f402bf4ed66b53bfea2f5a5c6291d75be7e5a57", size = 20429, upload-time = "2025-07-31T19:41:57.056Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/cc/7e02bc269e5275f3fff40c52f792cf6e29327fae84d19abc468a62ab6a02/mypy_boto3_emr_serverless-1.38.0-py3-none-any.whl", hash = "sha256:e26a6ce791a21113dca4c75a01a9c2febe9a5ea70d86b93928cb33f20d41b191", size = 27444, upload-time = "2025-04-22T21:23:24.691Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d1/1035333d18cd1a24ed3c2ceffb6ef7bd23b91699813911090b8c90bfdb97/mypy_boto3_emr_serverless-1.40.0-py3-none-any.whl", hash = "sha256:92356460a684e3519e83881818eae5d4f2c9a51107cb0332307b80a025f3996d", size = 27820, upload-time = "2025-07-31T19:41:54.357Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-entityresolution"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/61/a69beb4eb003fb4f961e24a8d0eadc396cf51fc8d02427460cec0b9186ad/mypy_boto3_entityresolution-1.38.0.tar.gz", hash = "sha256:53baba076061ff92775810740a65096cd0456be776f05613b0689a6cc0392a37", size = 26717, upload-time = "2025-04-22T21:23:29.318Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/d7/18c500677af73e3e65e34cc4491263a4d03faa2b3abb31ee0451b3334340/mypy_boto3_entityresolution-1.40.0.tar.gz", hash = "sha256:fd7ce8d0a536375e12dfd8246f5327255dbb6a720df7600d7026ca9756fd615c", size = 27357, upload-time = "2025-07-31T19:41:57.656Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/22/ca231c929f70ed7d1a400c3b34ff7bd07f1a7b49f991d2ee4e62afcc8e0a/mypy_boto3_entityresolution-1.38.0-py3-none-any.whl", hash = "sha256:1774cce7cd1ed534a807c283ee426265fd8ee3e89903331e14208605b565718e", size = 33685, upload-time = "2025-04-22T21:23:27.361Z" },
+    { url = "https://files.pythonhosted.org/packages/76/09/dc5be804c5d83077446ce9a8a311f127167bb70b5d036660397ffdf6159a/mypy_boto3_entityresolution-1.40.0-py3-none-any.whl", hash = "sha256:0ddfa32ca662d09bb6d53034b8052884a64cf3b19341d2493af53ecbc5086257", size = 34366, upload-time = "2025-07-31T19:41:54.873Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-es"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/dd/d63b1fa2ed4e6f7a9b9bbb04f93d14142ac4c44c0208d004f941d673b1a5/mypy_boto3_es-1.38.0.tar.gz", hash = "sha256:bba12959516bacbec109e6817510af637de6e3a7e3f2a417f2e3584597ec50e2", size = 35904, upload-time = "2025-04-22T21:23:32.246Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/88/7cba2fd7bcd6348a3ea097f973cef49da292ce54804f2c87fc87b5782099/mypy_boto3_es-1.40.15.tar.gz", hash = "sha256:9c845278bf9c5f8155a33928805e39e48d241a134950e31ab903cec42b63bb9d", size = 35981, upload-time = "2025-08-21T19:43:17.366Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/e6/b1b2ac65c547d2969e13ff000a0efd356d9dabcb6cae6bca77c7f26d23bd/mypy_boto3_es-1.38.0-py3-none-any.whl", hash = "sha256:e8ae36c8ec4d67bc84f9bda7e45925e8837ef40c6ca60c46a7b663c8bf8bb877", size = 40861, upload-time = "2025-04-22T21:23:30.277Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d3/d78ab3c33cdd6fd9474e7531d18ff4c01b1a2f6cc3d815207564b1a2319d/mypy_boto3_es-1.40.15-py3-none-any.whl", hash = "sha256:6b31efb47166a17a85fdddb74ea4636afdad0cd3b915c5889fb6c654e0d03231", size = 41006, upload-time = "2025-08-21T19:43:11.057Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-events"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/0b/5b2a6adb1ea36550a0d4d899b4e3d735dabbc24acf05f14e302bb407bfe9/mypy_boto3_events-1.38.0.tar.gz", hash = "sha256:3017e0cb81b99556171b36ecd1a40af2ac776f5ead9a2032abf65382ec2d6dd2", size = 33762, upload-time = "2025-04-22T21:23:35.166Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/58/d6be71675966457fee97c8683e9c4d0ecc5b4ef228ea1a80d91e9361f679/mypy_boto3_events-1.40.0.tar.gz", hash = "sha256:3627db3a067c434a149ca72122dd3846030c0c15cc8b024908a0e66b1de3e04b", size = 34006, upload-time = "2025-07-31T19:42:02.483Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/4a/72a37802c2232d727e858d74da238bff31a0ed8ac55e09a747c65844b18d/mypy_boto3_events-1.38.0-py3-none-any.whl", hash = "sha256:99c4eae4cc882195cc9e295bde971543606c998bc71b6e11ae9e2bd35d5e5529", size = 37350, upload-time = "2025-04-22T21:23:33.353Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/3c/50b48207dafde510fc8febcf2ced1ce28b5f77c24c6a2fc5fb659d60331b/mypy_boto3_events-1.40.0-py3-none-any.whl", hash = "sha256:3d99a5bf9a357347a3e0a28b5f5f0a288a691fca765a3330ae0db5907a0a7a6f", size = 37666, upload-time = "2025-07-31T19:42:00.202Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-evidently"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/d2/d64bc697d82cacecc2e413c2e8ade5a1bed9a046142e11b14c58c8d13757/mypy_boto3_evidently-1.38.0.tar.gz", hash = "sha256:4cb64c119876dec50ae0f99df8027b9b4690165c37bff5d02b6c566f5c4717f6", size = 23390, upload-time = "2025-04-22T21:23:40.164Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/e9/17b60eff43c1a8cc63bb7c366fd888bdcdb0e146de2935c498f7b02ded94/mypy_boto3_evidently-1.40.0.tar.gz", hash = "sha256:a6a5eda8aced988e2039fcafc208cd83431284bfd13f055085d7071c6970ed09", size = 23388, upload-time = "2025-07-31T19:42:07.132Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/ed/2654581b188a1897dc36560fa662ab7b19ed12b36e2cb7a43fcdd09eb9c4/mypy_boto3_evidently-1.38.0-py3-none-any.whl", hash = "sha256:71e2b156f26897f4cf0ddd7df2faab6b72b5f4ddba9535374b0e8d7f41e3ce87", size = 32562, upload-time = "2025-04-22T21:23:38.629Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/4b/c47089dd345f46804fdc98fbc370589373987bdb69e8a4cf85efa698d9cd/mypy_boto3_evidently-1.40.0-py3-none-any.whl", hash = "sha256:18ff3b5e11ab18ef8141f5728b07b848d27bbd622ad59a44bc71a61f5be86ab4", size = 32619, upload-time = "2025-07-31T19:42:04.79Z" },
+]
+
+[[package]]
+name = "mypy-boto3-evs"
+version = "1.40.7"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/f3/572eb57b498a314addba14213b113047463a4efd6de2e4338361e4cfc05f/mypy_boto3_evs-1.40.7.tar.gz", hash = "sha256:d16c248cdd34474e741dc44be796e6f17267f76ad42fec6ed374e7233a585bd0", size = 18579, upload-time = "2025-08-11T19:30:52.231Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/34/dd12ac2999814877beffd2ef307bba6e6da5e2f83bd8957f82ae49ed3acd/mypy_boto3_evs-1.40.7-py3-none-any.whl", hash = "sha256:257f5055cc6946049e6de189355b8168b1b1e55879491ef8991bb7ce5df97d53", size = 24422, upload-time = "2025-08-11T19:30:49.976Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-finspace"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/4a/81e49c81f8b673bdfd911cb350c5f16ba69b24756dbf41271fd2672dbd9d/mypy_boto3_finspace-1.38.0.tar.gz", hash = "sha256:b9b2b60d797809be9d0035786c0ca3258c30d0ea9a00ec2d224b741d8e3aad99", size = 30618, upload-time = "2025-04-22T21:23:46.327Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/66/637eabac516ab45a87cc212fbed303726d445fce98f955fe22e875f71a5f/mypy_boto3_finspace-1.40.0.tar.gz", hash = "sha256:ac875353703a8cdd1ca67ea4404d273d2aa360fa97505db2ca332ebe99de8e91", size = 30622, upload-time = "2025-07-31T19:42:13.639Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/dd/9eb5781592022ae5d9733d3ef934130ef98004aa36e817c7af646b67ffef/mypy_boto3_finspace-1.38.0-py3-none-any.whl", hash = "sha256:4883311bedf479acfb18ee65b703a73bfca246ecf3e8370d8f46ac27308c7842", size = 34308, upload-time = "2025-04-22T21:23:44.643Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/05/62802743239d0a02ef66256f9980d379267f4d1d6e5d6748733c7797e314/mypy_boto3_finspace-1.40.0-py3-none-any.whl", hash = "sha256:c32ff8cae0ab795e57f03eeac4b818fd76fa9cb492a5b1185d68a176af6fa203", size = 34363, upload-time = "2025-07-31T19:42:11.007Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-finspace-data"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/b8/cb/e6345fe3bdbcaba505f657c02838f9fc3e46a813cfbdc381750fd0a1aba1/mypy_boto3_finspace_data-1.38.0.tar.gz", hash = "sha256:d0b9fca53d2b85a478c577b880b3ca416bb3baad9627523286fa547f760a7a13", size = 22110, upload-time = "2025-04-22T21:23:43.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/7a/05b2374e1037a7b0866a0d07690f2c7b02a4cc429cdcd54ba4278cf5f811/mypy_boto3_finspace_data-1.40.0.tar.gz", hash = "sha256:8d7d5f61446c2a9b6b9fbaedca87a4aaf4bcd4fe361a25b927b912f5a2b0d5cd", size = 22117, upload-time = "2025-07-31T19:42:11.648Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/6d/0ea9d6dd554dac572e91647fcb9ffb33ce89fdafe6d95e302489d75476a3/mypy_boto3_finspace_data-1.38.0-py3-none-any.whl", hash = "sha256:9039d21c2b5c5f5bd199b1484cf5eaa74dbdd19fd05cef7246c66fecaead3886", size = 30685, upload-time = "2025-04-22T21:23:41.783Z" },
+    { url = "https://files.pythonhosted.org/packages/70/fa/13d7ed06150fcde7cbc864b1efa3c90f5597961f5adfb1425352c6b02f03/mypy_boto3_finspace_data-1.40.0-py3-none-any.whl", hash = "sha256:262ad8660ab855407cfdb8da9965aaf2aef1051600853b5205930703a32218c1", size = 30741, upload-time = "2025-07-31T19:42:09.742Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-firehose"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/f2/b3202b632d7b5b818f05722fc134b8d9885dc7b4876ec3b6d8f9fee97ba8/mypy_boto3_firehose-1.38.0.tar.gz", hash = "sha256:9a63a900dbc14d44e29565d9f21e6d313c1f7c46b077a1f0541269a4b7b567be", size = 27707, upload-time = "2025-04-22T21:23:49.214Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/2a/5e20752b062a5a59224d140365b8207cc92197108fafb096e7de1048dc81/mypy_boto3_firehose-1.40.0.tar.gz", hash = "sha256:673a7b5683da5481d7dca71cc651482deb063493fb7f5a7adee5cbc0ddeb2dcb", size = 27728, upload-time = "2025-07-31T19:42:17.48Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/cd/58a040c7717e14a2db16fd756a3e82bc1e54654f92f7a61117a87b5c72bf/mypy_boto3_firehose-1.38.0-py3-none-any.whl", hash = "sha256:6f742420dae65184163d416091757efef91012b33fe20ba4805e406803dd4b29", size = 31785, upload-time = "2025-04-22T21:23:47.513Z" },
+    { url = "https://files.pythonhosted.org/packages/46/a4/0616411fc9ae50402c1547393ac2eae11415d80f23eb79efc347dc900342/mypy_boto3_firehose-1.40.0-py3-none-any.whl", hash = "sha256:0a16dc2e4b66dbc8c918332914eae1f8695ac6412838bb55d04f6558f419205e", size = 31846, upload-time = "2025-07-31T19:42:15.059Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-fis"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/57/5e3b237a4858e36a1aa47d6f14d891c6522a233a570bfcff40a4e1e56b63/mypy_boto3_fis-1.38.0.tar.gz", hash = "sha256:7dd8386572ea988f0736b830e9baec3b3bd383f622730c91b9071e3e0bb370f0", size = 24209, upload-time = "2025-04-22T21:23:52.411Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/aa/31d7a1e2e421bcecd449823c7f2cbd5b290530eecaad54620ff5a42c790f/mypy_boto3_fis-1.40.0.tar.gz", hash = "sha256:d263424a72b3fce4c2338bd2c1d4b190c54f121b22614398f9bfbac0bfec2323", size = 24233, upload-time = "2025-07-31T19:42:18.407Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/60/9c259c81eb6d2c81ed7edba64fae404a5340a5176e4d3a8d44a8b65e0f1a/mypy_boto3_fis-1.38.0-py3-none-any.whl", hash = "sha256:b2903534de5990f0866367c9fcc34e07378a86b346a395952be4bb784505b7e8", size = 29487, upload-time = "2025-04-22T21:23:50.945Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ad/da889d0d75198bb614ae9927c82196d9026de09a2cb6b1a4c5eb779edc76/mypy_boto3_fis-1.40.0-py3-none-any.whl", hash = "sha256:4decda0522b4015d5dc7625d8d36743a0c2952cd616c0cddbb1b72554c46d0cc", size = 29535, upload-time = "2025-07-31T19:42:15.999Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-fms"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/ad/bd/8d875596c0e47c54a4191c21392520f727e8267f32bc05864fcc7b589130/mypy_boto3_fms-1.38.0.tar.gz", hash = "sha256:8b3f9b61b7142d179b8afe510893486865e3cb1cfd992cb2a34c9bb222d0241c", size = 35432, upload-time = "2025-04-22T21:23:56.526Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/94/1fb97e8d24dc87c2ef9e684fc02439c38b8bb58d1a61dad0988c15e0ce7f/mypy_boto3_fms-1.40.0.tar.gz", hash = "sha256:b13b9343700382202963475abf33811f3fa3cf6d6da760b82fb2aaea3f1d52f6", size = 35471, upload-time = "2025-07-31T19:42:23.224Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/6c/bf1fd221ed236ed7647478833bc45f61cfd428ee50cc52ae1f552f152e5f/mypy_boto3_fms-1.38.0-py3-none-any.whl", hash = "sha256:f78a8cffdf5b74b80afad74e1006fc25b44f41c56a1bc5c8b354ae07d42330f5", size = 40955, upload-time = "2025-04-22T21:23:54.483Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/5dff5416b29a405652f3c2a8915bacc161ee3106cbf73cdba0469a2d763c/mypy_boto3_fms-1.40.0-py3-none-any.whl", hash = "sha256:d23e397ee04ac768d27871e43593554e03653bedc4a496c714b66c2c6fa917a9", size = 41010, upload-time = "2025-07-31T19:42:20.498Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-forecast"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/7e/08780af6357270b7773efaa0158ac2af26ce60eb136e248626f27f8c7893/mypy_boto3_forecast-1.38.0.tar.gz", hash = "sha256:f489f69c43e7a31bf91c617dff636beedd49cbb342276e1dc0a4524c2ec0ca07", size = 36473, upload-time = "2025-04-22T21:23:59.162Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/e4/8cebe9142e496a93a79bd4704fb7ca9f7de3872247644fe7b5e34b274803/mypy_boto3_forecast-1.40.0.tar.gz", hash = "sha256:9a8db1a765e70298a52bacc1f8a64bb7f29c27a9933ec92389d7d9d23bba5ecb", size = 36482, upload-time = "2025-07-31T19:42:24.518Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/c2/6c2cc5e2a067eb05d506990eb6bce4d26c0b8caa6147180e655fa29d6691/mypy_boto3_forecast-1.38.0-py3-none-any.whl", hash = "sha256:33caad3b4c5b85768c43a478e698c945e9d7216b7b88745eb22825fc0e47eb25", size = 40905, upload-time = "2025-04-22T21:23:57.482Z" },
+    { url = "https://files.pythonhosted.org/packages/21/37/39f5dbc6c4c7dded9f889adfe1dfd6316686c81a87ec91acd2ed1b0eba98/mypy_boto3_forecast-1.40.0-py3-none-any.whl", hash = "sha256:19b0eb41449feced6416a5506c59dfa724722a7f19a7d66d1fa92c3a3e48c441", size = 40968, upload-time = "2025-07-31T19:42:21.295Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-forecastquery"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/db/c9/cd989852f96835571f744262552e0f7a977248fa7d3678a2a9ae7bb14d91/mypy_boto3_forecastquery-1.38.0.tar.gz", hash = "sha256:2f44d15a59432f190df04a78467e87122f1b23bb0062db3cb940f4f7c239b7bd", size = 15256, upload-time = "2025-04-22T21:24:02.374Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/c8/22be6d70e3edd4dbcf073316d8ae404ecf6fb15f68c566676832aa3c0a40/mypy_boto3_forecastquery-1.40.15.tar.gz", hash = "sha256:40f433ea8bbb79d536f2d50fba816ae2fdc79f3fee0129b8e9ced33123b2f966", size = 15329, upload-time = "2025-08-21T19:43:19.437Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/5d/8bd9826222c1abd642706e2f58cfeba2e10373cb90bdbda65649ee351c9f/mypy_boto3_forecastquery-1.38.0-py3-none-any.whl", hash = "sha256:3ef873311c4455e04d076222040d6cb301286641161348259dae76b22fe0b5bc", size = 18027, upload-time = "2025-04-22T21:24:00.226Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3d/fd2d170cb8dfc9bf235492ca07d579a0cefb3cb0b9b37cdc1090ed00741b/mypy_boto3_forecastquery-1.40.15-py3-none-any.whl", hash = "sha256:a53840e534e5346660a89d7e8b5b3ac362672d0ededfa1fff09002dd93acda0b", size = 18151, upload-time = "2025-08-21T19:43:15.912Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-frauddetector"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/cf/a315469925010993e33cf1f9a791baf08049c8ef0460f10b347197b82ebc/mypy_boto3_frauddetector-1.38.0.tar.gz", hash = "sha256:b753e3f064abf570f29bfb35a805da88648658412db438630673eb07f2fa2f0a", size = 31961, upload-time = "2025-04-22T21:24:06.992Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/63/baf21a87c7bbc5ada07e4d9d286b6eb2621856ea1b0a2529741061439653/mypy_boto3_frauddetector-1.40.0.tar.gz", hash = "sha256:8bbea1a332cb70de18e49a60ffddbee854a04ada70d927c5d077918508913ea1", size = 31994, upload-time = "2025-07-31T19:42:31.047Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/88/8f4e89bfbeed465129c71dd9efad76c7b672e7fbcc7d415e4b13024dfb2d/mypy_boto3_frauddetector-1.38.0-py3-none-any.whl", hash = "sha256:ed40b83df77321278301218ccbe68e273c6cb8198abb516ff3ed9d9b1d3bf171", size = 34097, upload-time = "2025-04-22T21:24:04.706Z" },
+    { url = "https://files.pythonhosted.org/packages/51/f8/ba17dfb73a04e03227551d36fb583ffe2f8251ffa7ac5be25f3d95c094b4/mypy_boto3_frauddetector-1.40.0-py3-none-any.whl", hash = "sha256:0c4212ca87ee74188966d6ca75715b0f622961dc4939e0709292520fc0fd8ec9", size = 34150, upload-time = "2025-07-31T19:42:26.949Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-freetier"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/55/ae/e1a2ec2f45622e11ec3893ecd1022063b521e0cad687eec2caed0bd716ca/mypy_boto3_freetier-1.38.0.tar.gz", hash = "sha256:1732f47fbe2ea28a9b6068d54c4dbc7fc36a3403010ee589048fb9b078073366", size = 16102, upload-time = "2025-04-22T21:24:10.429Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/2c/2e54c3ccd55bcdc5ea12583afd93f037c8e0692b00d35976fb56d06587f5/mypy_boto3_freetier-1.40.0.tar.gz", hash = "sha256:cdedbdb1533b0af5be8afba03198c639aa612ec45b913be9dd397efd0e5ca95e", size = 17423, upload-time = "2025-07-31T19:42:33.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/70/c716a20a3f366893e5277c2075b7c79635d60ffa56d0a7e0bfdd28cc93b0/mypy_boto3_freetier-1.38.0-py3-none-any.whl", hash = "sha256:903f488c6ccb691b72e868da15c2740329968edec3dd0df211d4d45706d2cc40", size = 20490, upload-time = "2025-04-22T21:24:08.715Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/95/613768e128114e3ed0743ef6d41424424e2b306c95d33ad43281578be576/mypy_boto3_freetier-1.40.0-py3-none-any.whl", hash = "sha256:51848ef3595432ff63eecd18e0b7c24d0816adf4295b20dc71c2a220cf4c4375", size = 22958, upload-time = "2025-07-31T19:42:29.796Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-fsx"
-version = "1.38.0"
+version = "1.40.10"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/2f/45/2d3c9f8d9c330be45b8d926b9871e9d22963a4dccb9825d01ff77f4b5585/mypy_boto3_fsx-1.38.0.tar.gz", hash = "sha256:943182e4bb9a9dc969cde0e0ad0f5b0299b7045cc6dec00d9c5bdc855338f144", size = 39502, upload-time = "2025-04-22T21:24:14.768Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/00/2938cd3f3f281701b8c57aaebe48f2f4a98af40f986c657c1e6050d7b857/mypy_boto3_fsx-1.40.10.tar.gz", hash = "sha256:13db37321eba6d752ccbf0543e8ad868ea79f21918d07a64c97ddd5f43ac5f3e", size = 42144, upload-time = "2025-08-14T19:27:32.953Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/24/c6ced6fa6fa832ac5f3106e6a06322994735882573a2db8d7e51e008aa8a/mypy_boto3_fsx-1.38.0-py3-none-any.whl", hash = "sha256:c35917e0abb1d324563b6ad8b560d27384414c45a508b81dd83652a21ca6c0e2", size = 44828, upload-time = "2025-04-22T21:24:12.489Z" },
+    { url = "https://files.pythonhosted.org/packages/86/33/0818952f5f4f7b6dffcb7837f5ba1aff7d21af99e1dab8831be1f48c4924/mypy_boto3_fsx-1.40.10-py3-none-any.whl", hash = "sha256:075bd522b3c0e94a3d9b0b0aaba5742f683c9af0ff79eb84254fb0c309b32028", size = 47897, upload-time = "2025-08-14T19:27:27.795Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-gamelift"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/fd/aba6a464ae47b0f809dd13beba84f7d1ecbd997f660a5cd36f0668efebae/mypy_boto3_gamelift-1.38.0.tar.gz", hash = "sha256:e5beb9879b97847ad18cbf2eb849ed01e3d6cafe63d96323c6346232436d81fa", size = 66653, upload-time = "2025-04-22T21:24:21.969Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/59/618e1ad40026d7023c1cccc61af5cbda8deb6d867c15a902e88a93f9bb11/mypy_boto3_gamelift-1.40.0.tar.gz", hash = "sha256:2a030c5b2b36d5d1e10cff64423c4f790b490567e239e482b70b84f45200ce4f", size = 66889, upload-time = "2025-07-31T19:42:38.115Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/b0/19dc4512e379d1f0c06894d30728b245a257018972986bbf4b8d529cb6a2/mypy_boto3_gamelift-1.38.0-py3-none-any.whl", hash = "sha256:638e31f15a0c1958acd2258bc4280b52f3c254056022b2a59a76efb44f320fa6", size = 67024, upload-time = "2025-04-22T21:24:18.323Z" },
+    { url = "https://files.pythonhosted.org/packages/21/4b/730d04188f492b0d688dd7ed31a73c6ef35461ba9340f6948d7722a132af/mypy_boto3_gamelift-1.40.0-py3-none-any.whl", hash = "sha256:b753d7fd7b8739491f0c08f58cb4fc4f3c1e881e8fa4bc7c1e061fb8af8ebfa2", size = 67295, upload-time = "2025-07-31T19:42:35.569Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-gameliftstreams"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/8f/d0/9d0066e7f0ebbe734f885e8db711241a35fa542239c59084fa03617a2754/mypy_boto3_gameliftstreams-1.38.0.tar.gz", hash = "sha256:32c01e1c2a331cdd922ede6db3376575d70475801eed20ce96ed63c4f31cbe46", size = 22445, upload-time = "2025-04-22T21:24:26.071Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/1f/32aa2377b3bfd95c8eb33f7cf8e212f6ea92693a95e1db899f0566d9885b/mypy_boto3_gameliftstreams-1.40.15.tar.gz", hash = "sha256:a74059b7b32ee15316ede760be7859c3e20c38e8f5d5457dfac300904e5a45be", size = 22556, upload-time = "2025-08-21T19:43:20.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/76/106ba5d8b12be5fc371ab1c6d3b3e60766b11aa9e62a067f0b38297fe4ce/mypy_boto3_gameliftstreams-1.38.0-py3-none-any.whl", hash = "sha256:25930d692bddfa5598b7a468b07fc4512e376c48d1f7e1f2cea9580b9630189e", size = 32119, upload-time = "2025-04-22T21:24:24.059Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b3/6d417497177df518389d2e4267c6b9a08798f117c4c51e281ec5520c3578/mypy_boto3_gameliftstreams-1.40.15-py3-none-any.whl", hash = "sha256:252a525166eeca4919410ba343c5a8735125238004d6ee51df18af0b17c5e90d", size = 32218, upload-time = "2025-08-21T19:43:17.859Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-geo-maps"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/af/1048bc61f17ae45be65b2db02dcaaa815db3a741ea191f2f92055576ec20/mypy_boto3_geo_maps-1.38.0.tar.gz", hash = "sha256:640612f0ec8c9ad6c198ee3c7e10dae4ec9420edda1fbb56ec364d1e8ade30fa", size = 15825, upload-time = "2025-04-22T21:24:30.004Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/a2/d3a8028dcc83e48dd733e2c79345128ee3df10f832496e62f2ebb28e3f03/mypy_boto3_geo_maps-1.40.0.tar.gz", hash = "sha256:ecf7780e5d951a95a73756960c6547b93cf93c4470a6fa107d84d24b30775ae3", size = 15832, upload-time = "2025-07-31T19:42:42.303Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/0e/2724688d92ae6518046c011b09f684c327bec3fb3c6295a6ba375434bd99/mypy_boto3_geo_maps-1.38.0-py3-none-any.whl", hash = "sha256:6f59a575d8545d1ccd51ce1fdf9948a150aa10277d06bf21e311bac95e28a000", size = 19096, upload-time = "2025-04-22T21:24:27.876Z" },
+    { url = "https://files.pythonhosted.org/packages/29/94/43e73b80a2e7acb5c0189dc69a3c61c144b89d801d1239a8a06269883a5e/mypy_boto3_geo_maps-1.40.0-py3-none-any.whl", hash = "sha256:09676b13f5bf99f7b5f5f92eba9a22163c5076e9bd21cd6af401716a76222f0d", size = 19145, upload-time = "2025-07-31T19:42:40.093Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-geo-places"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/13/e81410e51acaea55c09521cb071d929c27ba3b9bc9280ecb8a6434a55eee/mypy_boto3_geo_places-1.38.0.tar.gz", hash = "sha256:5b9ed7d699d064f93c48b8c90931be0ac12f4c3d831c7c632d9a9dbe607376ac", size = 18818, upload-time = "2025-04-22T21:24:33.839Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/80/47df8544dac1ec18df6d280f868d2d75f5142bdda4cd3c5183178ab7b6ea/mypy_boto3_geo_places-1.40.0.tar.gz", hash = "sha256:b67b2111d9f136b5c0cf5a278404fc0b92f1807837021234072a81d3ee9b5c41", size = 19295, upload-time = "2025-07-31T19:42:45.239Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/f1/54d3eca1243bc90660c062c8f32a0d5adcff9a0bfd5dde3286b41380d1b5/mypy_boto3_geo_places-1.38.0-py3-none-any.whl", hash = "sha256:bdb15220ad997dcaef2ba6b3720d10d7d60a2709a61d1f38cc7ac27d43efcd7c", size = 24383, upload-time = "2025-04-22T21:24:31.828Z" },
+    { url = "https://files.pythonhosted.org/packages/14/82/d8b8a7f4cb8a5fc7a1508f44b3046a1548982d805d0626d39de1851bf22d/mypy_boto3_geo_places-1.40.0-py3-none-any.whl", hash = "sha256:7a78105746b80254b23dcc7b849aaa4166ac33cb748b9a52f9f78d6227158894", size = 25225, upload-time = "2025-07-31T19:42:43.129Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-geo-routes"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/bb/ba3c9661d67f9c8585659ae6c96eb5053501d15fb549cec3d63e9c157fe0/mypy_boto3_geo_routes-1.38.0.tar.gz", hash = "sha256:978b540024ab405ffc220e643c229ca60c7c5e43edbd382845cecaff5ba85714", size = 30697, upload-time = "2025-04-22T21:24:38.022Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/98/e990964b6f692aadee698f7ef9f2a7c2d3eee9a325175ee899d132b320d3/mypy_boto3_geo_routes-1.40.0.tar.gz", hash = "sha256:1d8813ff547cadc8b024ab9a06be4ebf46253e4474bfc4dc5f139a5fd811322c", size = 30738, upload-time = "2025-07-31T19:42:46.22Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/2c/a8b314ec0c909dc2b7f5f283513785a2cdefe4425cce34d294c1fb6b08b6/mypy_boto3_geo_routes-1.38.0-py3-none-any.whl", hash = "sha256:632756b2d356d130f7229a1a00a65b2937dd6afb92b6da197000ed7d854e6d2a", size = 36019, upload-time = "2025-04-22T21:24:36.033Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/92/03f33fc9c9530f5bc009302b847bfa175e7ef43b4aab498f59d9ea1762d2/mypy_boto3_geo_routes-1.40.0-py3-none-any.whl", hash = "sha256:bee5a7b2da0132dacc82b6975f060be96cae298e5cf05e1e4142d2caac6412a2", size = 36074, upload-time = "2025-07-31T19:42:44.581Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-glacier"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/25/112dde7ffea64491aeabf98799bc1d709294f6ea430b6b9ca1ca0c482239/mypy_boto3_glacier-1.38.0.tar.gz", hash = "sha256:7c50a8ec51faeb3ed81b87fc3bb5a1974d7f906499559d0c4b8153204983a5a3", size = 32112, upload-time = "2025-04-22T21:24:42.226Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/65/81e5027e6a5dac74ff4defbaccdd59e79e0d9455bdad8242fd8f6f3947bd/mypy_boto3_glacier-1.40.0.tar.gz", hash = "sha256:3414ab961c9cb09a8281b8a2b5f36648019c4cf8197e47f1e431a6f1986b4727", size = 32117, upload-time = "2025-07-31T19:42:50.524Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/28/c04d2dbecb052c99a6f4a4df0e90c96f04e6a5744b9103c6618c17d61ff0/mypy_boto3_glacier-1.38.0-py3-none-any.whl", hash = "sha256:6b4bc6100bb30af1798c41a0c973cdb885ba1793a8530f48d5820da39749d4be", size = 43022, upload-time = "2025-04-22T21:24:39.898Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/6d/fac0c5a8242aad1a7d77066d72b9ebef4f4f78bc21a074414cb7e84ceeb6/mypy_boto3_glacier-1.40.0-py3-none-any.whl", hash = "sha256:a19bbcc571f08936e27b82ad6ecfc5383d1dea243b3d1611802f655cc5482e04", size = 43076, upload-time = "2025-07-31T19:42:48.591Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-globalaccelerator"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/3b/3ee944f917c4f2d0da78d6bfb0d71052195f73eb30101ee763b4605c05b8/mypy_boto3_globalaccelerator-1.38.0.tar.gz", hash = "sha256:69b00b3da3a8c4cf1dbf0a9df23e359934f5666727fec115ce5a2948c73e7d83", size = 30575, upload-time = "2025-04-22T21:24:46.29Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f3/46c7daaaa7042e45bbe3d891836a77d1109faa617083fa2a8f0679d7e338/mypy_boto3_globalaccelerator-1.40.0.tar.gz", hash = "sha256:4a8fcd0cbd0a1798b2a4b622b6727fdfc0b9468bea0465dc5211ed9443278cc3", size = 30609, upload-time = "2025-07-31T19:42:51.42Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/e0/e92ea1b26b8f42944199f1f798b02414d41b3920cde144f10a9e457e82ff/mypy_boto3_globalaccelerator-1.38.0-py3-none-any.whl", hash = "sha256:ae6ff41b97088cb516916c615fd6d20f2d9138328f776e913bec51fb048ed063", size = 35411, upload-time = "2025-04-22T21:24:44.073Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/8a/521b2ac9843350aeff3f7265eb4af86983aa282564583d161e769892b5b3/mypy_boto3_globalaccelerator-1.40.0-py3-none-any.whl", hash = "sha256:6702f3b0c279067d4f757ba1d528f22a65d1d93746ac98273a5796d3994d2931", size = 35459, upload-time = "2025-07-31T19:42:49.04Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-glue"
-version = "1.38.12"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/58/203aa62c114d050b1238f237cda71609bc0bacf30118908cb8a8ea4cb5dd/mypy_boto3_glue-1.38.12.tar.gz", hash = "sha256:d0c709de2f23b6a9277ec03bb0df4fefe20e32a6c748531049c17d8349bc5a09", size = 121640, upload-time = "2025-05-08T19:42:37.436Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/21/fb317398bbe77014434edfa6a7e3bb5fa56cc9981acd25d0849f1e50ee17/mypy_boto3_glue-1.40.15.tar.gz", hash = "sha256:37b7cf934902031a2231db3b943a6a51c977dbea68eccc16238947c920031f20", size = 127329, upload-time = "2025-08-21T19:43:22.813Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/b3/4bd3ff0ff92dbd6d41efe00ecbba5cdc81720f5ceec2fdf1e233ca696c85/mypy_boto3_glue-1.38.12-py3-none-any.whl", hash = "sha256:2fd93c0c941f5a603e6fba7c60d277053bf68a72df8e6e6532addef61267f892", size = 129132, upload-time = "2025-05-08T19:42:34.379Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/20/47d52ef05642e5a1bd149dc1d5fbc3060e5854514bc2682fbd5bb3c54570/mypy_boto3_glue-1.40.15-py3-none-any.whl", hash = "sha256:c6dd6a8eefb651aaa26db9080695f30cf2eb0d46e94374136715a562a8c56714", size = 135106, upload-time = "2025-08-21T19:43:19.867Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-grafana"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/74/36/428492b5f6d2b9a484e954580d2df84dd4eaf5483c9ea9674650a2cae1ca/mypy_boto3_grafana-1.38.0.tar.gz", hash = "sha256:487f11aba13a0b45bc02f52a2424190a97859f0e0731ea5ebf98e3578b839647", size = 21551, upload-time = "2025-04-22T21:24:54.369Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/b0/06729beb26cec64d5026a99bf6cb08b6555b3a3f01ecc19d2d54a19fa8c7/mypy_boto3_grafana-1.40.0.tar.gz", hash = "sha256:290ab293d3c552db730eb656eef89ebfcc5bba676e774e4405d368c73fff8446", size = 21577, upload-time = "2025-07-31T19:42:55.48Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/80/82cc03b6db77f255217ab577f67d27013e3789e394b9ab5ee8643f6d88be/mypy_boto3_grafana-1.38.0-py3-none-any.whl", hash = "sha256:44b4368a4449f0432c0ba0f6e893cb30d39bc54916a9a56ec09eb0bc2799ad81", size = 29464, upload-time = "2025-04-22T21:24:52.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c7/73cd650a60266fcfbcb7e7d8d5d86cd3397eb072bfb0122bb852a9fb4c6e/mypy_boto3_grafana-1.40.0-py3-none-any.whl", hash = "sha256:de95f3639e419f64d52706f6af7df4552d5f77e317f2fa52b08ce997160c72e2", size = 29510, upload-time = "2025-07-31T19:42:53.152Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-greengrass"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/ed/c575e7250230d8daf77c03ae37f5c682b12f57969a1c84d8b2d35b3594fe/mypy_boto3_greengrass-1.38.0.tar.gz", hash = "sha256:22bfc195ffb5bad886c062bc019f97b2ca8ba413b7d40c611e346e2203b096ad", size = 38561, upload-time = "2025-04-22T21:24:58.913Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/e1/84f5782fd6be5db6fb30a8d3b48124d323e5438bbee6b50c3c86ba1e15e4/mypy_boto3_greengrass-1.40.0.tar.gz", hash = "sha256:2e341154675a0e84e42d3f85451b7969d159873ae357eab6b3d1f206b474a5d4", size = 38593, upload-time = "2025-07-31T19:42:59.244Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/ec/e55852f9f0ab41f01a2d42261af8f5b5d0420c0fb5d43de337ae791a6b54/mypy_boto3_greengrass-1.38.0-py3-none-any.whl", hash = "sha256:baa125f0f24b7d2e7ee1df776483981a530c5eba171c2b2329e660df6af5399b", size = 42619, upload-time = "2025-04-22T21:24:56.261Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f7/eff7ad7b7c8d48c6222aab807e16b93bd142804ebe256b840783edd13127/mypy_boto3_greengrass-1.40.0-py3-none-any.whl", hash = "sha256:8c4371b98d4733fa9dc29aab6d577d913846fa1e5a5764beb49f40d76780b8c1", size = 42675, upload-time = "2025-07-31T19:42:56.773Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-greengrassv2"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/56/a8/68f9d762eb1fb87a97467652d98725e7dec942e83204b7dbe50b2524b150/mypy_boto3_greengrassv2-1.38.0.tar.gz", hash = "sha256:335e59ca4afc5683530252733364af45066d7d1cb2d023a56616d5068df7e5cb", size = 23997, upload-time = "2025-04-22T21:25:04.317Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ed/13b296bf0efaa8f3471b58ee69c242af1cb16a86ed68ce6da5cad8bc75db/mypy_boto3_greengrassv2-1.40.15.tar.gz", hash = "sha256:fcef9f337314d87b4522dd52f3ec84dd11b9f5db072b025b9c835a5666149c3d", size = 24015, upload-time = "2025-08-21T19:43:24.333Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/32/54aed5833940c50fc1570754dea27ca85372e1dc9f38c3cfa8bb0a7c9273/mypy_boto3_greengrassv2-1.38.0-py3-none-any.whl", hash = "sha256:2447333cab4b3699d0414749801fee3420bfa433c3fea01a4b9aef596bfe2d9e", size = 33793, upload-time = "2025-04-22T21:25:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/05/17/28dff882d0a70017266d2e2db3b08aafaec4c39de0d9cac1cc4cd45a3919/mypy_boto3_greengrassv2-1.40.15-py3-none-any.whl", hash = "sha256:6d0a7f8ed11acfb840b6a49110709cd0e576753a50f93be49a9ccfc2f674dae1", size = 33941, upload-time = "2025-08-21T19:43:21.237Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-groundstation"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/f0/44a6d67e4724483d8e2a9d4edbeb7119ad91fa60e7942ad6e495c02349e0/mypy_boto3_groundstation-1.38.0.tar.gz", hash = "sha256:1a40b8885f7a7789d030d659c7624706f81d16fceaba3987d982f312e88cd67f", size = 24512, upload-time = "2025-04-22T21:25:08.483Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/1a/807c8eed70acfe19ee7ae6921082fa6882abe8817686a6c13e727e8ffa40/mypy_boto3_groundstation-1.40.0.tar.gz", hash = "sha256:fcb94c1580bb70959bf42e4922dd1d4c43ed976b0fb1a952abb99868549fddce", size = 24529, upload-time = "2025-07-31T19:43:04.514Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/fd/7113c3812ab6ba96edb8938d90ed702b9bc32d538ce7374aeaf0b633af88/mypy_boto3_groundstation-1.38.0-py3-none-any.whl", hash = "sha256:5bed12f6164354c0c38c0fb243f7aa8933aa8f62afa57fd6b54f113c301bb2b3", size = 35602, upload-time = "2025-04-22T21:25:06.213Z" },
+    { url = "https://files.pythonhosted.org/packages/08/fa/ae58dc1376005a7469813e762fe736645dd0ca9b96341fc4fce7f5b1fb77/mypy_boto3_groundstation-1.40.0-py3-none-any.whl", hash = "sha256:0642b911b12106d00b7d032073a9c8a5a241f08f2fcddba7b3be09ed3ccaf7fb", size = 35659, upload-time = "2025-07-31T19:43:02.018Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-guardduty"
-version = "1.38.12"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/56/cf/aa4d03c118e12baacd12a3c57af6295da7eb60e99a784f5cb01f14c141fe/mypy_boto3_guardduty-1.38.12.tar.gz", hash = "sha256:98acc3e31517ba73acc714d7248a15d1aadd815921bebe7b2aa44bc63d8a84f9", size = 49161, upload-time = "2025-05-08T19:42:39.517Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/320e19992b1eaa5b7c9281f9dcd1b96ff9fdb17f0794a01fc36386188e78/mypy_boto3_guardduty-1.40.15.tar.gz", hash = "sha256:65ca88871849a742d88c77c2aba98b9bc70ba75457b2f0d22305902c53035d61", size = 51677, upload-time = "2025-08-21T19:48:18.77Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/20/bd92e8d47fc6c2d35353a8b09a31ddfba365e56fd5de9840c84da73cd79d/mypy_boto3_guardduty-1.38.12-py3-none-any.whl", hash = "sha256:8a2b07c1d43f3e5be3d3304cdbeaccc5eb0441428b7007a874da825196ef1ab2", size = 55088, upload-time = "2025-05-08T19:42:35.595Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/46/6d68b37947f58e36340f8f52aa0890630d4c342b4f7b4f61897fe5300a7b/mypy_boto3_guardduty-1.40.15-py3-none-any.whl", hash = "sha256:957ad9bbb0092e8ee516e36a16be56ac2849c93ba3d27fef15ff45f042cccfff", size = 58122, upload-time = "2025-08-21T19:43:23.298Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-health"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/33/c113798801896afa544590529c1a64db843fa96b7bdd573d69e3482c27fd/mypy_boto3_health-1.38.0.tar.gz", hash = "sha256:dcb013f05d2e46b395a28583e8374969e60df4c45f396132ecaa35f68b27d39d", size = 19954, upload-time = "2025-04-22T21:25:18.421Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/ab/50c433586df7afa635bdfe23292928d0ca2bb9252a4b827e4b2a51b34133/mypy_boto3_health-1.40.0.tar.gz", hash = "sha256:73f40280cf2658801eefa0bb7b7fa0f73de2fee92f3b3f501ae9e0a1fa36858f", size = 20020, upload-time = "2025-07-31T19:43:08.453Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/91/b9d82bc316b1ffb5e62bcb91fec3353773d8b3071a17734d31aa31a0225f/mypy_boto3_health-1.38.0-py3-none-any.whl", hash = "sha256:1fc914cbd4cca4b6e171966202e37857ba872dfbc035f91ad85954c480aa0337", size = 26524, upload-time = "2025-04-22T21:25:15.86Z" },
+    { url = "https://files.pythonhosted.org/packages/47/25/2b12ae48035ddc8220e17995b5ef379170aa4a500849bf112e215f8a704d/mypy_boto3_health-1.40.0-py3-none-any.whl", hash = "sha256:257d82f1445577d5c02e5e587cb75f9ccfa44c76bdcbac1b43b9aa2a96e394eb", size = 26582, upload-time = "2025-07-31T19:43:06.498Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-healthlake"
-version = "1.38.0"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/d1/b600763ce65fb23564d6c9edbd20380bee32ee43b1c303b87ca1e2776139/mypy_boto3_healthlake-1.38.0.tar.gz", hash = "sha256:cfcdfd5750cb1f122466b4a3cd6a4b6c0306b332f75289081c01f06951614834", size = 17609, upload-time = "2025-04-22T21:25:22.465Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/0e/e37f0917530ed217cea8f0d51d04fab32e018ab33d666f8da996a7c98782/mypy_boto3_healthlake-1.40.16.tar.gz", hash = "sha256:f069738cf01a91ed3389dcaad4c545f5c310d78f94754e7372e30404ea131013", size = 17667, upload-time = "2025-08-22T19:42:44.017Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/d4/b46fb55bf13c4dc6e67a2876c4d300954e58956dd4436b882b00c9161377/mypy_boto3_healthlake-1.38.0-py3-none-any.whl", hash = "sha256:c7c3720dfbeb168a97c71979b755cb993e6689d58301697b7dbfd79456beddbf", size = 22058, upload-time = "2025-04-22T21:25:20.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0f/dd7a6f63df8079844d8f4cff0f35a26db83397a69483fc9a7634dd00c828/mypy_boto3_healthlake-1.40.16-py3-none-any.whl", hash = "sha256:9e588976f8b1540421d8cbfe6a976337b04a49781c514eac0bb2953812b08b20", size = 22204, upload-time = "2025-08-22T19:42:37.846Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iam"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/25/11/cb501ac886832a3a2969464b09304174507c6c1c6ca10c4b3f3c1acd905f/mypy_boto3_iam-1.38.0.tar.gz", hash = "sha256:2e1d449c47431901161cd0d08835f9c74f2817e4dbcd377922e9ccc184ea52ce", size = 86285, upload-time = "2025-04-22T21:25:26.909Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/7c/fdec1447883fb90470b7cb1917a32923583e7bcfa4b592e8f9f5871cd1a7/mypy_boto3_iam-1.40.0.tar.gz", hash = "sha256:b900ac557375428f0bbc37aa24fdd2901e2db7018ae44e0aaf99ec0f84a28d44", size = 86593, upload-time = "2025-07-31T19:43:12.695Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/98/4493b4ee6f51d379b43480dd82fd8a62953798f0909645a8f013a33f5cb9/mypy_boto3_iam-1.38.0-py3-none-any.whl", hash = "sha256:1dc701bbae0e69f904f0732669ac9a4f6370663c14d5a403bbaef6529f40b631", size = 91644, upload-time = "2025-04-22T21:25:24.292Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b2/ab85f6812bd53d88b7508a2d6601387c9ffccdb73002730686680723f2b1/mypy_boto3_iam-1.40.0-py3-none-any.whl", hash = "sha256:46e354287c93b4f84eef2407076f56cb42e504336eaec114641b1b184808fae8", size = 91992, upload-time = "2025-07-31T19:43:10.783Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-identitystore"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/ab/b5/6ae1bc472c218700b452a77b86292e53e16153f283694e5035e442f7a6b3/mypy_boto3_identitystore-1.38.0.tar.gz", hash = "sha256:9f5d66bb73b6a36b0f2f5df13edc25595be935f554755ee5ecd3b695783e6723", size = 19095, upload-time = "2025-04-22T21:25:31.628Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/005aa2544796c0b53c2815026eb13bda3d8421e588fe9ecdf73aca441f1e/mypy_boto3_identitystore-1.40.0.tar.gz", hash = "sha256:44b7063950e2c2bc83eb17fd13a95649d00020a08fe2135a0509278dbc0f02e4", size = 19136, upload-time = "2025-07-31T19:43:13.54Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/0b/87f52e2e533f7c32f00bba59388d6bbd7668eaa5d3d7f3bb1b2cdff6d2dc/mypy_boto3_identitystore-1.38.0-py3-none-any.whl", hash = "sha256:be4b9f3201b7e1d8d318a6ee651c6ee4591d97edd3d8758ec1804921b9e44f28", size = 25306, upload-time = "2025-04-22T21:25:29.076Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/ea/615a95f62fada4ab9996065beba6fec1c6a261e9ea5eb62937b9e837c889/mypy_boto3_identitystore-1.40.0-py3-none-any.whl", hash = "sha256:0816bbb941f5125adbd2d6b9b522eb9bd46361d9005a00d34fd4da443138b47f", size = 25379, upload-time = "2025-07-31T19:43:11.229Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-imagebuilder"
-version = "1.38.11"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/7a/90/2848e80ac11d68eb159605370f691fe441cddb74c128dee70a842182945b/mypy_boto3_imagebuilder-1.38.11.tar.gz", hash = "sha256:1a3203b9c52d71bf803f563d15e4bcc1b2ce25b9d95cc5ed26242464919655da", size = 42771, upload-time = "2025-05-07T19:42:38.051Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/ab/b77612dc86888464e7d4a7bdac5962f442c19e89440978dc4c12671c2010/mypy_boto3_imagebuilder-1.40.0.tar.gz", hash = "sha256:31ca7934225a97d63227d6d037dabf33413fa57bd788394b1af02aa42a36c4bb", size = 48312, upload-time = "2025-07-31T19:43:17.177Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/84/37712e6fe1c372f078299655c6767dae146731e3440a39cd004b529a8476/mypy_boto3_imagebuilder-1.38.11-py3-none-any.whl", hash = "sha256:36f04f5746f4ecd512302184380971240e4a1d587ae74b238189e280438dee31", size = 47183, upload-time = "2025-05-07T19:42:30.894Z" },
+    { url = "https://files.pythonhosted.org/packages/26/f5/f82f0292ec6f563d6ae1de55379b8b68008bbbf12edb9d90af1f51602750/mypy_boto3_imagebuilder-1.40.0-py3-none-any.whl", hash = "sha256:ebcb1027b6f0475b4f6508bd9ed2344d718a7b03360d959dc9aab77ed377ba71", size = 52262, upload-time = "2025-07-31T19:43:15.23Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-importexport"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/66/4f56e63a805bb5ed1f0b2d4379dcc876cff1a0c6c7ee5ccadacb4a338a15/mypy_boto3_importexport-1.38.0.tar.gz", hash = "sha256:d70bf82ddd442e329f969c0011fa4a6346dff64b5dae6789b92a3c317afe3cd3", size = 16907, upload-time = "2025-04-22T21:25:40.404Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/c9/88132eefa72b45f4e9d91c9dc13796776ac9d471c2a35fe3b5fb8e34c058/mypy_boto3_importexport-1.40.0.tar.gz", hash = "sha256:6dad3574234c95c4f0ffe5abba54240ad0da81c3ceec517de1c824635e0f82c8", size = 16947, upload-time = "2025-07-31T19:43:18.041Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/f9/dcea6afd2148e1ea193054c4c4e0c8bf052c7061fd76fa24bcd8e6c1c72f/mypy_boto3_importexport-1.38.0-py3-none-any.whl", hash = "sha256:c133b8b063f1288b1ab4ecd86588425e6dc0485a2b9b3cc8c55643022d4d5985", size = 22018, upload-time = "2025-04-22T21:25:37.813Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/22/38734a5e4825e846da699da77de32ee941658d7f17358f60cdcd88b34f78/mypy_boto3_importexport-1.40.0-py3-none-any.whl", hash = "sha256:4d38dc9bdd934f5a3ec0ea0d8f8d2f06556eb936f74fd402da82e70b76283aa6", size = 22071, upload-time = "2025-07-31T19:43:15.719Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-inspector"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/7b/304b3518b579b94869c20810285bf0ccb520d2b28b3deb3ff29d44f61d9f/mypy_boto3_inspector-1.38.0.tar.gz", hash = "sha256:31a39eb55988a88f2f55a56de870945f1acb3bb9549b88b90c3cf07f111d2c88", size = 26950, upload-time = "2025-04-22T21:25:47.905Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/2c/ce78c2a6c8c2bb28ec52ec1541757bb95b0f5ff9824b135da57edb927f3a/mypy_boto3_inspector-1.40.0.tar.gz", hash = "sha256:aab7854e3973f8c72bddd7201c63237d5d063c5d927c4ff357e14ddba2476b40", size = 26973, upload-time = "2025-07-31T19:43:22.12Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/b3/de9ddd38eb21c6fc1dd053a38d5c0fbdcb912075128e4dd149c046978408/mypy_boto3_inspector-1.38.0-py3-none-any.whl", hash = "sha256:98fdc7fa302eaa7737c198df99ba9efe64e2ac80533342b2416ee8c2e0ab7a70", size = 34203, upload-time = "2025-04-22T21:25:46.445Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/74/877557997cc6182e35ffbc065fac45cc683524365f387c5bd66c589eff99/mypy_boto3_inspector-1.40.0-py3-none-any.whl", hash = "sha256:bf87bb3e536970c25feb94c3e9642f007eaa508b5650aaf6afa5ff912b060144", size = 34259, upload-time = "2025-07-31T19:43:19.965Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-inspector-scan"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/ca/c47ddea7a32441d5183a824fc6a0f632ba57695310de347a2f352694dd2d/mypy_boto3_inspector_scan-1.38.0.tar.gz", hash = "sha256:903cdfcb1e0816243d720a7691c156df957da5b5505c2f8eaebe7f90e5dc3652", size = 14986, upload-time = "2025-04-22T21:25:52.586Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/2d/3ee067655152cf3eecf6ced23b8635ae87b31b585f22807205109d0f8810/mypy_boto3_inspector_scan-1.40.0.tar.gz", hash = "sha256:952bb75df90da1e7235d233018f748afa00caa975137bf82b1645fb55f8ad5c6", size = 15030, upload-time = "2025-07-31T19:43:24.967Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/f5/f746555196526934cdcd8f54a6ca3da73e63983d6c443ff38fd3e0239844/mypy_boto3_inspector_scan-1.38.0-py3-none-any.whl", hash = "sha256:ac526820890a3f591525601f725feda1ca9896bb74ee017dc66c12bb18740668", size = 17759, upload-time = "2025-04-22T21:25:50.412Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/0a5bf5f92d8b72895d177e25d11d7baaed36f3b400f562cfc3e236299cfb/mypy_boto3_inspector_scan-1.40.0-py3-none-any.whl", hash = "sha256:e6ac395324d812e9bbc46b21cd19a2acffb8921f0b886a1ea7412ab98d67e1e7", size = 17816, upload-time = "2025-07-31T19:43:23.32Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-inspector2"
-version = "1.38.0"
+version = "1.40.6"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/9c/5b/d3f353ca85b2081bf41e008c8b02dd01af7daeeea2e0cfdc38f0d0e081aa/mypy_boto3_inspector2-1.38.0.tar.gz", hash = "sha256:b3052ff4a7189b46ec8f5d67e614496b2517b85b0b51909056b390f9468325c1", size = 46939, upload-time = "2025-04-22T21:25:44.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/cd/78f3c735e29d25c8515639c2803e7770a9749901d53e85bc6e44399a68b9/mypy_boto3_inspector2-1.40.6.tar.gz", hash = "sha256:03c7ce9762d1fa6a21fbf3808cf6378ae7e9a4b6854b11e5c0c8f1cd96f27ce5", size = 53417, upload-time = "2025-08-08T19:43:35.844Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/09/21251326a0372f2730eaf88e9aff7b8be6cb92fca4b89c95c420b47f1277/mypy_boto3_inspector2-1.38.0-py3-none-any.whl", hash = "sha256:f1373f318a68b58b27481f08f11af2aaef10576cf5f467638ae794ff0032ba95", size = 54584, upload-time = "2025-04-22T21:25:42.184Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b7/400bf69a1bdfff196d16a7acd994de6e25520947f43b870d044c346e30ef/mypy_boto3_inspector2-1.40.6-py3-none-any.whl", hash = "sha256:6482df9327b1afd7f76a19d790270c263d52e58fedb2f7ebe74f039d7adc6248", size = 61867, upload-time = "2025-08-08T19:43:31.297Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-internetmonitor"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/d8/1a24970408005a407f31321a4b81a8801ae660330bc9efc40a2269a053d5/mypy_boto3_internetmonitor-1.38.0.tar.gz", hash = "sha256:31e4f2b39b8432a30d554b1736a1e92b891be15a3e5640ec4acff53679d1f8e8", size = 19910, upload-time = "2025-04-22T21:25:56.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/50/e696006d158b1d04d8d66de629178671508b3bcfa2515dd4b382a14985f2/mypy_boto3_internetmonitor-1.40.0.tar.gz", hash = "sha256:9997ef28dfb1f75535ca3070a38a4a64dea30a750c6e5f129f0585dc8331fa4a", size = 19932, upload-time = "2025-07-31T19:43:25.659Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/f0/41af51c36dabf61c4447d6c9c75cdbf721ec8e1c2a08e5ebc02f3cd497ff/mypy_boto3_internetmonitor-1.38.0-py3-none-any.whl", hash = "sha256:fee34dcaa1a58268e9d639e5aaeaf54497ae45d88d27f322b6d5bc2994bdbbde", size = 27159, upload-time = "2025-04-22T21:25:54.916Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/d1/7943556498b70f6d0f125df1e8eb8d3596bd393833adf7ebccf2a31b65b0/mypy_boto3_internetmonitor-1.40.0-py3-none-any.whl", hash = "sha256:b2655cee29a051221e288f5a1cc85d089932f1b567016e75fedc33f61a6ca26a", size = 27226, upload-time = "2025-07-31T19:43:23.846Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-invoicing"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/67/28/6bc40210091c5a1c3573aad13066f68055bdb85bdb6dcf986466b20b9fb4/mypy_boto3_invoicing-1.38.0.tar.gz", hash = "sha256:f02bab7913b91e954525a5cd81957bf12804235c9036def709f712a6c8f81639", size = 17150, upload-time = "2025-04-22T21:26:01.648Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/bf/ff6233481d2c218145b75512b6e6a82b1a04fc12a5098f2ee01cae57baa4/mypy_boto3_invoicing-1.40.0.tar.gz", hash = "sha256:2cf5d1f27a814ab4e6470d5b5baabec6b73a51cae31312c4a3d524d7f6ffbd5a", size = 18327, upload-time = "2025-07-31T19:43:28.739Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/24/629f45fca613882fd1cfb8966c61d477e4407a0737ed3b6b355cd27454a5/mypy_boto3_invoicing-1.38.0-py3-none-any.whl", hash = "sha256:303e838c0e35846e20ff18be9b5555eb6b2d4b6df896dc1caca9d43de203c015", size = 22190, upload-time = "2025-04-22T21:25:59.13Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/e0/8b60a9a2e59e9e81de3817d9a8f83458d22982894b8b0f5f3fbbaa8b988e/mypy_boto3_invoicing-1.40.0-py3-none-any.whl", hash = "sha256:0fbcb0aab0314a694d81b89a0918522daa06c6da2db295fb2e5a719c491898d0", size = 24100, upload-time = "2025-07-31T19:43:27.228Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iot"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/7c/5aca181f9dc825786a57597eff668801c937f4f4eca82b8221306cc6948e/mypy_boto3_iot-1.38.0.tar.gz", hash = "sha256:edc9f9dd040b91b4ecc95b400af3d1b8515e15d5a2f00113efff5c7db471e131", size = 109496, upload-time = "2025-04-22T21:26:20.701Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/db/5d61bf8058fa5b9e5520c70d867022448acec498728efd0c558695f5ac37/mypy_boto3_iot-1.40.0.tar.gz", hash = "sha256:d0050ad076aa9a82d56db2c372c6a05195fb2a4145f7353ba1b3b406670af3eb", size = 110120, upload-time = "2025-07-31T19:43:37.11Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/ef/08e2e15851f4913e27ed0b4e210b35ab7d767bd0165986787a7a4ccbf1a6/mypy_boto3_iot-1.38.0-py3-none-any.whl", hash = "sha256:27a90dcc0e3ffecacaa84496721ef9883789e1ad8a0fd908e267772eee1f3c3b", size = 116739, upload-time = "2025-04-22T21:26:18.333Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/26/54cecc6c1956621a9176e8fbec48ae3013ade5b31f8353ee7b9755303b3b/mypy_boto3_iot-1.40.0-py3-none-any.whl", hash = "sha256:abfae49af9cb5e5e82e7703491a43041dd57473c802b03f38788ea02326fe32e", size = 117400, upload-time = "2025-07-31T19:43:34.749Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iot-data"
-version = "1.38.0"
+version = "1.40.6"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/97/a13e9609fa1dcd82e4bfb5def40ae7d79dc3326d3da23df8102e855e9096/mypy_boto3_iot_data-1.38.0.tar.gz", hash = "sha256:1ffe0b9a6502449dc397cf24af16cb8bfa622499b3321dc4e4a1e4c50ffbfd7d", size = 16831, upload-time = "2025-04-22T21:26:06.532Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/bf/1fc14edfbf8b44394ae255c247488e97c91f5a9821bb7848d93112574bd2/mypy_boto3_iot_data-1.40.6.tar.gz", hash = "sha256:7c4c37683f051b2bee40c9abf3415bf6993f2115dad195475ede4ba6d6a19e87", size = 17049, upload-time = "2025-08-08T19:43:44.061Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/ad/1a59a5d31fa5e39e8091122503bbaef9cbaddfe460867b3dcb5392e6a62c/mypy_boto3_iot_data-1.38.0-py3-none-any.whl", hash = "sha256:11125085512b5e3943df55cba5ae7fb9ab75c76b752e7ba56ad8b1be9a49308e", size = 21842, upload-time = "2025-04-22T21:26:04.483Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ca/50b0dac5eb4330cfa0608c5c4f23ea37f7335839e34fefae2c7eb7921fc6/mypy_boto3_iot_data-1.40.6-py3-none-any.whl", hash = "sha256:fc28c194782a0c0f453041a7c04b7a535684439edeb3d91ba69886ac21938aac", size = 22184, upload-time = "2025-08-08T19:43:31.286Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iot-jobs-data"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/0c/7e/c1c24d630dc182b684ff5621df9cedfc7cd894e56c7711c0a74a105296f8/mypy_boto3_iot_jobs_data-1.38.0.tar.gz", hash = "sha256:881862b2b0a24a4c00bdeba993471efef8115dbef56be9a6b2cc5cda686fd5a5", size = 16165, upload-time = "2025-04-22T21:26:10.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/6f/8604fd7fe98b73d617285a9b2187f8fc7d23fe117e6e11afecb6da91d59a/mypy_boto3_iot_jobs_data-1.40.0.tar.gz", hash = "sha256:347f1d40559d0398e266708519c7c3575448fdf50bb61f6423590d966576cfc6", size = 16208, upload-time = "2025-07-31T19:43:32.78Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/64/e814f63e71f8d1c92f0630961b8cabaeadf2077caf4f520e779a06d5829d/mypy_boto3_iot_jobs_data-1.38.0-py3-none-any.whl", hash = "sha256:26532a5b9f209547903734aacd74bf6bfab5a274bcf55f8b1d83f690e703a601", size = 19940, upload-time = "2025-04-22T21:26:08.977Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b5/4da0178e908883d49478ef35ac76b9baf0431ff64de3475abd37c37196a3/mypy_boto3_iot_jobs_data-1.40.0-py3-none-any.whl", hash = "sha256:a18c42e207055acd90b55fc6937d04bb50ec01eed7794a2c6a94eddc6291665f", size = 19992, upload-time = "2025-07-31T19:43:30.827Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iot-managed-integrations"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/4f/09dbcc61f8fd8e9da97a4493764c3d4ad95cdfb0beb39d4d2bed56ff4847/mypy_boto3_iot_managed_integrations-1.38.0.tar.gz", hash = "sha256:437b54f20b087531b4f533fe65a36e563d1f518ff729b590136386e5cabdf662", size = 34310, upload-time = "2025-04-22T21:26:15.689Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/d5/ea5fc1ed4dd62a37c1ad4a01475acbfc82f126e4dad19c1f8609fdfaaeaf/mypy_boto3_iot_managed_integrations-1.40.0.tar.gz", hash = "sha256:d234591957e387437695dacc17c30ced54a549f63309534f2938f2752e48df88", size = 42530, upload-time = "2025-07-31T19:43:33.518Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/05/083d3fe0fcff067adab7caa22c293507814c6a021c7a76ef1aa1187b0b57/mypy_boto3_iot_managed_integrations-1.38.0-py3-none-any.whl", hash = "sha256:3ed5576867615f9c58e6782aedc7a708edac17cfcfd8b4abe0d5af1a68f7579e", size = 40211, upload-time = "2025-04-22T21:26:13.12Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f8/17bd57c4136370ea37b83474482ba8ac9ab5f84dc21167538337d7a582e9/mypy_boto3_iot_managed_integrations-1.40.0-py3-none-any.whl", hash = "sha256:5d1442b2c0abfd927e282d495b3d40075e9e89afc2746a7b0b6a11d28d7f5dcf", size = 49081, upload-time = "2025-07-31T19:43:31.318Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iotanalytics"
-version = "1.38.0"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/6e/d3/0c6f1760a6572dd4cc11d7cb9c185106bcd43abe2f47a0b5221636e2328f/mypy_boto3_iotanalytics-1.38.0.tar.gz", hash = "sha256:112eafbeb37b35ebe6e933ac329a2745220c325dc9c1d14824cf4efa5e2ad1f8", size = 26568, upload-time = "2025-04-22T21:26:25.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/e7/e5af6f3ff73988612e9617cb3995101a1d590842c0f4a8f442d3af8c5774/mypy_boto3_iotanalytics-1.40.16.tar.gz", hash = "sha256:90b37e4b9c7d5cc3bc4e8bd1e7b8705e7a90bc2e8af89c079dc826acb14ea456", size = 26637, upload-time = "2025-08-22T19:42:45.705Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/5e/cf42811acf1bc74cd1afbc28579d1da66ac2496eb295d5c940322d445716/mypy_boto3_iotanalytics-1.38.0-py3-none-any.whl", hash = "sha256:6cd6b273a0e8bfc204a9f0ec5656af8584cbee48fdae4fb06a0c65332168fffd", size = 32647, upload-time = "2025-04-22T21:26:23.337Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/2b/9202121fcbf499594c7ff86395cdb93fbd428c87d3f1d49e9e423b383ad2/mypy_boto3_iotanalytics-1.40.16-py3-none-any.whl", hash = "sha256:6468b18bff52a850dbf5797df45d8136c8ccb95be0fd5cbee140b0160d4ddc1f", size = 32781, upload-time = "2025-08-22T19:42:41.039Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iotdeviceadvisor"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/26/24/9c7b4883376f6ed3b121b5080ebdc4de99125814ef0cbfbc618f39081112/mypy_boto3_iotdeviceadvisor-1.38.0.tar.gz", hash = "sha256:ea3f9bd5c05cfc5e004a5523bf255d3673cb6c7cd7d0d86fca6daa20f40cbc78", size = 17378, upload-time = "2025-04-22T21:26:30.05Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/ef/00b7fea575ce8364cd70a9aaa3602c76e3f9fd13fc0c296321c198c960e9/mypy_boto3_iotdeviceadvisor-1.40.15.tar.gz", hash = "sha256:13a63eda0ecbb16ef06c5d6dfd202214de52f69d3ee2fc0dca4909765d7dbe80", size = 17432, upload-time = "2025-08-21T19:43:27.975Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/c6/fc5d92205bb1b4eff7c25c6bd2dca1d11600a35e5a14a93074456eeb2ac0/mypy_boto3_iotdeviceadvisor-1.38.0-py3-none-any.whl", hash = "sha256:dbbe107e78e56bdb147bece568cb0efe1068819a5d59207f115743940ac06059", size = 21803, upload-time = "2025-04-22T21:26:27.926Z" },
+    { url = "https://files.pythonhosted.org/packages/00/70/59df37846cd9bced851cdaa573ec50c5c1172d254532f838b5fd506dff9d/mypy_boto3_iotdeviceadvisor-1.40.15-py3-none-any.whl", hash = "sha256:8e0a1cdadea2a519ba7618df42aede4dd4bdf43c3355874d284b77d65e229df8", size = 21929, upload-time = "2025-08-21T19:43:24.961Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iotevents"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/0f/5ee9699c711c11a71183b4fb85257c40f543caae8fe3f881f2543034484c/mypy_boto3_iotevents-1.38.0.tar.gz", hash = "sha256:7ad2f975ec9116d9693cee39d6c2d53ae2a8f31999922bd202ea5db92916c346", size = 20607, upload-time = "2025-04-22T21:26:39.953Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/a3/db88461c9298f46c3f494ac39d6d180eaa5097934f2a74184e4af7ffa41e/mypy_boto3_iotevents-1.40.15.tar.gz", hash = "sha256:435b39b78e432a421ea255c387a7e1a22615a2621d1534d9ca1886912ae5360a", size = 20629, upload-time = "2025-08-21T19:43:31.71Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/c7/1fdfc41d6c5c1bc8b95d01b52b7d180190d10e7592c892000257a22223ba/mypy_boto3_iotevents-1.38.0-py3-none-any.whl", hash = "sha256:57723b2aacd0e7de492e57af56ec7d30523a97825b7263b71acf3f0c5ce3ae1f", size = 26894, upload-time = "2025-04-22T21:26:37.756Z" },
+    { url = "https://files.pythonhosted.org/packages/22/12/bc1aae0c50850ea797f0a53ce071cd6c36ca44ca9fd6bd5f45a24ef01eb5/mypy_boto3_iotevents-1.40.15-py3-none-any.whl", hash = "sha256:1c1571ab487a8eb827f97262eeaca72bfff57621e9e994e4f41f1cee723e2ad7", size = 27021, upload-time = "2025-08-21T19:43:29.846Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iotevents-data"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/3d/bf5025785bb96d9283a1fd88447eaae087f934d17ebd6eef0be071ac5fee/mypy_boto3_iotevents_data-1.38.0.tar.gz", hash = "sha256:927b7f17fe4eff745ba90089fa77835d759f5fb01d13a67219a7fdbd318c1e62", size = 17638, upload-time = "2025-04-22T21:26:36.074Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/02/f5a060fda009bdd85e55e3391f293d9307dc8e5cfda03798dc05bd29dcb8/mypy_boto3_iotevents_data-1.40.15.tar.gz", hash = "sha256:088afd513b3aa8746f116ae51cba284ce63314a69603e0701bf37c169f974c98", size = 17699, upload-time = "2025-08-21T19:43:29.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/ad/6add6326b93e0ad049f4fdbd0a758dfb50810479533bc0523b20008b4382/mypy_boto3_iotevents_data-1.38.0-py3-none-any.whl", hash = "sha256:6dcd7638c64431b5a4392d123ebdbd188e0199faf1a63eca6c900e4b36ccdba1", size = 22237, upload-time = "2025-04-22T21:26:32.596Z" },
+    { url = "https://files.pythonhosted.org/packages/98/53/6b8bb0bdead2f8aa047115018837a46293cedddce81459bc452ca26a9360/mypy_boto3_iotevents_data-1.40.15-py3-none-any.whl", hash = "sha256:63ababbe6cab572ff9627dcc775803c947f61b50027748b70969739a685fdf2a", size = 22368, upload-time = "2025-08-21T19:43:26.877Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iotfleethub"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/89/43/78294e0cbc16955bba32f63c9595a9f0740765a1abeafe360e1af2364fc8/mypy_boto3_iotfleethub-1.38.0.tar.gz", hash = "sha256:519245f39a863ff0f8c32cfd7a87d5fc41c04b38d0fe0fe22681b53fad4d9e6d", size = 16644, upload-time = "2025-04-22T21:26:44.179Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/7a/4b29c5542ac34d010692887ae5b704d51b232a27f1af7d0d6a02dfeaca46/mypy_boto3_iotfleethub-1.40.0.tar.gz", hash = "sha256:5369c289f918ba96fe0dc327f098cf50cf9d0913accb2646ba40a1b1a0cd44e1", size = 16656, upload-time = "2025-07-31T19:43:46.096Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/c5/21a87fe1db21e52f247de1e2320777bc626a2d6c3a7b84df0eedfb2c8b2c/mypy_boto3_iotfleethub-1.38.0-py3-none-any.whl", hash = "sha256:d1b5311ba397be2a9a6d3464d5da084cf71b7ce0a634ec74f16903aa69293278", size = 21474, upload-time = "2025-04-22T21:26:42.032Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a4/544bab24ff5cbb7188827eb842ece094bb143f34220f435ec529a4ef411b/mypy_boto3_iotfleethub-1.40.0-py3-none-any.whl", hash = "sha256:77bcfe6bc777fb9febb8fbdfbbdc76c663568c80cb4ea7f895ef71233a00fcb0", size = 21534, upload-time = "2025-07-31T19:43:44.078Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iotfleetwise"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/b1/7c1436b9d38c8430ad740a733c9b2c5e346fa768cef5174ead7932b84569/mypy_boto3_iotfleetwise-1.38.0.tar.gz", hash = "sha256:8527dd2388912fb9d56580c05d1402a1d41c4df657c7d72774739077d23fdb0e", size = 38241, upload-time = "2025-04-22T21:26:48.919Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/df/7074d318b3abab9f346d4aae9e9ad4354f346f86c266e3502db87edd3aec/mypy_boto3_iotfleetwise-1.40.0.tar.gz", hash = "sha256:3c44750faf30eb006f1d41f9086127e07d7392ef76be1730583151a685d99668", size = 38274, upload-time = "2025-07-31T19:43:49.499Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/c0/2fa37d4b06144b425cbfa3bb981e3850d1c76653b0c761d4e18d59b15a85/mypy_boto3_iotfleetwise-1.38.0-py3-none-any.whl", hash = "sha256:8966c0f060e89644049aad3afab02cc8d83b61f483396478bedec510b0d7c808", size = 43629, upload-time = "2025-04-22T21:26:47.054Z" },
+    { url = "https://files.pythonhosted.org/packages/13/8c/20bdb6d10230b50729abc4fc7b6688d6d5429a1e41707aa013b410aed705/mypy_boto3_iotfleetwise-1.40.0-py3-none-any.whl", hash = "sha256:0b24b0228219c28df9c26163631a423955e00a787162ca84f6b9b66781240f7f", size = 43702, upload-time = "2025-07-31T19:43:47.764Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iotsecuretunneling"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/b6/9197de5ba3da2ad4d8e27d69e0e3fd210224561b161494a12abf01c4e498/mypy_boto3_iotsecuretunneling-1.38.0.tar.gz", hash = "sha256:e9abf36d6faca3822ec951d3cbb2f33ff236adcc69840e7ec3cce60be9161738", size = 16348, upload-time = "2025-04-22T21:26:53.22Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/4f/b3cab2cd5d25702b19e9d16a2ac4e2c6f1d1ee3fd08f9b2b163de9ecf906/mypy_boto3_iotsecuretunneling-1.40.0.tar.gz", hash = "sha256:135979ecaad83f78208cb563f78933041f3908517b1ed95d50c1c664feda504a", size = 16360, upload-time = "2025-07-31T19:48:42.382Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/ef/97c75cce5f86ac4b8cf700d99d45e8238f28f2c64dc3cc440ac2d615d862/mypy_boto3_iotsecuretunneling-1.38.0-py3-none-any.whl", hash = "sha256:f4582b153ef96e54a47ac1f636757040ca98ccb89048f8f0ac054a7bdb78f176", size = 20169, upload-time = "2025-04-22T21:26:51.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/e1/6421c5a97a21ab736878d143ac333ef1d3426d72235c7fd7f9f78e9107ba/mypy_boto3_iotsecuretunneling-1.40.0-py3-none-any.whl", hash = "sha256:4259c9bf4200376d427799c0985bdf54770996c1a0730ffb0fab60455b3b7229", size = 20226, upload-time = "2025-07-31T19:43:48.228Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iotsitewise"
-version = "1.38.0"
+version = "1.40.2"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/98/b80c8e52315798729655b8dc0d11991b5e2ff4a69ccfc91a4f7868be9eb3/mypy_boto3_iotsitewise-1.38.0.tar.gz", hash = "sha256:8bb703a3daf61ff769f9ab27531ffb8cff8890c37f98b3dfda634fa558ff4ab4", size = 54539, upload-time = "2025-04-22T21:26:59.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/ef/7a32236731493772b0d32db4cf535e3908abd2fdb81d1379e1d6b6e9f74e/mypy_boto3_iotsitewise-1.40.2.tar.gz", hash = "sha256:0572cf3307dba9ca5a46702ec6b986e29594b15147516f9fa0cbc1d6087961ee", size = 60818, upload-time = "2025-08-04T19:33:09.948Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/a2/45bff1b5692d3985525f94cb5049ea0618b0ff4aad0e0404d1cd17cf8d10/mypy_boto3_iotsitewise-1.38.0-py3-none-any.whl", hash = "sha256:adaebaaa39d1153078b3793419a90b83b561f0b8b6b497bed54a05ef41b2b09f", size = 60682, upload-time = "2025-04-22T21:26:56.608Z" },
+    { url = "https://files.pythonhosted.org/packages/34/00/2fcd19160c885e3a659ee9e695cdef7d5ca9d0fbb9387f4888fdd593200a/mypy_boto3_iotsitewise-1.40.2-py3-none-any.whl", hash = "sha256:12d98e38eab5550c30eb00ea2d123b525d46b71b8197463f4bcd4a9c143506e9", size = 67200, upload-time = "2025-08-04T19:32:34.205Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iotthingsgraph"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/7a/e67397bf94d7107d54d16cd20a04a708ef9338c53a8b841b754cc3cdc330/mypy_boto3_iotthingsgraph-1.38.0.tar.gz", hash = "sha256:ebaf5d317806c69c8b0185f0a24fc87a7073610d7cf888be65b3762c78d7a864", size = 23195, upload-time = "2025-04-22T21:27:04.607Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/4e/cf56600277aa2e9e30d1532f0c91278233fbc3ce23e0b1230fff5b4b0611/mypy_boto3_iotthingsgraph-1.40.15.tar.gz", hash = "sha256:64187fbdde5c3563afd24937d201573670eb7c29a5494afc98aca9118b9c5207", size = 23245, upload-time = "2025-08-21T19:43:32.784Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/fe/9e8f5144d5d5642e38f5d389ae65262eabf9023f9586a9495d9478d394d8/mypy_boto3_iotthingsgraph-1.38.0-py3-none-any.whl", hash = "sha256:67cb6c2e23e3e5ac6dd599f97b220cabcecc468941599afb67a37469479d47f5", size = 32472, upload-time = "2025-04-22T21:27:02.446Z" },
+    { url = "https://files.pythonhosted.org/packages/97/47/225f05b464323aee6189b9dd62f5d23169447e768806fb373f74202b0343/mypy_boto3_iotthingsgraph-1.40.15-py3-none-any.whl", hash = "sha256:469b45654f86d740efced88d36a58d586e9998b42b89281b8d9495b543602237", size = 32601, upload-time = "2025-08-21T19:43:30.257Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iottwinmaker"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/aa/43ef02c0548ac6581bb54d5cd7b8135d08fcc9c2fe1c6219cc1685a9fac4/mypy_boto3_iottwinmaker-1.38.0.tar.gz", hash = "sha256:267da71920960cb85a8cb6ddf8f84aa5e3f4733696bd3640d225a0b9650fb24d", size = 27260, upload-time = "2025-04-22T21:27:08.396Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/f9/b3408548512a9e8ade7701d618aa21493dddbeef798e7df21e400a2dbd28/mypy_boto3_iottwinmaker-1.40.0.tar.gz", hash = "sha256:52e438354215de87d8f3ffaad5d066dc3a6b1b1fff94eaa7817fb3cd0230be7f", size = 27283, upload-time = "2025-07-31T19:43:59.054Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/bc/e857c749862b467f9252e6265725c72f36dd47ccc2e75d5898d1bb3c55a9/mypy_boto3_iottwinmaker-1.38.0-py3-none-any.whl", hash = "sha256:59875620641c634a695d24c96ec3af59a13fff297fd64e38abb5c6ff261c7752", size = 31741, upload-time = "2025-04-22T21:27:07.027Z" },
+    { url = "https://files.pythonhosted.org/packages/19/64/224b3f3f427b653056ae39dac2df9bf6bd7897bfa35bfc1aaeacfff2be54/mypy_boto3_iottwinmaker-1.40.0-py3-none-any.whl", hash = "sha256:7d8bc3e8ae7f7f1156393d46a4d542800b21f02de118e7b5eb8b1db4a05c8644", size = 31787, upload-time = "2025-07-31T19:43:57.759Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-iotwireless"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/fb/d0/6eaea405cb44530c9a4f6d2606bfd2cd3601e3262e8a4db23304a6f0cd5d/mypy_boto3_iotwireless-1.38.0.tar.gz", hash = "sha256:6bf0425c3059de228b4acfc3f198467f8cc2fc75a204451b895d137d0aed2e3a", size = 44412, upload-time = "2025-04-22T21:27:11.515Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/32/73a866e06dd9778a607ca6f28d232dcfe55d1bebdeda258cb5fbd180870e/mypy_boto3_iotwireless-1.40.0.tar.gz", hash = "sha256:2a3fe0e65087ec0807465494ea87773b88f53a2969a2c1e80cfd61617e12f9fb", size = 44467, upload-time = "2025-07-31T19:44:01.555Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/d1/4ca1bcd52e16985bcec185b01f18b20d2ed273497216cc7e005defc05bd7/mypy_boto3_iotwireless-1.38.0-py3-none-any.whl", hash = "sha256:734475d3372b1ccdb1feb4078f0b73c9660aef6a9ddc2941476965553a6d5aec", size = 47321, upload-time = "2025-04-22T21:27:08.412Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/f6/d8398f5229603cdb13ddd407ba816c7d59eb70e02b007d2b49ae057e8de8/mypy_boto3_iotwireless-1.40.0-py3-none-any.whl", hash = "sha256:0ab9928ed0ea2ee9a5a4e13f1c11febd9373b3a12ae2be7839bdf9273c0b6ccb", size = 47418, upload-time = "2025-07-31T19:44:00.412Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ivs"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/42/dc129bd0efcafbb2a93c2b2e7e9695e08eaf945cead59036a3e7e885971e/mypy_boto3_ivs-1.38.0.tar.gz", hash = "sha256:15d1afb40bd01aff40aa1a38f1607febe2d872155eb66ae34348bf189addbf1e", size = 22216, upload-time = "2025-04-22T21:27:13.179Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/5e1d469fc936838fb806e10c15387c5dbdb86e6edc17b4b0ee3e0466043e/mypy_boto3_ivs-1.40.0.tar.gz", hash = "sha256:bd933dad7c6b4a2278976949fa170bb58530b3e01ccd1cb19dc00abf7bc830ca", size = 22276, upload-time = "2025-07-31T19:44:04.141Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/23/ef73d253ec03d9af8fd78d09159f32988d131de4d324b74d5380082eb956/mypy_boto3_ivs-1.38.0-py3-none-any.whl", hash = "sha256:80c7c7f02ad9d8038390b987d8d2c29b9abac3c1d74097d7f9c4819a52eee5c1", size = 30560, upload-time = "2025-04-22T21:27:10.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ce/a8303e93b3a857f2f515478d18b5a35bf7e57dea47534b0f24c353e0b53e/mypy_boto3_ivs-1.40.0-py3-none-any.whl", hash = "sha256:63aa4e523aabd6a7165c4503b3f755bab3d8fe9a510d3493a884779ecebed873", size = 30613, upload-time = "2025-07-31T19:44:02.801Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ivs-realtime"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/5f/fbdd5da4df979742d21795b2d679a4af06c0b9a683ef1deae6b3a1e0607f/mypy_boto3_ivs_realtime-1.38.0.tar.gz", hash = "sha256:97c7c35f60f2d7e495d1850ab3583900ee147044e26cb02eb911727d2a625a0a", size = 22311, upload-time = "2025-04-22T21:27:16.357Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/db/ef913afc945af9113ef028bf31cc600cb96b7b109483b62f4847a6ae7b23/mypy_boto3_ivs_realtime-1.40.0.tar.gz", hash = "sha256:88cce1ad96bac6d256cb8e95d2d060ba4a8f2624ff705f411d098d06d8e98d68", size = 23175, upload-time = "2025-07-31T19:44:06.577Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/02/7ec11edd97d1ec6c1982426d7e996a568ec08d820a48fb6dbce823133b49/mypy_boto3_ivs_realtime-1.38.0-py3-none-any.whl", hash = "sha256:bd548bc26f45d9534386e955e5f5407556f0e6938ed0034a0f52adccd27b3946", size = 30925, upload-time = "2025-04-22T21:27:14.469Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/cd/2406b0f67db7f5081c929553fc56ab9366473574b6aeb678218f20c90ae9/mypy_boto3_ivs_realtime-1.40.0-py3-none-any.whl", hash = "sha256:d1ea39951b7c505831d39cef92bc5d9d0701e91c26f54c249cc4ccc091338ac0", size = 32420, upload-time = "2025-07-31T19:44:05.443Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ivschat"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/61/6d/6f70e30ec4d1a1c507d6fffd5b756b79858b8a7b4f4b395d34629a14a4c0/mypy_boto3_ivschat-1.38.0.tar.gz", hash = "sha256:4806e8006b4d4123206ad556854e724b3c0b16964d2295692e496cd59e268f2b", size = 17592, upload-time = "2025-04-22T21:27:17.102Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/6c/2894e92a74d241c7de924bb0af4c3432fdf1572cf3139cac484af18eae72/mypy_boto3_ivschat-1.40.0.tar.gz", hash = "sha256:9ad58f17cc261462c2d0faa4297fd48984fafd51bb15f82b6eca93a9120e82c0", size = 17620, upload-time = "2025-07-31T19:44:09.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/07/180c378cc2d842f757fae650fbd5b509fd92ad37de654f6595e1482e84ce/mypy_boto3_ivschat-1.38.0-py3-none-any.whl", hash = "sha256:82f82c9f13e92572a07d28a76d233724230e1b04ba6e18262aac0c6f9f8380e3", size = 22058, upload-time = "2025-04-22T21:27:15.009Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/25/36d7680d7e176f73de8cdc923a162403232e85a1cc3e6a7a81fdcb8bbd4a/mypy_boto3_ivschat-1.40.0-py3-none-any.whl", hash = "sha256:d2c474d5479333a73e875ea028e3f416cf3fab16410197070291bd05b879bfc0", size = 22104, upload-time = "2025-07-31T19:44:07.776Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-kafka"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/3c/85/71a49a6fb0787fb559994c8f55a4fb3354dac21ca711a406176102207530/mypy_boto3_kafka-1.38.0.tar.gz", hash = "sha256:6711106ade377f3a0d7bed89d2e2d8df1484df631159b2c76643491f20d7e3ce", size = 35019, upload-time = "2025-04-22T21:27:20.695Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/e8/6dd587c6ee56ce2d10bd716b52c0cfcb9634a58fa2b5bd9d274b89e9a22b/mypy_boto3_kafka-1.40.0.tar.gz", hash = "sha256:ea05e967fa631bc3b62c1ec2b78802db507f47fdf6c359498b5af5b5daa498aa", size = 35057, upload-time = "2025-07-31T19:44:12.015Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/14/cf0b4f3245618cd9d09e99a1e5f6e34761d3cbb295ee3a194ec7ef5673be/mypy_boto3_kafka-1.38.0-py3-none-any.whl", hash = "sha256:5030fd2b52c0531727356c8964a50b58da5e179539644bb25ef56e77c27fad60", size = 39338, upload-time = "2025-04-22T21:27:18.426Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b9/f9c69435d142c988cf297cee8da203cc97534d6ed7bb06f9fba8b261445b/mypy_boto3_kafka-1.40.0-py3-none-any.whl", hash = "sha256:6e1bbb808821a67e033290cd31c822413f2695be80a5cc669d311e7a6ea7587c", size = 39416, upload-time = "2025-07-31T19:44:10.541Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-kafkaconnect"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/31/4e/c297b558009acb330cfb44a6c9728c92e1477dd7245cc8fc72ba35a51702/mypy_boto3_kafkaconnect-1.38.0.tar.gz", hash = "sha256:bbb1525e5941e6772160c808d27312f9e1582166c0c1c3bf3f53e27089ec89d1", size = 20712, upload-time = "2025-04-22T21:27:21.438Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/a3/10bb0f39bd0a583108562650a14f519448c83bacc9a129895112c2deb4f2/mypy_boto3_kafkaconnect-1.40.0.tar.gz", hash = "sha256:e3035b86e36c2f0ad87a690fb9a751ea879a0ae49a8d4e48c026f4127f3d3375", size = 20743, upload-time = "2025-07-31T19:44:14.456Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/cc/a16163b6f67357078d63d79a129612bebe43f93e80c6ac826a41b1a1cfe4/mypy_boto3_kafkaconnect-1.38.0-py3-none-any.whl", hash = "sha256:3e7664f2bb31585676b5dbf356d3f315dc8757dbf3986dfabadaa7a84754612b", size = 28039, upload-time = "2025-04-22T21:27:19.276Z" },
+    { url = "https://files.pythonhosted.org/packages/99/b6/76b9fa08a3fef842acca436d020a9f96fd283ff4af46bb7d1d69a29aa6f6/mypy_boto3_kafkaconnect-1.40.0-py3-none-any.whl", hash = "sha256:61d0e04a3ba95af7f3017dc2275723c5716833a32b2b9afe578cab9081b50c91", size = 28100, upload-time = "2025-07-31T19:44:13.168Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-kendra"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/9c/14b75a6365b67c49caefb5743f9fc1252f8712092b0434b532c8b7adb265/mypy_boto3_kendra-1.38.0.tar.gz", hash = "sha256:538470562dafd110c7079441e255880c8a4d1fbccadd06e779d968327a06f267", size = 46809, upload-time = "2025-04-22T21:27:24.77Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/3f/342d81dd8f67375d41d20b0c962bba9c01c2f7234115380120bd5dde0739/mypy_boto3_kendra-1.40.0.tar.gz", hash = "sha256:8b9089f6dd96fc4138fdbd6320fa914770e3215592495fca49848cfb031cf78e", size = 46854, upload-time = "2025-07-31T19:44:17.497Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/0e/50b439b096d8f41c7c8d2b25007435e5f79701e29ce25eb96d256d7e0be1/mypy_boto3_kendra-1.38.0-py3-none-any.whl", hash = "sha256:f14f368546115c4867ec4be53dd31242440d6f84af23ecf6a83306c6969daa91", size = 50686, upload-time = "2025-04-22T21:27:22.736Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b3/99b78d8dec0d8c06486a56517114d18d412560ed8ab94f5761b27f55100e/mypy_boto3_kendra-1.40.0-py3-none-any.whl", hash = "sha256:2c196c4c4fefd014b5d16741d9d12e437634e3144dccbcf9edb0a510ff13f67d", size = 50746, upload-time = "2025-07-31T19:44:15.994Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-kendra-ranking"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/34/ac/cf883847ce294858eb4d8588b713ae00410dd711dc0d5dabccc28744cd27/mypy_boto3_kendra_ranking-1.38.0.tar.gz", hash = "sha256:05b529151c186019075013c2f10eb396dc734831019c1f4b690c437a230e1590", size = 16368, upload-time = "2025-04-22T21:27:25.485Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/73/bc5e9712906a4804aaef45699cb8c3b844e88aca9aec5ecb0eba7f75284c/mypy_boto3_kendra_ranking-1.40.0.tar.gz", hash = "sha256:6263c9f660ec047060203122b68c4e3d5309c56e32a0b7b88031c24276937bfa", size = 16415, upload-time = "2025-07-31T19:44:19.835Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/2c/f1aaef2d0fec17de8d045dde2e82884763cf4b959b2545e55ea02805b7d2/mypy_boto3_kendra_ranking-1.38.0-py3-none-any.whl", hash = "sha256:d12dc01a24f4b64471658d9b0ccabcb6f602c2ba237b9ac68d37d12e441de500", size = 20116, upload-time = "2025-04-22T21:27:23.183Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/4e/e054fa622ca5a4280fb8bbcb791a52f2dbd91b0e07f3241530bedb0905ea/mypy_boto3_kendra_ranking-1.40.0-py3-none-any.whl", hash = "sha256:4b4bf67a9ca462d4c5d8c747348e50458fe44c7f139baebbb6294cdedfde03b3", size = 20176, upload-time = "2025-07-31T19:44:18.68Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-keyspaces"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/16/e2d7e4959feb74255ec1f40381493c5c095d6878ffa742e3829efa1549eb/mypy_boto3_keyspaces-1.38.0.tar.gz", hash = "sha256:fe9e8869d8536b9f44a455e037719ec402fea8b27391e7511477cc3ad79521e6", size = 20507, upload-time = "2025-04-22T21:27:28.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/e6/fb5dc4aeffd95c8fb2b5fdcafc818efb3c17d40e6cbc4f0852a915ed83ed/mypy_boto3_keyspaces-1.40.0.tar.gz", hash = "sha256:ee0374dec683745a4cc83cda8a91d15edab6aa4aebcc3729ef18448e6d35f562", size = 20711, upload-time = "2025-07-31T19:44:22.427Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/3d/cffad29b39b5ba9b3c65e48f87304f64d16237252376790a0055a5d7226d/mypy_boto3_keyspaces-1.38.0-py3-none-any.whl", hash = "sha256:68f3431ed7b8659938c403c87d3f42ede282c9f5d1058f4b4dd982491c8c844b", size = 27920, upload-time = "2025-04-22T21:27:26.824Z" },
+    { url = "https://files.pythonhosted.org/packages/01/0a/6bf219ee30d3bc574c36e9b7d34ece54194aa7a21abd06f0b873b69e8430/mypy_boto3_keyspaces-1.40.0-py3-none-any.whl", hash = "sha256:e4391cd2a3388eb2d32b629a38fd1be7dfc46f61fc00d537951e75ddafd1ff71", size = 28339, upload-time = "2025-07-31T19:44:21.206Z" },
+]
+
+[[package]]
+name = "mypy-boto3-keyspacesstreams"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/6e/35f3b828e7a483ca2ac786836b548500bc5411b6a60fe9273dfed7874c91/mypy_boto3_keyspacesstreams-1.40.0.tar.gz", hash = "sha256:c73360c0152717f75f4f6ca2462e90ad16e1f2af60a27b9524c803cd5cda6fa2", size = 17370, upload-time = "2025-07-31T19:44:25.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/de/95b784c993445bbc88d2356ad8925257e214ae4cd7325424a81e3f0c37bc/mypy_boto3_keyspacesstreams-1.40.0-py3-none-any.whl", hash = "sha256:dbe758c01400074b37fd2cff6d9d4c61270f593922b7c683f0757c28d2b93d08", size = 23008, upload-time = "2025-07-31T19:44:24.45Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-kinesis"
-version = "1.38.8"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/33/ed686441c535fb43bccd3b63fee86b2538bbf0ec14d4aeb145ac24267db5/mypy_boto3_kinesis-1.38.8.tar.gz", hash = "sha256:3932c77f3fc8c375454f3dfa71e1e2f18545d95c854dab57dc9c3ba6b561d928", size = 22824, upload-time = "2025-05-03T00:52:27.213Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/ea/b1ccfd706bc5ccccf4a88e324c2426b7fd9dabd7cf4ed07206840572713b/mypy_boto3_kinesis-1.40.0.tar.gz", hash = "sha256:4f74f715e23a8dce062b40f6a4f2ff1023cec6f41b4521f0bc15679883a7e68e", size = 22884, upload-time = "2025-07-31T19:44:28.871Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/b9/88373f4a06b804c262df8dca1dc9743bd076ff96b98784c8598a1549efd5/mypy_boto3_kinesis-1.38.8-py3-none-any.whl", hash = "sha256:0dd7ea2e5ff953d6e32dcb792747df86521cb95e1c4ccb547552694a49f9861f", size = 32693, upload-time = "2025-05-03T00:52:22.119Z" },
+    { url = "https://files.pythonhosted.org/packages/da/48/f3ad4872914241fbdb9f88a3191d12862188c1be1eafb3190882316c9efa/mypy_boto3_kinesis-1.40.0-py3-none-any.whl", hash = "sha256:5edd790730bdeca17c5287acbec04d8930b6adf34dc4f48854330f7092484984", size = 32743, upload-time = "2025-07-31T19:44:27.151Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-kinesis-video-archived-media"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/fb/cd/f33762fce9e1018009d9b9ce5561424b602c30d096aed472bdab6708b1be/mypy_boto3_kinesis_video_archived_media-1.38.0.tar.gz", hash = "sha256:70adb7a1207e84f4018946f901f20d6e4487bd2c08c2ae2cb49a451e3b94b562", size = 18286, upload-time = "2025-04-22T21:27:33.404Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/52/ffb69c992562258b705b283e8b6f9d62ebf3533a3a0dda312ce813bc2535/mypy_boto3_kinesis_video_archived_media-1.40.0.tar.gz", hash = "sha256:8a17f189583f4f7412e0d68bdde139281f4aa8b40ee1a50817be8b7c83e73a65", size = 18310, upload-time = "2025-07-31T19:44:32.054Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/d3/84aae7933478d180701ba58b97192068f064f42f84c149134e44547b114e/mypy_boto3_kinesis_video_archived_media-1.38.0-py3-none-any.whl", hash = "sha256:eaf91a910c8f06b5797003818ccd96878629abb1678d6a1dbaacce195c9b4ec6", size = 24870, upload-time = "2025-04-22T21:27:30.954Z" },
+    { url = "https://files.pythonhosted.org/packages/61/78/59f3c21bb438985ce42406ce905c3429d098045bb6776392a6f66e6a3eef/mypy_boto3_kinesis_video_archived_media-1.40.0-py3-none-any.whl", hash = "sha256:14f1f84e0b69a56d4a493ce2d876088e9e1bd15f3ebd7a132d91cfb0b6ee07b0", size = 24929, upload-time = "2025-07-31T19:44:30.624Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-kinesis-video-media"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/24/6fa5be27d639279d25fc44f0646e830a57add310312416e9028ee5482d29/mypy_boto3_kinesis_video_media-1.38.0.tar.gz", hash = "sha256:86e0aedcce0b0b08e6f57efcd09efebe5f382181cb7b0786de2af5cb7aeb6171", size = 15371, upload-time = "2025-04-22T21:27:34.37Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/87/c91833d2e94ac7b3e44fe32c833f4698b62e47264a08a77ec21e2a731bae/mypy_boto3_kinesis_video_media-1.40.0.tar.gz", hash = "sha256:3aa1f034c78ba3ccb527d0a5a1f65cd9bf28afd2cbf595baeaa20eaa704f1384", size = 15392, upload-time = "2025-07-31T19:44:34.78Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/50/181f8ce421f41a403ca8ace19a1518e66c8beaa5475acdb03bb85f43bd38/mypy_boto3_kinesis_video_media-1.38.0-py3-none-any.whl", hash = "sha256:4b03ecca47e44b16fa483055a30434f5b25472b2c7adeeac2dfe90de7f473798", size = 18516, upload-time = "2025-04-22T21:27:31.455Z" },
+    { url = "https://files.pythonhosted.org/packages/21/fb/725423ef80e38853ba0481c01613c16a2e4e328f9e7a1fbb447ad64759fd/mypy_boto3_kinesis_video_media-1.40.0-py3-none-any.whl", hash = "sha256:e243e36d215e871cca9ec0aedb05966b7b386013af243d1244f6b78f5063d401", size = 18575, upload-time = "2025-07-31T19:44:33.416Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-kinesis-video-signaling"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/22/9fd63663463dd908decbc5f35fa274c3b1f34b5f6517e553e25891782eef/mypy_boto3_kinesis_video_signaling-1.38.0.tar.gz", hash = "sha256:0e06ce9cb14f35da3cb1d3528adb276e427001bdf2924208e0cc14f49994f640", size = 15494, upload-time = "2025-04-22T21:27:38.647Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/21/0102514e4f4a394fc6d95b25eb83aa10d276ae3ea9baeb24d4a27b2e05bf/mypy_boto3_kinesis_video_signaling-1.40.15.tar.gz", hash = "sha256:dd7c19b234a242679deccb33d871cfefdea263dc769d2c9de9a320964bf72dfa", size = 15579, upload-time = "2025-08-21T19:43:35.388Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/13/1d2b0808dfd8e484909b0affaa1eee57f53cf66f131752b49d39f7325962/mypy_boto3_kinesis_video_signaling-1.38.0-py3-none-any.whl", hash = "sha256:02d4dbf5c3f36bf4e030c887abccf47404f57ca95a8b9f8f9d7d270e5880f8bf", size = 18966, upload-time = "2025-04-22T21:27:36.312Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/32/c244aa83e5b538c9f2d3720cd0c7048e94d8d0da9f70b3c1eb580a25ca45/mypy_boto3_kinesis_video_signaling-1.40.15-py3-none-any.whl", hash = "sha256:46dc9e962038f466969eeabead1037526cef242b4c9dacf0eee5979cc568698f", size = 19120, upload-time = "2025-08-21T19:43:33.647Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-kinesis-video-webrtc-storage"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/72/51b19b93097077f97624d1e9eb092cafe7843373b8b4aa38073511d1719f/mypy_boto3_kinesis_video_webrtc_storage-1.38.0.tar.gz", hash = "sha256:a868f8317cd7e63d49d25561f528c62daee6bed30088c1f2aff8f7ea6544053e", size = 15410, upload-time = "2025-04-22T21:27:39.758Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/5e/86a7cee6f8fabd80dc48af94b25784e5fbfa8d47cc0cae58620cd5c3d532/mypy_boto3_kinesis_video_webrtc_storage-1.40.0.tar.gz", hash = "sha256:7275169097cfc9dec6f429451563571c5c2e4aa9937141f096e3c1785e2a3bca", size = 15420, upload-time = "2025-07-31T19:44:40.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/b8/7a06f03ad9e0f28336b1b9e4d6b47aa49764c4c6a1863d253992dab64886/mypy_boto3_kinesis_video_webrtc_storage-1.38.0-py3-none-any.whl", hash = "sha256:e10d5667b7d916782666d577f57bee97df6cf7964304c4541aef75100d3c8116", size = 18751, upload-time = "2025-04-22T21:27:37.078Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/59/316a7e0078a2a2922c85d8b48ca0873e4350033b791a2035befbd93f78df/mypy_boto3_kinesis_video_webrtc_storage-1.40.0-py3-none-any.whl", hash = "sha256:ad9d6a11e022298a4db3f17fa8c4e3b32b147e3bc974ba190b19933e05bd6b9a", size = 18804, upload-time = "2025-07-31T19:44:39.032Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-kinesisanalytics"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/b9/f85cfb3ffbe0f7195b5fcae6581616cbb16f00a05ea71d8272d6699b9b11/mypy_boto3_kinesisanalytics-1.38.0.tar.gz", hash = "sha256:6ef16719e242942cffa03c630d2111e86ba9159805e9fcc630f64be9ff0c2517", size = 18807, upload-time = "2025-04-22T21:27:42.532Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/e5/bc2bbe01a1958939bd034ce0774997f32b26868ff7f5319945c20b3ab268/mypy_boto3_kinesisanalytics-1.40.0.tar.gz", hash = "sha256:f76c5896b777437d47acebc9d5d381fc5db333e0b295d62f64161b1d968eb48c", size = 18840, upload-time = "2025-07-31T19:44:42.691Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/a5/971e7f9f0d6e2e5139146e43bafc8a991c16334476a83f0c4218382518ac/mypy_boto3_kinesisanalytics-1.38.0-py3-none-any.whl", hash = "sha256:9639d3d23026d5d4336bdf18fac24b7496ed6870738e2119a8ceec34b1d84771", size = 23899, upload-time = "2025-04-22T21:27:40.048Z" },
+    { url = "https://files.pythonhosted.org/packages/34/86/1643946ab4af20fd36ad1308436ddf6bbb3c8b17b85aaac0d30799dc3da1/mypy_boto3_kinesisanalytics-1.40.0-py3-none-any.whl", hash = "sha256:5a9755638657c30365264f8d14bf4ef8bec3cba402aeb927f76d091c224f9f66", size = 23970, upload-time = "2025-07-31T19:44:41.374Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-kinesisanalyticsv2"
-version = "1.38.0"
+version = "1.40.14"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/1d/4bd527c9e9de1815b934c8638c49b6592acc1f74cc426e26c368b37e5153/mypy_boto3_kinesisanalyticsv2-1.38.0.tar.gz", hash = "sha256:7ec08847e7305e211dcdd8104c1d8e3d91db73ff832d97d52c1d931d88f1852a", size = 29675, upload-time = "2025-04-22T21:27:45.066Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/e7/02b9926c15c152684d26f63e2fae857d5f14fb5ead79ad9701fc2ee25bb2/mypy_boto3_kinesisanalyticsv2-1.40.14.tar.gz", hash = "sha256:adbf6c7263bbb82f569a29b0a02916c8cd75c9f392647420411db0d4f911468d", size = 29986, upload-time = "2025-08-20T19:27:27.069Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/2b/65daed1a29bab16e503e38034d5a018c3bc6263a1ff2c1438827a6ff9c32/mypy_boto3_kinesisanalyticsv2-1.38.0-py3-none-any.whl", hash = "sha256:a8af3f9f12ab11345d7318a298295e3740c8d0894c7322a3d88aca644ea2b5b5", size = 36199, upload-time = "2025-04-22T21:27:41.068Z" },
+    { url = "https://files.pythonhosted.org/packages/07/b5/f71de4efc7d0eb81bdcb4518df78d6cd568ac5f9cacfae14b182b80eef7b/mypy_boto3_kinesisanalyticsv2-1.40.14-py3-none-any.whl", hash = "sha256:66b9a2eb8be17ef02a696411172869f0554f0a518719bc1fbac613b975ec688b", size = 36612, upload-time = "2025-08-20T19:27:21.862Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-kinesisvideo"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/fd/df/c64cd05f396dfae96c83390274bfb1f71b8ad525d692f9207bc90f95bfed/mypy_boto3_kinesisvideo-1.38.0.tar.gz", hash = "sha256:3ca385fe37755a3cfc942c1b09de1c7c7792b64bdc0e142eedaedba476a2ce05", size = 21725, upload-time = "2025-04-22T21:27:48.092Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/8f/cd16112913a684604bc1cbe558b5c12c5c42c4a25d72fc548d67f1ba46e3/mypy_boto3_kinesisvideo-1.40.0.tar.gz", hash = "sha256:c4d3759445316cb22cbb0d6f7d8d07724cb3da8ccfbe2213c2a8f7e7d87272a1", size = 21749, upload-time = "2025-07-31T19:44:48.101Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/b6/bcffa84cac1c9e6776c6a8608f00112233ae89997d7da5a6bfbf16d2ba8a/mypy_boto3_kinesisvideo-1.38.0-py3-none-any.whl", hash = "sha256:f8d97047547434a4525d60cf0461b0df8d37a70c04e49eefd897bdcf7dbe938b", size = 30237, upload-time = "2025-04-22T21:27:45.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/28/0957874c5898a0c8e1ff931aca280e7cf0be7d1c01555bac3c1949578feb/mypy_boto3_kinesisvideo-1.40.0-py3-none-any.whl", hash = "sha256:34310e1120b73c781661c08ec846b2f429305ccc0c1208c5dbebfc1b80881e80", size = 30289, upload-time = "2025-07-31T19:44:46.151Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-kms"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/15/df7c11e19489cb7d3a1c5285cb439c67bb18ea23b90e09a7f0d4c252b23d/mypy_boto3_kms-1.38.0.tar.gz", hash = "sha256:b350fa9b3ab94fb1bc8e6da7c54afb2aae90793de80c1385e3269f6a10fe7eae", size = 30011, upload-time = "2025-04-22T21:27:49.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/f1/038851407812eac7e61deff56c3809d4b7ea8eb17d413dc7a6f34b0360eb/mypy_boto3_kms-1.40.0.tar.gz", hash = "sha256:9fab57be0cb5c4a6e00855b5627c7437980684b486d86693a85f8d7f594a7e0f", size = 30414, upload-time = "2025-07-31T19:44:50.643Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/d0/6c59e403d52827ea6242026f6382cc670650fa511cee77c362b4e9f49d0b/mypy_boto3_kms-1.38.0-py3-none-any.whl", hash = "sha256:52b079f831927fb39751f51a0886139e0c4ba7f743c10521131e03ecb63e966c", size = 37589, upload-time = "2025-04-22T21:27:46.996Z" },
+    { url = "https://files.pythonhosted.org/packages/58/bf/375bbd4e14f9930cdca562343aa6ff2ca85a9ac5497a2926d315a655f8ff/mypy_boto3_kms-1.40.0-py3-none-any.whl", hash = "sha256:287868874a9d88c47a5e3b41ec312ac2657dbc250638ccf5ced1a99610c7511c", size = 38200, upload-time = "2025-07-31T19:44:49.023Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-lakeformation"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/51/1f87495c7f48037151a721ab4ba9c27c15b76eb8205e61be5c745eaebe81/mypy_boto3_lakeformation-1.38.0.tar.gz", hash = "sha256:0932699d6fa98cd02be94f753fc03425d12317301cdf534629be347f16238524", size = 34956, upload-time = "2025-04-22T21:27:53.038Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/ce/00b93306b024c45bfb9c59e8b50eda51c199947ec9a18eb28474df0f2e6d/mypy_boto3_lakeformation-1.40.0.tar.gz", hash = "sha256:52f4e83fcd5bd972f7dea443dde2d31aae42910fe838bd737335fae226f390b6", size = 35054, upload-time = "2025-07-31T19:44:53.674Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/01/e6244ac0792b5295d8a7950b333ec84302ded5a3524d66ac6307e55f09ea/mypy_boto3_lakeformation-1.38.0-py3-none-any.whl", hash = "sha256:9bde23cf53fdc4beb5076c958df513ba945f588a721ad161649c3754080b8db9", size = 39551, upload-time = "2025-04-22T21:27:50.101Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/be/f5d55caaf7cb36e5e885251da7cdc5bf99d88e5a81351635262197a8358e/mypy_boto3_lakeformation-1.40.0-py3-none-any.whl", hash = "sha256:e0ec896f5b46ea75720987e44866900af4eae9d79ea81f39d883d7c4f2f86209", size = 39616, upload-time = "2025-07-31T19:44:51.847Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-lambda"
-version = "1.38.0"
+version = "1.40.7"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/8f/e3/0436071b28942788bdd22d6f91847654a7b1d167fb9d86c5779108e49ee9/mypy_boto3_lambda-1.38.0.tar.gz", hash = "sha256:ece7b3848c045e1be81c4f2b7482002c17ce7cb70de850661146103a8cb1a3fb", size = 41767, upload-time = "2025-04-22T21:27:54.666Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/4f/63def7a5be630e8d39186594b01fee86f2e6dcbca3e0b0e80a3ea90bc4ae/mypy_boto3_lambda-1.40.7.tar.gz", hash = "sha256:e8bedf03a67fade5db861fe902df063064292352eed5f785f74cd0e591948db9", size = 42491, upload-time = "2025-08-11T19:30:54.805Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/09/602a39b39abd0d58d8b6bbee4c1552b64fadba2324676d7d45c3fa00fe7b/mypy_boto3_lambda-1.38.0-py3-none-any.whl", hash = "sha256:0dcb882826f61fd2751f6b98330b0e11085570654db85318aea018374ca88dc9", size = 48210, upload-time = "2025-04-22T21:27:52.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ef/ab7a0fc83b8f3c39145cbce4a8bf5326e153157f0edcc939b4570e0b9f9e/mypy_boto3_lambda-1.40.7-py3-none-any.whl", hash = "sha256:398c9dd051278430168e907b6b6c2078a3a1bca3948c2bf4d47eda8d7da28573", size = 49058, upload-time = "2025-08-11T19:30:51.675Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-launch-wizard"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/b2/cfd929855b44406dd3f67d43151a59664b394dbb5ed1aea806bed0951c2d/mypy_boto3_launch_wizard-1.38.0.tar.gz", hash = "sha256:d5033ed3b2322514250359011b0a0d1919ec8e816e7c915dc28ec5a9d6a4e0d4", size = 18437, upload-time = "2025-04-22T21:27:57.59Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bb/07020142e3cc79031350511f00180a853dd66918b17ee99cdec7b5286622/mypy_boto3_launch_wizard-1.40.0.tar.gz", hash = "sha256:dd9db950bb5f9f763f8dc335293a11c0aee8944f9366d9b3ff9e5ab4fd99b5ae", size = 18483, upload-time = "2025-07-31T19:44:58.77Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/e2/de9449280302bc10f2d0a5603fbd8825af5d6b129ea02031e828da577834/mypy_boto3_launch_wizard-1.38.0-py3-none-any.whl", hash = "sha256:8d521fd5c01bb871d3b80b1658ba7c476fe2299ad5a59e68385196f1e4e53f34", size = 24363, upload-time = "2025-04-22T21:27:55.296Z" },
+    { url = "https://files.pythonhosted.org/packages/88/2f/3068846ce91114277dbce22320facfd45cc29ed5c58a220c4d503dce9b69/mypy_boto3_launch_wizard-1.40.0-py3-none-any.whl", hash = "sha256:7baa9bb906a90dd2a5ca1d7c8ed8d195c2fbae81b1f1cf1b090efa6b032a1339", size = 24418, upload-time = "2025-07-31T19:44:57.473Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-lex-models"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/70/48/9366ea8f082011c833f26e155d2af2da0689ffe2010245e135210610b4c4/mypy_boto3_lex_models-1.38.0.tar.gz", hash = "sha256:6f24be1d59fb3557d41f4ccb3a4c8817963dd5d8010362ee7ce5f3eae9251f67", size = 30287, upload-time = "2025-04-22T21:27:59.187Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/62/94c0576dc70e2ea4f7859635e7814bb9f0c0dafd5060256b3adc3199b5db/mypy_boto3_lex_models-1.40.0.tar.gz", hash = "sha256:3a32138ef85b76a05cf4232f696cf222ef8e6c5893176b5f4a9b10f775beb01c", size = 30307, upload-time = "2025-07-31T19:45:01.597Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/5c/676588f01757a55137d9d1c7371211841624b1d6f61890cbb870eed57ca1/mypy_boto3_lex_models-1.38.0-py3-none-any.whl", hash = "sha256:1b1ffa3c213465c2d49331d1cadc539433288c7f03f196f14a86cf3da93fa1c1", size = 35102, upload-time = "2025-04-22T21:27:56.897Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2d/92d3534df251a382535de4e3ab7fcdea959b2d733f3ba734ef3d7b54b83b/mypy_boto3_lex_models-1.40.0-py3-none-any.whl", hash = "sha256:55b8efc39e892addc7a3a92cf1580222f242767648123f8f86932a64b83e29fb", size = 35155, upload-time = "2025-07-31T19:44:59.756Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-lex-runtime"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/ac/be/81ec6ba990abf645d34c155635f3e437304f4447a802c061a8dc948ddad3/mypy_boto3_lex_runtime-1.38.0.tar.gz", hash = "sha256:d766c6b32bb4bafaa732ea2b8175c8b4329ded453bdbf6ba58c29b6377831e2e", size = 16733, upload-time = "2025-04-22T21:28:02.442Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/28/ff5a3049b39324b39e4216455cb2b13f1f87b5756fe2f797cfecd3ebb777/mypy_boto3_lex_runtime-1.40.0.tar.gz", hash = "sha256:768ca715b6fc898887fc9efe39179ca7ccf4fcf1498f19671dcabdebe8aa1d5d", size = 16767, upload-time = "2025-07-31T19:45:04.663Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/e2/1668cc13870a89f39b0b048e8149fdec21d666eb3a288e853ae147795863/mypy_boto3_lex_runtime-1.38.0-py3-none-any.whl", hash = "sha256:fa9b57592076fd4a501b53226e8697b957fdbcc1dc11afb1ab36dbe6f747fa2f", size = 20845, upload-time = "2025-04-22T21:27:59.691Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/1c/62a9cf550b6195311b6971d81d4f0250c37bcc374144da1b945bd94b40da/mypy_boto3_lex_runtime-1.40.0-py3-none-any.whl", hash = "sha256:93065e464aa252fb3d0e382675429506940a9e1feeba3e43403c439f51a3e46d", size = 20905, upload-time = "2025-07-31T19:45:02.573Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-lexv2-models"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/70/37/0c547422bc9cf262e06cbf9f2aebd3dd6aa64da8cc5333c9497cbb7f6e0b/mypy_boto3_lexv2_models-1.38.0.tar.gz", hash = "sha256:be69704ec476ad07b72f3a1e40a26116b5b1bc80f6c7286477372fc4c9f822ad", size = 59550, upload-time = "2025-04-22T21:28:03.934Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/f0/964f2067e5d7647d99b099ceb99c8726f1e2f165115d09549ae8e477bb82/mypy_boto3_lexv2_models-1.40.0.tar.gz", hash = "sha256:16041a956bc73b46738acc3d08b28829e35c8438790cc1e3a2cd8e2325eda38d", size = 59628, upload-time = "2025-07-31T19:45:07.811Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/01/1da78a7d19632c2a319f7a9af226d133f166b7ba506a8c8370d93d8e526b/mypy_boto3_lexv2_models-1.38.0-py3-none-any.whl", hash = "sha256:ed73adacfb5790b4063a107584c2545e65c8c463a34c1929e39fb4660f304ffb", size = 65644, upload-time = "2025-04-22T21:28:01.055Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/804a6ca9ecd5622a82055e5c1b5e16929332b24cb2ed489be3779beaa92e/mypy_boto3_lexv2_models-1.40.0-py3-none-any.whl", hash = "sha256:7445a78325009cdaa1cb40750fb892629f9a3bef4182f6505ee5425237b56e5a", size = 65747, upload-time = "2025-07-31T19:45:05.809Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-lexv2-runtime"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/93/37/8669928fd437afe660f30a8831d3e6d83d39ba78370fea1ee7ff535a443d/mypy_boto3_lexv2_runtime-1.38.0.tar.gz", hash = "sha256:84731945e2c7d89daf81d9040964445c0a7fd993a8252ca7654f1ea5aa42d7cf", size = 18528, upload-time = "2025-04-22T21:28:07.128Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/92/3e6e951927aa4aec77c8b353232171a93f7178c7136093739c48d1d5e5e0/mypy_boto3_lexv2_runtime-1.40.15.tar.gz", hash = "sha256:ef92770cb06c7fbd0feaeafc5f207a886131cb3a2cac76dbf36a3b463139ff73", size = 18561, upload-time = "2025-08-21T19:43:36.445Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/98/ee5f47629e55016fcc7da778d98c3f19dd4c109dd70cc489f240a7785c9b/mypy_boto3_lexv2_runtime-1.38.0-py3-none-any.whl", hash = "sha256:2dc21e557a1e2d2997353400d7edfba51bdd51b51dca84bfa49ef50be802fcb1", size = 23859, upload-time = "2025-04-22T21:28:04.491Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/51/03feb386b074422c492e992a75f128f2cf50a6ac3582ddfa4088551a4895/mypy_boto3_lexv2_runtime-1.40.15-py3-none-any.whl", hash = "sha256:46f89c1c754328deffa0ee46ceb209413a96752d24049bd856f8bcdd7bf28f55", size = 23983, upload-time = "2025-08-21T19:43:34.11Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-license-manager"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/25/27/ad84bb9cf9642d29b8ef5aaf10508508533977b29bdd8123903585417179/mypy_boto3_license_manager-1.38.0.tar.gz", hash = "sha256:8c3166f95eec4d7fa841e5adf1a896e323761de5f3f1f4aef598c89ffbcda228", size = 31656, upload-time = "2025-04-22T21:28:11.402Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/aa/c48fb02012cc01bdf6ab101b330774722ab96800b50c512886f180fb84df/mypy_boto3_license_manager-1.40.0.tar.gz", hash = "sha256:f407ded36d2cba23f5e0396fbc61134fedf09547cf582dea5bee3b480c701ee2", size = 31908, upload-time = "2025-07-31T19:45:16.579Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/1e/dbe17e2b2ad54b2c6ec95321142f377a87eb80f289963308ea2c491a93b9/mypy_boto3_license_manager-1.38.0-py3-none-any.whl", hash = "sha256:5a91d3ea5f89918f60a86507a8d1cc07de49404ba41add548c25e5ea24bbc99b", size = 36196, upload-time = "2025-04-22T21:28:09.021Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2e/f0bf51911828a3e34ede5997ec2cbc8bac6b415a562f1a6e4d225b454f5f/mypy_boto3_license_manager-1.40.0-py3-none-any.whl", hash = "sha256:4df73ff2a12f0c2c8869e937512c84af9a17d4003cf49ff6e59833092a085488", size = 36465, upload-time = "2025-07-31T19:45:15.102Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-license-manager-linux-subscriptions"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/c0/5e/eb8a89fb7f2f67e44f3eb0b4595b7def55c97b2aaa53a4ecae143e6611c3/mypy_boto3_license_manager_linux_subscriptions-1.38.0.tar.gz", hash = "sha256:bc21897653a4bc926a715b86e97c382db4c190c38bd48e88643122ed4cb32d65", size = 18732, upload-time = "2025-04-22T21:28:08.455Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ef/3f865a18ee110fc2609922910c1eb04b1f5593366e36cdd7eb912b283c68/mypy_boto3_license_manager_linux_subscriptions-1.40.0.tar.gz", hash = "sha256:a5f2104bd6acd361a6e261d4737ab780c2911f3fb04ff951287594736ba0b75b", size = 18779, upload-time = "2025-07-31T19:45:13.911Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/f5/5ad04572f8db45ce1c3f00bed85d45d4df28b34d55125e350c16950caa46/mypy_boto3_license_manager_linux_subscriptions-1.38.0-py3-none-any.whl", hash = "sha256:e266bca54fab67e51e199586e281bf86b50357de46e221260ac14cf44f5b1af6", size = 25532, upload-time = "2025-04-22T21:28:06.245Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/5b/3d47f1b3d4ef3f3f1405fb7d767b2f6c2306b01fe0c97794438f03c8cdbf/mypy_boto3_license_manager_linux_subscriptions-1.40.0-py3-none-any.whl", hash = "sha256:94c8c5f61c00968125d062ede8cc0b5c6b8f9b5ddc4a14e9b646dd4fad6c54e6", size = 25595, upload-time = "2025-07-31T19:45:12.479Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-license-manager-user-subscriptions"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/c6/7c/719adb35e83d885de06efbfb4fc6036e5ca2c29b235f64c0dd04e6f78991/mypy_boto3_license_manager_user_subscriptions-1.38.0.tar.gz", hash = "sha256:e04fd324ae6259a43f753d3c4db31af5e6de0811b69cbbb583335bd727eee71d", size = 20446, upload-time = "2025-04-22T21:28:12.686Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/37/59a0b9d0f58078a4db00e443f00ad6b7a39db01e0205f2af43a6ce78b6a3/mypy_boto3_license_manager_user_subscriptions-1.40.0.tar.gz", hash = "sha256:4a4721f346fdc4381c2f0ab6086ad2f311212993c4309193eaa07d7f46795f06", size = 20480, upload-time = "2025-07-31T19:45:20.582Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/29/30f98f7ff57073c0c42e267ecb6ffbd124155b37afbaf09dfe476b5d4a59/mypy_boto3_license_manager_user_subscriptions-1.38.0-py3-none-any.whl", hash = "sha256:5694e268e0eda0b4d9fb8699ca4accb2c2a893ba5ca5d279224812bcd3cff860", size = 28292, upload-time = "2025-04-22T21:28:10.406Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/8a/77650f8660de67d35e42e3c13f18f0999970b5292ca4ce441ad32bc524a6/mypy_boto3_license_manager_user_subscriptions-1.40.0-py3-none-any.whl", hash = "sha256:91caa886d88c2fc169773bbceccb0bc90ea22d93ec85c6a51a5f0d13e354ef17", size = 28346, upload-time = "2025-07-31T19:45:18.069Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-lightsail"
-version = "1.38.0"
+version = "1.40.1"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/16/4c/660e92057346d2dee166330255260ac92a82f1e86a0a730e720bddec38c7/mypy_boto3_lightsail-1.38.0.tar.gz", hash = "sha256:0833395e83e9b797eb0e2a87de9c46d557ba1a8b9c0403c7d6907a4cf89176fe", size = 66039, upload-time = "2025-04-22T21:28:16.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/91/5943e62c4ca3500e0f4eaeac0cac3b3bd88af6501210422ef215a015c897/mypy_boto3_lightsail-1.40.1.tar.gz", hash = "sha256:d7ed5420dacbb81c10ac1c608cb588e31245ec68900e21c8e8e8c1e8a91cb7e6", size = 66127, upload-time = "2025-08-01T19:29:21.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8a/2e8b8d20eaf2d24ad4a99328db1e6ced01a76906266cf6cf82f175ce383b/mypy_boto3_lightsail-1.38.0-py3-none-any.whl", hash = "sha256:61594ee6a70d7ce9081c2fb411a65bccf14f68901071957b8fa455509edb901a", size = 74287, upload-time = "2025-04-22T21:28:13.277Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ec/afddd5bbf9e6b25c988d2383e47c88d69f9eb6167530ef93d98c47c00870/mypy_boto3_lightsail-1.40.1-py3-none-any.whl", hash = "sha256:39985aa83a928b16c860ee9466bf1d82ef723376cace44a8cf181c18f7ae11d8", size = 74391, upload-time = "2025-08-01T19:29:15.888Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-location"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/f2/62b7f835dd5d9b77248e5f45a88885fc4c65f5aa6bdfe34a6f6f74663c23/mypy_boto3_location-1.38.0.tar.gz", hash = "sha256:bb2a4a5b70aa8fdf122de5a64b009754a84aa5759712fc1d51ec6aa858177847", size = 35805, upload-time = "2025-04-22T21:28:17.903Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/86/19ee6ffd6fbbc733c406e83376292c101648dac9aadad1677791322ceac2/mypy_boto3_location-1.40.0.tar.gz", hash = "sha256:8405142ea55118fc3422bd1753285112a4fc0bc03df652441989f89c0c675bb0", size = 35986, upload-time = "2025-07-31T19:45:29.544Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/84/b2765b515ae533007c104f1ddb616df103d3070ebfae029f676879c9a8bf/mypy_boto3_location-1.38.0-py3-none-any.whl", hash = "sha256:9b83c9b97127040f3a9332c4218d0c3af4bcfae3f221d1ac8cdb2ac6528d6484", size = 40325, upload-time = "2025-04-22T21:28:14.603Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b1/308a5825734fa908ad1f70eb6c63c67421a810a20023cec29d32dbca306e/mypy_boto3_location-1.40.0-py3-none-any.whl", hash = "sha256:10de5136093e08dbc1ae555db44be50471cf1dff0ff3faba4524b8c52a242607", size = 40537, upload-time = "2025-07-31T19:45:27.336Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-logs"
-version = "1.38.13"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/ab/5f/c2e8fdd37bcfaf6589ccf1dd4fb9795129bb4e038a7a5fc49dce4a0e68ba/mypy_boto3_logs-1.38.13.tar.gz", hash = "sha256:54e9047200e7e06d6fd4307f05eae0e723fe3d851fed805f43e4f8caf013541b", size = 45371, upload-time = "2025-05-09T19:42:12.332Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/39/04226e710cc4682987f6ca0537b0d41bd20ceca9926947bb3a26b3ae030f/mypy_boto3_logs-1.40.0.tar.gz", hash = "sha256:780648820c4fe8c2453a39a8044443435b4969f69ea39ce538ba5b2225cfd513", size = 46369, upload-time = "2025-07-31T19:45:33.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/0e/658665ec45a8330aa289d8f479791b2fe173927088189ade34d33e263e84/mypy_boto3_logs-1.38.13-py3-none-any.whl", hash = "sha256:12d3a1cc9a17fa8c4f53fac25f5bde116bdb0087fce36d3a91befeb2d418deb5", size = 51185, upload-time = "2025-05-09T19:42:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/12/c66f68dd01675ca76388b678b42c2d4a2aac0c483015614a43026339c63b/mypy_boto3_logs-1.40.0-py3-none-any.whl", hash = "sha256:70c8d13772cd9ea0924508b8e16db83f22b043e2897ff881e9a6d0b282664634", size = 52243, upload-time = "2025-07-31T19:45:31.47Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-lookoutequipment"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/00/c42b93af6859948942d07860d7c1dedd9e88f967461d9dea03878f065153/mypy_boto3_lookoutequipment-1.38.0.tar.gz", hash = "sha256:7284d8d45441d6498014bbc75d40ad0f4e0b94849368678815c09ed07bb18355", size = 29009, upload-time = "2025-04-22T21:28:22.724Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/55/1dfaf3c856b0db4cfd01fa3dd8d7680c1fec4f9ef3b9fddfd190be47fded/mypy_boto3_lookoutequipment-1.40.0.tar.gz", hash = "sha256:44401e03ba8ac2293c70a93d599a0e706dae64bb4514aaf88d345d02ef74d9bb", size = 29036, upload-time = "2025-07-31T19:45:37.737Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/06/ab46ca7f828dff84ae193c076097a5b0d8298b3344b4ce07a0d95c82742c/mypy_boto3_lookoutequipment-1.38.0-py3-none-any.whl", hash = "sha256:d84a772e2bc5720e488007e886ac443b653d06acaa9a408a9af96a7e75f47b06", size = 31594, upload-time = "2025-04-22T21:28:19.861Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/64/ec003d1a657508b4decf8ea9fb1b65959eec2a2e4a1c73ff317fc2f0bd5e/mypy_boto3_lookoutequipment-1.40.0-py3-none-any.whl", hash = "sha256:e2ed723692c6f1d58e14c2f43ef4548bf7c69efc8fac2fce4b6f7afbfcddb182", size = 31643, upload-time = "2025-07-31T19:45:35.545Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-lookoutmetrics"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/e0/9c03774dd39543e7f69bce718fac87b35cce2a943a506291256b59baf360/mypy_boto3_lookoutmetrics-1.38.0.tar.gz", hash = "sha256:e0afcf4a173e9646ba497abbebed3f10c349c8a1f4d7a6e2a641b0d14f13cb5f", size = 21420, upload-time = "2025-04-22T21:28:25.744Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/e1/3d4eaf4a5469db54c7849234096577f6dac35453408838798050c7306ff8/mypy_boto3_lookoutmetrics-1.40.15.tar.gz", hash = "sha256:65c2f5b191a5724a991610aa4d9c0c7a084ff0af4779ed598b737ac196fd86db", size = 21488, upload-time = "2025-08-21T19:43:38.756Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/4f/b22732c8729baedbcbd5f702579c62606b756ec4070ef38d7a2fc0a60ed9/mypy_boto3_lookoutmetrics-1.38.0-py3-none-any.whl", hash = "sha256:32892d7205788b95d0e447fd775fd5633045a1cb5a904c9b5c0317df6b6be4ab", size = 28461, upload-time = "2025-04-22T21:28:23.683Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/78/07b34ff892a1a111668ef8d2f3be07bfcbbd63c6163a33a2ceb84612e758/mypy_boto3_lookoutmetrics-1.40.15-py3-none-any.whl", hash = "sha256:6cfb9f66c09df0fd1a986be88cd25bbec783119cebae62a96015b8ab64fc2b54", size = 28590, upload-time = "2025-08-21T19:43:36.927Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-lookoutvision"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e1/f8/b5d0df2f216d7d9e7cd5917beaf100ef9c63a838d87f1dacee9f2a184c98/mypy_boto3_lookoutvision-1.38.0.tar.gz", hash = "sha256:d5658daa209e80545388334b90c63b6937ffef5ff0c8b449c2bb295e0e4cf4a2", size = 20484, upload-time = "2025-04-22T21:28:27.17Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/5d/87cb1c34042b4587324e563a9b966ea9fabe01205caf37432f4fe2b8f589/mypy_boto3_lookoutvision-1.40.0.tar.gz", hash = "sha256:28f3818a9b4e0b2c07c77f948fa189bd9cd5689da8122adf41711b888ea289c1", size = 20522, upload-time = "2025-07-31T19:45:45.49Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/c1/1f14d01ac9fe32acc21d28b516e7a3ea2a97d6b2898e743c3be065c38476/mypy_boto3_lookoutvision-1.38.0-py3-none-any.whl", hash = "sha256:a2ea84b377f28288c2bb7a8ff9961a32868553b795346560c3a52324b665649d", size = 27863, upload-time = "2025-04-22T21:28:24.885Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a2/c213715a88f754a36778f8c81cafccbd26535f8c360758ef91687d44bc2f/mypy_boto3_lookoutvision-1.40.0-py3-none-any.whl", hash = "sha256:6b056880e6627d73411de62bf6fc4cf395b5af5789dc8429fa1ca0c91e33e594", size = 27920, upload-time = "2025-07-31T19:45:43.314Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-m2"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/7a/7d/b1145c5b7fa3543fd626eb7b591db84a1d1dd89eab8a26334ef78a23d163/mypy_boto3_m2-1.38.0.tar.gz", hash = "sha256:9a3e0c0e036238895f5757dd090636419677e98b57b47074bb3accf679da10a5", size = 24618, upload-time = "2025-04-22T21:28:29.751Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/2e/e693a2393366c0e4fe33ae7603525ac2dbf95f40d2eed52d2319e5f69e33/mypy_boto3_m2-1.40.0.tar.gz", hash = "sha256:77b2eeae44b36db5ea6095e73ac42dc697120e7636d0ee6401239564939bb7e8", size = 24655, upload-time = "2025-07-31T19:45:48.057Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/c4/598fd16dd661d74c949adb404e52bd07abc0e9231b714c2b75fdc7cb092f/mypy_boto3_m2-1.38.0-py3-none-any.whl", hash = "sha256:3739048874ff09d6911f51fa620c67afb2194112d62dbe00102dd5922b0f07cc", size = 34238, upload-time = "2025-04-22T21:28:27.676Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ae/3de157bc6b0a4b6365e2de56cafa2879e9f2a47c391fc07e2171e8a2e34f/mypy_boto3_m2-1.40.0-py3-none-any.whl", hash = "sha256:08ff9b59a48e555ce953a25457f04d4d3dd3ecda3dadd564e3d03141b23cb42e", size = 34287, upload-time = "2025-07-31T19:45:46.67Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-machinelearning"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/fb/711cdef750e57606e28e0ad643dfe65d8308e4ce6c240ab225251415ccd7/mypy_boto3_machinelearning-1.38.0.tar.gz", hash = "sha256:b7598e0d77246c08fdd698a4610b50a1b32adf1c588fba89a1b382ebc9ccc046", size = 22609, upload-time = "2025-04-22T21:28:31.211Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/db/f6a2abf3180c2340cca205e4dfe5aad3038a1645c7b7d75929c2221d750a/mypy_boto3_machinelearning-1.40.0.tar.gz", hash = "sha256:f06516d7986199354c1d48846ba1b7f37f59f0ef9551eac161537b9551075238", size = 22650, upload-time = "2025-07-31T19:45:50.654Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/c6/38b37989e79aafd8774936d19792c859b40cc93654ad0b0f8f3a9600a91d/mypy_boto3_machinelearning-1.38.0-py3-none-any.whl", hash = "sha256:3aff947da067e0dc2e190bd4dab4ef2c4e228da954e3751b6785ef557500787b", size = 32565, upload-time = "2025-04-22T21:28:28.999Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4b/1c49a8d01a0ec13ed4ad24b4272e41124b9af28f80699fa92c3e1f81d387/mypy_boto3_machinelearning-1.40.0-py3-none-any.whl", hash = "sha256:c3f58fa2b01ee476d9985dc80b11a89a32a20d7f6313f07b8132094f84f7e8bf", size = 32617, upload-time = "2025-07-31T19:45:49.049Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-macie2"
-version = "1.38.0"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/06/3bfb395b06e2d59e515598e144b11bec37a1ccce2dc1ac0c5ae91744941e/mypy_boto3_macie2-1.38.0.tar.gz", hash = "sha256:0c291679929dd11aa5eb6af311c028087c6dab09600417575112d539cbf23d16", size = 49732, upload-time = "2025-04-22T21:28:34.772Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/c8/d1f9b1c39fba2a86b20f8cdc3926fefa117aa51f4830d472d81ad2d2168d/mypy_boto3_macie2-1.40.16.tar.gz", hash = "sha256:24a198e7bdca46de575a02d570dbe53604dd1581c2ed08ff60d71d383994174d", size = 49777, upload-time = "2025-08-22T19:42:47.289Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/cf/8f4f5588c3ee5dc0b06a780d85978fac0b9b18a6e315fc17b4aea0f5496d/mypy_boto3_macie2-1.38.0-py3-none-any.whl", hash = "sha256:62155315eab735a94a32e0976cf0ae779fee69474d6b2a3b4b11e4975e58164f", size = 58330, upload-time = "2025-04-22T21:28:32.191Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f5/925b8a80fea82de9ee94fe45aec5e0f6dc9601e36922bbcc1def746df339/mypy_boto3_macie2-1.40.16-py3-none-any.whl", hash = "sha256:a79ff85c641b0d87cec88e4196d3ee45dd9eae9d07f4436c3fc6f7dcced4af76", size = 58463, upload-time = "2025-08-22T19:42:41.946Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-mailmanager"
-version = "1.38.6"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/5f/17/846e947a44189fb2a94887d2231af972b2d1d17941694ba82b312520f3a3/mypy_boto3_mailmanager-1.38.6.tar.gz", hash = "sha256:f90110053ed6276999433614fb2398d9d201378be9127e6a63d4b5d369df35cd", size = 36936, upload-time = "2025-04-30T20:13:12.448Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/09/28208bd39e5febafc99d7c8beb1a5c99e75bc27bfae29d4ebc357b04c65e/mypy_boto3_mailmanager-1.40.0.tar.gz", hash = "sha256:8b032591e3668a4912e668699fef798cd43ddce9e1ba902cceb2c6e76a69c878", size = 36889, upload-time = "2025-07-31T19:45:56.481Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/5e/d3ef1f8a91cb815b6cb6c7d0190bcb8b08146b51d7a16f8bcb4aaf6e8afb/mypy_boto3_mailmanager-1.38.6-py3-none-any.whl", hash = "sha256:99b1d819450c07556dff1e3548ad3f0421dcfee8f87ed10ebf2ae01812153bc9", size = 42067, upload-time = "2025-04-30T20:13:04.945Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f3/e18238a2c7bfe2a480f7ca5aad887b370be4d320310c782bf092dc7af4c3/mypy_boto3_mailmanager-1.40.0-py3-none-any.whl", hash = "sha256:97708111c835eb92000576098700d75a6fef6189b609a81b579daf803bdb6c81", size = 42048, upload-time = "2025-07-31T19:45:54.82Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-managedblockchain"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/2d/9bdbbb9ca67e6fb9a44c6920ea4aac2bbc2ddc9a034dc00c48d0a6ef153d/mypy_boto3_managedblockchain-1.38.0.tar.gz", hash = "sha256:4ba7199d3c3ef234458e4ace702a070af225a9e2e5911384025697f449e71248", size = 20543, upload-time = "2025-04-22T21:28:39.624Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/7b/5c337664581bd434164cef7c9b5ee1eb3422d70253b8414ae170ac76d844/mypy_boto3_managedblockchain-1.40.15.tar.gz", hash = "sha256:6013415f01b44fb6bcd3938f5d8982bea87cc07b9bb4c1b7416dfcfde082b81e", size = 20582, upload-time = "2025-08-21T19:43:40.01Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/e3/3366aedeb7261f6c395ae039f4c774d668e76649e33bac0badc75af4c8db/mypy_boto3_managedblockchain-1.38.0-py3-none-any.whl", hash = "sha256:3e27b00896c756477403efcf2ea770e53915b92d0d5fcefb24be2a73b90f4a69", size = 28169, upload-time = "2025-04-22T21:28:36.71Z" },
+    { url = "https://files.pythonhosted.org/packages/59/aa/238d5c72253ac6d91efb5ef81d0346a04bdedfca6299ac3c9bcb164d5d01/mypy_boto3_managedblockchain-1.40.15-py3-none-any.whl", hash = "sha256:b67ee159e588c97e3f74c6f67a914d9cbdf946bfe0bbc74d5ac9ef83c3865add", size = 28296, upload-time = "2025-08-21T19:43:37.772Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-managedblockchain-query"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/89/f975f48854b590e708fe912fcae446c001464845c7ba607c3b9b683d7de9/mypy_boto3_managedblockchain_query-1.38.0.tar.gz", hash = "sha256:6fdb76f41a811ec85859bf60fc60fa9e8d4d5d8566b23c18ea49c4f1c2190440", size = 19592, upload-time = "2025-04-22T21:28:41.151Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/fc/e91aeffd742a880d6048a2ac0773c48357235ce28b525233710c4a9b4ea2/mypy_boto3_managedblockchain_query-1.40.0.tar.gz", hash = "sha256:970ecb795abfa3c4452bd3fadaf43b891fa365f1ff38e658d808ab62a0e5b52c", size = 19617, upload-time = "2025-07-31T19:46:01.974Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/b0/95bbcf1614eed54075b6043830d223d2b83434be6a5d10608384505fc755/mypy_boto3_managedblockchain_query-1.38.0-py3-none-any.whl", hash = "sha256:81d67c2653a9828a772578e799435b6a06ae50ff0d1a55bf8e0b0def600db2ef", size = 26718, upload-time = "2025-04-22T21:28:37.997Z" },
+    { url = "https://files.pythonhosted.org/packages/99/c9/ba1a0c5b1113b160f7c2d0cd162efd34244c96dcc93ac9d2b223e4dba323/mypy_boto3_managedblockchain_query-1.40.0-py3-none-any.whl", hash = "sha256:38c5ba65b1703f75ab1f4db7dc8533d204a4a575017a055c55af63cbcf74d5de", size = 26776, upload-time = "2025-07-31T19:46:00.036Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-marketplace-agreement"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/8f/3e/a9a0e7b62d19ab3c068eeae9fec12941cf2fdf0d0253f0ee395623a97c38/mypy_boto3_marketplace_agreement-1.38.0.tar.gz", hash = "sha256:c7a07cdb1337960c6ef1473a8289fe26bfe6a987a76deab96ff327821c08b4f8", size = 16757, upload-time = "2025-04-22T21:28:43.696Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/c9/78e5b107c2630d65f51dde5b4fa327c151d0375363f2a644e6930e6ab8af/mypy_boto3_marketplace_agreement-1.40.0.tar.gz", hash = "sha256:ecee1a398c6f7aa21da61834fd3ae6578f1d4a466a1afe02f0ed5b4d8a2e6d4e", size = 16774, upload-time = "2025-07-31T19:46:04.805Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/69/f70fd89b9fc664b5d3eae63adff07ea25304a1eaa016c68c766e8a0e35a5/mypy_boto3_marketplace_agreement-1.38.0-py3-none-any.whl", hash = "sha256:a6f2ae673b5e4cc045c90a76566ef1dca7af2baa1b2e1ccc7c010e5638347c66", size = 21061, upload-time = "2025-04-22T21:28:41.601Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/45/7ec0654f473be9f1c9055af7b8d7686e405c6e90e4c2e331d2c4878fe6db/mypy_boto3_marketplace_agreement-1.40.0-py3-none-any.whl", hash = "sha256:2552795f50578c56696430d3f4eed375bb843698f680baf319972d1f444f0426", size = 21114, upload-time = "2025-07-31T19:46:03.352Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-marketplace-catalog"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/b4/6f/70a9bd59c6e5640bfa472fb21cb020a715520429ee2193094fd5ada20055/mypy_boto3_marketplace_catalog-1.38.0.tar.gz", hash = "sha256:b612ebe42ee709ae0dc911c8548146c1601f979ef679427867b3f6dace760437", size = 20677, upload-time = "2025-04-22T21:28:45.839Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/81/659706af2c50b9062c94db4cb0893636f2e694c5e856cfae20fbeb85ebec/mypy_boto3_marketplace_catalog-1.40.0.tar.gz", hash = "sha256:0b7dc73230deb7c6610b609496bd3191894b42920e30a8e16ea2b0ec23f3f938", size = 20976, upload-time = "2025-07-31T19:46:07.432Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/76/45795080f98ce9d1fe6b268fd49a479ff26dcee2d6e5a268c2ad786c7089/mypy_boto3_marketplace_catalog-1.38.0-py3-none-any.whl", hash = "sha256:907006c5774a7ec5ed7c7d2fe1b0d7d6c3d6bd745ece34597303356a557741b5", size = 28371, upload-time = "2025-04-22T21:28:42.942Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d0/c1720c06b7d6fe24bf2626f66ceb785228f276a924c0b0649e3a85ff8535/mypy_boto3_marketplace_catalog-1.40.0-py3-none-any.whl", hash = "sha256:fe6285a7de88fd63a6c76b572b63a4395c9b87b118d1a0265af35c3c59e12993", size = 28792, upload-time = "2025-07-31T19:46:05.881Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-marketplace-deployment"
-version = "1.38.3"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/7f/a1/6f119055f257aef1d42720cac0cc570196ac1b95f5214fe8594e840714dd/mypy_boto3_marketplace_deployment-1.38.3.tar.gz", hash = "sha256:474ba0599d116c8c561377a302378fceea704fe9d12cf2e973124a5ddc3a4ecb", size = 15506, upload-time = "2025-04-25T19:25:56.164Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/f4/30143130283f5b599f639e5acc55bb6d4b65c6d870fae292f51771518bf4/mypy_boto3_marketplace_deployment-1.40.0.tar.gz", hash = "sha256:9c77ae28784a3b8683688b6ae7625f4bf9a59310224df80dac78bb9ee517ab95", size = 15544, upload-time = "2025-07-31T19:46:10.901Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/ae/89175eec5835446a074f14602730599c8312c569068370c3f3c138422d2c/mypy_boto3_marketplace_deployment-1.38.3-py3-none-any.whl", hash = "sha256:c6ec3931b034c768716e0c32d98029c766911a660b4cd5a4b7de8bdcd390e103", size = 18838, upload-time = "2025-04-25T19:25:54.943Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/9c/4adc6b3b73f7aa81decdf0bdb38ad971f4965337a7fead29f0f0239406bc/mypy_boto3_marketplace_deployment-1.40.0-py3-none-any.whl", hash = "sha256:69a66cc1e04f1b64242b421d7196f902c2b6093284a8adba0882d50fd6edd9d2", size = 18897, upload-time = "2025-07-31T19:46:09.366Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-marketplace-entitlement"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/1b/edff275e342b2cfdac7b36e98c247dc0e99bb356142b7dbda8cefce84572/mypy_boto3_marketplace_entitlement-1.38.0.tar.gz", hash = "sha256:080d132b56ef3e8f3e03996d4700f391ad49201647421d56ffb51c6427e3e79d", size = 16066, upload-time = "2025-04-22T21:28:50.653Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/4e/354daf56e6c0438722d6d038039010d1ddb3faf7ea547030735461c9fdbf/mypy_boto3_marketplace_entitlement-1.40.0.tar.gz", hash = "sha256:b60160b02b96b080b602445c2d0edee0035bd1e4f0a9f53d375fd75cf45e0792", size = 16076, upload-time = "2025-07-31T19:46:13.177Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/1a/5d5ddef5d11ab7c0d7641105bd17905be8eed192d32f2f8ba1adf88a4c28/mypy_boto3_marketplace_entitlement-1.38.0-py3-none-any.whl", hash = "sha256:ee937d0347f6d4fa4ac6dff92ccf5325e70831c85552ae34208bf43583abcd79", size = 20922, upload-time = "2025-04-22T21:28:47.678Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/52/7362032aa8ccbefc9f1e0e25e5fc2f22dba6e794385e2b5611cd4ebad346/mypy_boto3_marketplace_entitlement-1.40.0-py3-none-any.whl", hash = "sha256:3a1af7485dc9e7db058454c36c1733a29e8cd675b4abce8263c0ed77a27d10f2", size = 20982, upload-time = "2025-07-31T19:46:11.508Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-marketplace-reporting"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/0a/a3/9f066aedd4f1566de79a60ed20f8995cfe9d808c91e15548c019f3a87db9/mypy_boto3_marketplace_reporting-1.38.0.tar.gz", hash = "sha256:8924e0c5d689396394f668b79312466ab8079e59b37917ddeae1d1dda465fc36", size = 15101, upload-time = "2025-04-22T21:28:53.55Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/1b/cde2386b1ef6ecb5c82822bd8114995016931881fc6cb31012730d0d1265/mypy_boto3_marketplace_reporting-1.40.0.tar.gz", hash = "sha256:26327d884a1d1c770c39855a82439fdcb5b96db82d3fbac95e32df03067d5147", size = 15129, upload-time = "2025-07-31T19:46:15.119Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/28/fbd11c95e144c387d4a2399a034fecc060542b06f2139ac0ea159a03dd2c/mypy_boto3_marketplace_reporting-1.38.0-py3-none-any.whl", hash = "sha256:4edf0842525fd0316c5316b3ff63c088801b6dc6edf26d41e072c4e3fb4ce3ff", size = 17999, upload-time = "2025-04-22T21:28:51.112Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1b/4929135608a23af3efd95dbcac39f0666cb92f52b752d113e338684296c3/mypy_boto3_marketplace_reporting-1.40.0-py3-none-any.whl", hash = "sha256:77aae584976e8503529d41593c3138de2e223a4af88fe9e6ef14a9097ebd18d7", size = 18054, upload-time = "2025-07-31T19:46:12.222Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-marketplacecommerceanalytics"
-version = "1.38.0"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/9a/b8ca228707ac609555083cd0808a380082129563323497a24aaad8f1ef99/mypy_boto3_marketplacecommerceanalytics-1.38.0.tar.gz", hash = "sha256:ba64ae706c129df3b01db8becb08d328ee93beabf56ee508ec89c7cbceca1fb6", size = 15847, upload-time = "2025-04-22T21:28:55.189Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/e0/c967935b375d5b568faf46cc06ad18e7f3d4e28c695d7ff65be838a6f92c/mypy_boto3_marketplacecommerceanalytics-1.40.16.tar.gz", hash = "sha256:ee064e7744c1016cb263b83ce545c08e9e26895d3ca9f076d01e98430c37eb4c", size = 15911, upload-time = "2025-08-22T19:42:52.253Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/59/4b13d0ac07a906eebb81ad3a98dc53e22750553c8bf395e6616bdf04f54c/mypy_boto3_marketplacecommerceanalytics-1.38.0-py3-none-any.whl", hash = "sha256:60e4d587cdca9165143b0aa861b4be15ad59fbc6fd123f7ab07fb0ec1a1cb5c6", size = 19482, upload-time = "2025-04-22T21:28:52.459Z" },
+    { url = "https://files.pythonhosted.org/packages/35/95/926c702c5c53b191d02cb60ca07ee58db699eabf0532d9cea1732655eac0/mypy_boto3_marketplacecommerceanalytics-1.40.16-py3-none-any.whl", hash = "sha256:43061ee623934255a6a9d1030ae9c4bca1c98bed4375d6698310addf5877af08", size = 19608, upload-time = "2025-08-22T19:42:48.331Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-mediaconnect"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/97/39/ab9b18fb349670e4627c54605eda89adb6374c96defdaae25415a39fb14c/mypy_boto3_mediaconnect-1.38.0.tar.gz", hash = "sha256:17a62feed8079f382c7a41fb1c9f2ceff2a9ab52626641ecfaa6447b3e6c9d42", size = 36110, upload-time = "2025-04-22T21:28:58.405Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/47/9c7f63fff3ec237d975473090d1031605bbe2125867f6d7eb1125b9b76b2/mypy_boto3_mediaconnect-1.40.0.tar.gz", hash = "sha256:f0451399b1401573bbdb86f19b3c5ad91a28bc6f4bea69b57716cdba96ca2914", size = 36182, upload-time = "2025-07-31T19:46:19.367Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/23/16bc44cce8264e8922da05801b88da5478410182e7946fa09696c1a1c536/mypy_boto3_mediaconnect-1.38.0-py3-none-any.whl", hash = "sha256:78c19e49350d523d8534e6b188a6f8d3fc7ed137d9ac566166319da19fed5e38", size = 41825, upload-time = "2025-04-22T21:28:55.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/98/69afa7b46c446e1871b10157524343cec92d2932a5d5d4508f3fc0eb2d79/mypy_boto3_mediaconnect-1.40.0-py3-none-any.whl", hash = "sha256:1e286c324fad1e1c90ddaa10890e9177cabbdde154d11dd9299a85d6fd801054", size = 41887, upload-time = "2025-07-31T19:46:16.944Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-mediaconvert"
-version = "1.38.9"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/00/30/cde65543da99c2fd38eeeb0d3c7f9de79e15df783d0c022cd77850876761/mypy_boto3_mediaconvert-1.38.9.tar.gz", hash = "sha256:9fac8c133115c25a2b7e4c8f55fdf062c3636d356fba311de8647f4913d308e9", size = 76281, upload-time = "2025-05-05T19:42:20.095Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/1c/2bcf1db18061165fbaa1698fd3562730176ef2ce3c0bb306624335cfe630/mypy_boto3_mediaconvert-1.40.0.tar.gz", hash = "sha256:0c9114e076bc8e957f27c50fe9e99832372ff517d9b759e3b013c3d75ab40542", size = 77075, upload-time = "2025-07-31T19:46:21.914Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/f7/38a6891f774081d7bf85d9d05c44f5bc422c461bd9230727270b120c0562/mypy_boto3_mediaconvert-1.38.9-py3-none-any.whl", hash = "sha256:3bfe74e29e028d8c59b051e61355407645853672f0fe2d4502f829f8cdd629b9", size = 79817, upload-time = "2025-05-05T19:42:16.657Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f8/e2a555e5b146e531c8ae90ca8c4f7cf45db09a1a828638efaf3d277dc241/mypy_boto3_mediaconvert-1.40.0-py3-none-any.whl", hash = "sha256:dff85edcf7abf83c9e62cfc4fb4554c107b29b2648cf39cc9f5baa237d2cfdd8", size = 80619, upload-time = "2025-07-31T19:46:19.882Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-medialive"
-version = "1.38.11"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/89/ac/1b70a1f7529ce99aae3abefb81c8d630898cb3aeaf1bb185de79ffe818d3/mypy_boto3_medialive-1.38.11.tar.gz", hash = "sha256:2b412039a40a8130285656cfa9cf748f8e0e23ee987875040dedb48568e7c904", size = 102372, upload-time = "2025-05-07T19:42:42.635Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/3c/a117c7716bd7b37c33d342d9fd62f6cb603076fe9e90eb4a374a6abf2737/mypy_boto3_medialive-1.40.16.tar.gz", hash = "sha256:ce580b662e1ddc3a6d126bbbadee6bb16c75ea46731552f57a236f202fcc1739", size = 103133, upload-time = "2025-08-22T19:42:54.628Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/4e/8c1e137e8c1ab6d5433c3b862159dfa6739c27da9a5a9de5396d3022c509/mypy_boto3_medialive-1.38.11-py3-none-any.whl", hash = "sha256:e5ee66ad974ce87d2d479e5eacdd7b4575865e79e7f9704cac784a1602c834e1", size = 107079, upload-time = "2025-05-07T19:42:29.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/da/3d172e43ce45e8985281181e6896e75ba49fa7487b706f216d2036c0dafa/mypy_boto3_medialive-1.40.16-py3-none-any.whl", hash = "sha256:45c7102f4b644868a2c03dccf2600222e02606006d78a026bfa703d0f04b77b8", size = 107708, upload-time = "2025-08-22T19:42:48.848Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-mediapackage"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/10/4697325ba275fa622d7f7e7b7b7d703fce5e2b254481c684b82a0544476e/mypy_boto3_mediapackage-1.38.0.tar.gz", hash = "sha256:539a14e4f42b3da65fffd015b315bb00711b0653de77127fcc9db8a3216a029e", size = 20754, upload-time = "2025-04-22T21:29:05.695Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/5d/96a1842c1bc1236e8d3e3ee86133a1541ec5e83859ed21512b9dab075340/mypy_boto3_mediapackage-1.40.15.tar.gz", hash = "sha256:1cc3e67b7cd33ca086447521457830f37a34515f85af3db9fb478e101f5c0dd0", size = 20804, upload-time = "2025-08-21T19:43:42.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/93/0e098a0d63d1f79c28dbdcdb2d615993f476c0db97bf25d8644f812d1c98/mypy_boto3_mediapackage-1.38.0-py3-none-any.whl", hash = "sha256:742384b96572b8c2558b9c0d2bd2ae36b34c923f1446f53c20e6ca5fc8a19f0e", size = 28444, upload-time = "2025-04-22T21:29:02.906Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/08/4eca27a3f20b3ec8bced069ca67ddcc7458dead30df33a70dee06ffe8b99/mypy_boto3_mediapackage-1.40.15-py3-none-any.whl", hash = "sha256:2bcb7b059e813a16eddf430be9831f644145c190f5a4de301d7ac60c9ed456fe", size = 28581, upload-time = "2025-08-21T19:43:40.486Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-mediapackage-vod"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/09/21/b4483a619ff8590a45305b2628b3c64772f23768485f975e1b032df99a72/mypy_boto3_mediapackage_vod-1.38.0.tar.gz", hash = "sha256:40a2b0c1a249ee8fc51163d0a4b4fbc8c6a91b90d1e9b9f7513b795dc32537d0", size = 19807, upload-time = "2025-04-22T21:29:09.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/19/fd4be1b3399c60298434f9df231bfdcdf4308193bdef4d0f9884cb785adb/mypy_boto3_mediapackage_vod-1.40.0.tar.gz", hash = "sha256:d98fe817228df7e93a9db444de31aebf13d8906f2db3fb5eaeea8d6e8a529fa7", size = 19845, upload-time = "2025-07-31T19:46:28.145Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/d3/c327a3b8c1cce1d4b14bd3dd6c9f62f0ac43ec3afaad00d89edeee5cca07/mypy_boto3_mediapackage_vod-1.38.0-py3-none-any.whl", hash = "sha256:a764a0f0feaea6567b1e96c399c1f1f2680ab131a5356b696ffb509dfabe72af", size = 26897, upload-time = "2025-04-22T21:29:06.321Z" },
+    { url = "https://files.pythonhosted.org/packages/01/b5/ced332a7296a13710915fe60789bda6a8ab1ce7682abb8a3c2d2b1d9ee8c/mypy_boto3_mediapackage_vod-1.40.0-py3-none-any.whl", hash = "sha256:f3dd1b4b2ef4df4355767d3f37daf3dc75d79a8b46c65fc9ec165847bb43384e", size = 26956, upload-time = "2025-07-31T19:46:25.589Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-mediapackagev2"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/94/01068d1071ee8b24b5063958741ca3c34e856e488b23f011bd100372139d/mypy_boto3_mediapackagev2-1.38.0.tar.gz", hash = "sha256:7fe3213146f0727b4450e348cd820509c25082f34678366a84f6c0e07264554f", size = 23310, upload-time = "2025-04-22T21:29:10.543Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/f6/aaa1c63bf3c49179a112376008bc22ed7528589defb342bc74740a444922/mypy_boto3_mediapackagev2-1.40.0.tar.gz", hash = "sha256:351a421cf1178056b32d1b72bf3933b6588616d9b6788ab86f509535ac485d0d", size = 26823, upload-time = "2025-07-31T19:46:30.666Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/73/17f1bb5f0e824b8794a856b6be93654b12d7a56d0e07518ee7759a1aa018/mypy_boto3_mediapackagev2-1.38.0-py3-none-any.whl", hash = "sha256:2258d63600e51ddcaf938e1d5a38de312a27fe28e8bbb82ab45d0d68ec7536e8", size = 33411, upload-time = "2025-04-22T21:29:08.206Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/460f8c6a4c65abb54da867698fd485b95cb51ced2e620a9ee66a4eca9ffb/mypy_boto3_mediapackagev2-1.40.0-py3-none-any.whl", hash = "sha256:ef2f59cad29913bdbc3531ea575ddffdd13ce6c89c04834091f2872d5b74c98a", size = 34837, upload-time = "2025-07-31T19:46:28.918Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-mediastore"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/3e/55/4e8f938440b4a8ff922398f552489330d4bc7ebaaf5d979e0a1aa91a1063/mypy_boto3_mediastore-1.38.0.tar.gz", hash = "sha256:e1df2c38c578a70f0258af4ade215e69929d71caf43100268a70425452f8224d", size = 18065, upload-time = "2025-04-22T21:29:15.628Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/54/eab138c6d144eb439fb516a16eba58a362db13b6101a5c0ad38b7152b999/mypy_boto3_mediastore-1.40.0.tar.gz", hash = "sha256:f9dab699891f519f2795c58743ae4434b2d3c715f85f89f894e9e215dab10173", size = 18116, upload-time = "2025-07-31T19:46:35.445Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/59/4ed0b0d588bb7ec18dc8d1a830ffeadcecf720d7146f15a129542629a103/mypy_boto3_mediastore-1.38.0-py3-none-any.whl", hash = "sha256:24ee52ed3c211bf9e838c8c949abd5132cb2c14760364e9a998f2e8ced3d44a7", size = 23517, upload-time = "2025-04-22T21:29:12.431Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/72/01b5d9944c23782866e34aa14b692cf82f5c9a941b430f3b0add62c1965c/mypy_boto3_mediastore-1.40.0-py3-none-any.whl", hash = "sha256:3ae6f603d41be3c55d386f4e69be2ab69c9c6a2820b86d339d6408d470acc375", size = 23575, upload-time = "2025-07-31T19:46:33.545Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-mediastore-data"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/a0/fccb80333030684b5618b33aa1e250ec3850d809178baaba0ea67d67584a/mypy_boto3_mediastore_data-1.38.0.tar.gz", hash = "sha256:3b27a54dd539470875cec61f6d167ab7ea4936de32dd2f7a53628912aac876c9", size = 16479, upload-time = "2025-04-22T21:29:14.102Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/5b/88580f4c9bad0e209140fc7f1590bb7af931d5d10139b5ee6106fc2e4a75/mypy_boto3_mediastore_data-1.40.0.tar.gz", hash = "sha256:4c05726c75a8c005ea7e909480e7b42edf25d8266162a85aef73d297fd199a51", size = 16511, upload-time = "2025-07-31T19:46:33.042Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/12/ef4b386cf520f06088d63f20e33e50662d88939336725b2686a8e6487c01/mypy_boto3_mediastore_data-1.38.0-py3-none-any.whl", hash = "sha256:827abe5016561e7a319a9ac5907da831c9638c4ced38475749959c402fb87163", size = 21584, upload-time = "2025-04-22T21:29:11.145Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/86/79928375fcb17ab5220eb0ac8db881b239e94991e2067e6a1cb9cc89bbaa/mypy_boto3_mediastore_data-1.40.0-py3-none-any.whl", hash = "sha256:a545b19c29ec58325b78ecd05c38fd406821703a6bc2c7e3f8bfbc951545a82c", size = 21643, upload-time = "2025-07-31T19:46:30.007Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-mediatailor"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/72/dd8fc0479391aa22f58cbd8f29adb6a5eb23d5882e79c67be8a320350552/mypy_boto3_mediatailor-1.38.0.tar.gz", hash = "sha256:2e3586e34ba161153aaa9b931f8570f17523ce1bfe08de4f86e57e08fbb4b237", size = 32834, upload-time = "2025-04-22T21:29:18.808Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/eb/380f586d35d3f419b4b85c7f90dc552be64f93bf7968f0ce0b2ad240a879/mypy_boto3_mediatailor-1.40.0.tar.gz", hash = "sha256:d6e4cfc782b474625f44fba95ea9112933a27e65733610e0bda0583e97740387", size = 32846, upload-time = "2025-07-31T19:46:37.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/64/d3492cbe6dd29183d076002e96e773766ab42eff1bed0e87eed4812a197d/mypy_boto3_mediatailor-1.38.0-py3-none-any.whl", hash = "sha256:6aee66e07a5609ac6ea75d07f77599436e7848cd09978b4975aea9c61a886ada", size = 38153, upload-time = "2025-04-22T21:29:16.231Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/1b/4cebdd4c4dc21fab9c3c7ab5437690b9695e49484198e00908d2ef028a73/mypy_boto3_mediatailor-1.40.0-py3-none-any.whl", hash = "sha256:f72e2ad8c81aeac9b53ba448d511f65828937c785407ba42a3cc82ec2d5eb177", size = 38199, upload-time = "2025-07-31T19:46:34.615Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-medical-imaging"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/d9/74/f9ab5ab4dca1565992d87e57df680fb4472865fb1e70f7b6df5437b3fbf4/mypy_boto3_medical_imaging-1.38.0.tar.gz", hash = "sha256:02c5df680a4a2109cea26eb0b6a95c1503b515d3401d6072cd503dd1dac362a6", size = 20113, upload-time = "2025-04-22T21:29:20.051Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/c2/644e9bbe53190d55053cbcae66f434c57b6dd9643e30cf7cb0634357088a/mypy_boto3_medical_imaging-1.40.0.tar.gz", hash = "sha256:153da56315d75313ecb313ea8a7c086c48f56048514f20d9cf8e0bc8aafa8c27", size = 20110, upload-time = "2025-07-31T19:46:39.245Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/ec/7591bbd78db37cf3393e72e6ac33d7b76daca248863211be52046f9c536c/mypy_boto3_medical_imaging-1.38.0-py3-none-any.whl", hash = "sha256:fed671dfb54cbc23253bbf7f6cbf7d39ba04b879c52cec60cd34331a4cff1792", size = 27358, upload-time = "2025-04-22T21:29:17.95Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6f/4ef02a6c9fc19778f9e2c12644234d34ca58330993cd42ef2e598989229e/mypy_boto3_medical_imaging-1.40.0-py3-none-any.whl", hash = "sha256:e41c1a97020697c02d35d8199a106d85399fbd9f7d9c7ad1f9e1677584e52d16", size = 27467, upload-time = "2025-07-31T19:46:37.558Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-memorydb"
-version = "1.38.0"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/2e/1240d143a052083c8957b19cba916d703d4a3840d785e1adfa2f16a10c75/mypy_boto3_memorydb-1.38.0.tar.gz", hash = "sha256:000f884881dd5923dddd15b1f506657a07d5152701a12926f3a47495e4fe8334", size = 31934, upload-time = "2025-04-22T21:29:23.209Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/08/7f9929a25a4a3dd4feafc2fa069e7523c8234a883c2697896131a0fbe7ea/mypy_boto3_memorydb-1.40.16.tar.gz", hash = "sha256:6896cc4fe9f89a5fe571d8f886f2217f69841605544211ee07ae687ab6dd880d", size = 31973, upload-time = "2025-08-22T19:42:59.995Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/87/e442f0819464dead3b5ef2aad243579edffdfff39290d167b0859ead505b/mypy_boto3_memorydb-1.38.0-py3-none-any.whl", hash = "sha256:10a6b019bd80d79f3a2337dd0ab07d95917cde0b9eef25ac7a4cd05d8a28b392", size = 36341, upload-time = "2025-04-22T21:29:21Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/91/764096ce078e200d61b70c204761042308f7622964a7ee89224bc51c5abc/mypy_boto3_memorydb-1.40.16-py3-none-any.whl", hash = "sha256:ef9ad78e8dcd57c1631c6d6ecce5c7540a9ba06d2277b5609ba5b47b896064ad", size = 36469, upload-time = "2025-08-22T19:42:55.847Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-meteringmarketplace"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/b2/50f4d52d4636242608d06548b51d9fb7654749a1e377272890f438c96605/mypy_boto3_meteringmarketplace-1.38.0.tar.gz", hash = "sha256:07e6be230224417e4302f4697c113447e1a4e462d99d7835a6a3802c42dc9179", size = 16125, upload-time = "2025-04-22T21:29:24.782Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/57/ff606eb18879579bc7565e5423adfbfff275167711f7ab4905aa68550cae/mypy_boto3_meteringmarketplace-1.40.0.tar.gz", hash = "sha256:c1b3da92128a0ed358eb2f388f3a894253fb2221b94002904d1b183ffb67755f", size = 16166, upload-time = "2025-07-31T19:46:43.979Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/bd/ac3b15b653c3e17d288964ea8d66183e477754372847b17c2e956622e158/mypy_boto3_meteringmarketplace-1.38.0-py3-none-any.whl", hash = "sha256:bb1412bc52f087099b2221cb732c327dd9a945295361f06d071bde29d3f03a22", size = 19905, upload-time = "2025-04-22T21:29:22.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/f3/2c238896a0e9c5786806aa4bfd582486f4ce060a60f3b605c52af5c4724d/mypy_boto3_meteringmarketplace-1.40.0-py3-none-any.whl", hash = "sha256:5df44aaf076e97720ad83b13fa9fbbb1d0aea98a33119812162eec2f8643606c", size = 19968, upload-time = "2025-07-31T19:46:42.293Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-mgh"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/6c/39b1bfb6e94307061bd79316a0a626c01d3c46b6384966f79bd30b2430da/mypy_boto3_mgh-1.38.0.tar.gz", hash = "sha256:4316ca3dc41d6e69023fd4b3c459dfa1325f2ae19f9dedc945b1846cd8053dd3", size = 20304, upload-time = "2025-04-22T21:29:27.833Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/f0/404507836e224161cf81e96534aa02fe1652db614f3a4d50fa651df04c41/mypy_boto3_mgh-1.40.0.tar.gz", hash = "sha256:fcb9dc404c39915cc4ecb7284a0379f33390539ddf440b8de5b22c97fca22591", size = 20319, upload-time = "2025-07-31T19:46:46.034Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/88/9e9cf096c626289e7f849a2029d2dd1249da76e27367ab9bf1d837b2694a/mypy_boto3_mgh-1.38.0-py3-none-any.whl", hash = "sha256:381eb5be1f802217563d41a0c53854259e8d18e522122c6948be1c1d82ef9fd9", size = 27395, upload-time = "2025-04-22T21:29:25.335Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/37/2c5111a017a14024f6c81ffa7cf15418836cc26f10324099ac53da1373a5/mypy_boto3_mgh-1.40.0-py3-none-any.whl", hash = "sha256:d4a12b526a4a72e81cbe0eb9da3299cb38306963b9009a0446a95fc2a7e40753", size = 27454, upload-time = "2025-07-31T19:46:44.941Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-mgn"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/41/afe4c9240cc48fdb5813419eb84082ea8961c45b417ad760646fdf159853/mypy_boto3_mgn-1.38.0.tar.gz", hash = "sha256:999d1be3d5b5e2bce8a2f5c111f9fcdbfc39a613054e736a4149afea1f97b516", size = 39197, upload-time = "2025-04-22T21:29:30.368Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/f7/620c87b5884fa4c2b10acf5f9426e6e96f5127d03bc76d574f28f94886ae/mypy_boto3_mgn-1.40.0.tar.gz", hash = "sha256:5f207bffcce3e2953ff9cc6a8447f658ca01a28fc9d7694eae52f4583d8d8627", size = 39223, upload-time = "2025-07-31T19:46:49.122Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/7c/01f12e7ccb3ad9b9452f9ae70c249ac7602cb018159ed18a6982586aa940/mypy_boto3_mgn-1.38.0-py3-none-any.whl", hash = "sha256:3afc3c16bd7ed8eea81eec592681ad7d0bf5640cd4c696cc6dcd7586a2fbeb0c", size = 45171, upload-time = "2025-04-22T21:29:26.631Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/57/269219b0d78a5f0d8b89f9d5718d7b74a3a15407358b932679287776a60c/mypy_boto3_mgn-1.40.0-py3-none-any.whl", hash = "sha256:bae9706ea561de765cbd0113ff0f98ea753ca873684a57531af105f95f46e65f", size = 45241, upload-time = "2025-07-31T19:46:47.265Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-migration-hub-refactor-spaces"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/4a/af/48ae82bfb633c580df33d9e225508309194ddfe2db53facc67fad7ba8e9e/mypy_boto3_migration_hub_refactor_spaces-1.38.0.tar.gz", hash = "sha256:5e18ee184eadf8acf881ab7e0c130fe7b5420af6157dd1f42eec872c5b6e1857", size = 21262, upload-time = "2025-04-22T21:29:32.954Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/2d/2e8c0262f41dc77a4b09e7562f94af648782b04a2f2d87614451ba93ae8e/mypy_boto3_migration_hub_refactor_spaces-1.40.0.tar.gz", hash = "sha256:6e9432a97d643391bdb91202a0fa36d695b71321a1f700c766c90981a076a90b", size = 21321, upload-time = "2025-07-31T19:46:52.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/c0/4bf492f65621bd9dd0384f2870531226290d0561951c0830e6f409ecab62/mypy_boto3_migration_hub_refactor_spaces-1.38.0-py3-none-any.whl", hash = "sha256:0bb8ca596597a0ca6dcfad6b9c060b7da5d9199444268fbe111fdc246da78973", size = 29258, upload-time = "2025-04-22T21:29:30.979Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f0/8084eaad1bf03e30b310c35190366e18e0cec98789591fffd12cc4adf42e/mypy_boto3_migration_hub_refactor_spaces-1.40.0-py3-none-any.whl", hash = "sha256:b5b53ffd1728d84b9246344c76bfb2dcda4b81d07bce57a4f1557c8812abe254", size = 29311, upload-time = "2025-07-31T19:46:51.102Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-migrationhub-config"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/11/0072c1ff76c364fe3762fb308009420a20b6dcac9e6d5f68c8ed1b43f840/mypy_boto3_migrationhub_config-1.38.0.tar.gz", hash = "sha256:9789cad4a94f37af28977ddf492c88e19d40f08fd33c60279c8f4ff59935de49", size = 15494, upload-time = "2025-04-22T21:29:35.004Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/13/838f6abcfa3ab7098aa1af44bf465f9b6c944f0bce7248457be4c1cd1bda/mypy_boto3_migrationhub_config-1.40.0.tar.gz", hash = "sha256:16a25ca23e93365c200e8a41fea6198f7c239e9edaba2b6f33d1e7b41c181f3d", size = 15519, upload-time = "2025-07-31T19:46:54.819Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/77/c2dc1e344bea8f7bdac9f9d0fe63b2b3d6eed9030772452534e3b63add3f/mypy_boto3_migrationhub_config-1.38.0-py3-none-any.whl", hash = "sha256:c4dbec27ea8899a239289b15fe9b1dbda19f08d86eed7d9cd852eabd90cd6fa0", size = 18739, upload-time = "2025-04-22T21:29:32.397Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/41/218d3ccee1c3da2773576f0afc0055e20d43bd0c88e52ddf18183e3a52ff/mypy_boto3_migrationhub_config-1.40.0-py3-none-any.whl", hash = "sha256:29f3da0604fdc75fd72236930c373d2c569734a1cd390c56f2b482bdace17daf", size = 18796, upload-time = "2025-07-31T19:46:53.495Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-migrationhuborchestrator"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/75/1436baaeb9d643176250de4e3f2ccd659f20abf369dceb24e17870fd1ca3/mypy_boto3_migrationhuborchestrator-1.38.0.tar.gz", hash = "sha256:770350614e04ab950f395c37f40e563fc90b72c0ad81692b82d6750caf7e860d", size = 22186, upload-time = "2025-04-22T21:29:38.792Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/23/2ad811af753f4a663ff70e9294c8a93896684625d009bc146ce6416e6cd9/mypy_boto3_migrationhuborchestrator-1.40.0.tar.gz", hash = "sha256:12d3a3e0e8d9067e4ce50f6953631a48dc170155dbb45119202467febf9ef4e4", size = 22227, upload-time = "2025-07-31T19:46:57.627Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/3a/280a10e35568a8e30f2d7fb17a36f63b7c8e912d98ee596d0435aa258923/mypy_boto3_migrationhuborchestrator-1.38.0-py3-none-any.whl", hash = "sha256:f17a06f9439d342695589aac28e42388c445daf0d1be7b8419893eb4599149d5", size = 30541, upload-time = "2025-04-22T21:29:35.222Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/19/47d2f93470cfb74ffa3ceb23f0b1e8171b12c69e0fd13f15c1793a6040b1/mypy_boto3_migrationhuborchestrator-1.40.0-py3-none-any.whl", hash = "sha256:25960f145df8d27d430ad15512a78f076abc004d01d866d06f96f74540ef4fc0", size = 30601, upload-time = "2025-07-31T19:46:56.336Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-migrationhubstrategy"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/61/ae/f8a9e146dbcfbdca94b6a447b047af7f7735d1d531e2e7be2da8f8863084/mypy_boto3_migrationhubstrategy-1.38.0.tar.gz", hash = "sha256:12c46924018e228374dad9a73ed71c1592a9e3e28d6e98b36a7b514301465608", size = 25015, upload-time = "2025-04-22T21:29:40.326Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/f7/000ad87e569bc463d934ffbc65ee85aade80489c1612abecfa7745f89aa8/mypy_boto3_migrationhubstrategy-1.40.0.tar.gz", hash = "sha256:1be2a7d0af65236e2bfc0f8a04e1367ae87eada288cacb59eee07693d003fd98", size = 25004, upload-time = "2025-07-31T19:47:00.459Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/01/2ce69df73c32f17f9304cd5c3a4bf27f89cbfdb902dfd20bc126f3dd7ebf/mypy_boto3_migrationhubstrategy-1.38.0-py3-none-any.whl", hash = "sha256:0f0d967fdd2b8fb942969e171f335c93346b2b61bcd05fd5b3bdea23914eb42f", size = 36177, upload-time = "2025-04-22T21:29:38.124Z" },
+    { url = "https://files.pythonhosted.org/packages/32/c6/44edf622fa9285b37d459a17e3af443a3f140559ee0168a807079ef29524/mypy_boto3_migrationhubstrategy-1.40.0-py3-none-any.whl", hash = "sha256:fe85d29ff3adfa49977f56d237595eec6dd0f7a1206e5bd3173db96a89118f66", size = 36237, upload-time = "2025-07-31T19:46:59.063Z" },
+]
+
+[[package]]
+name = "mypy-boto3-mpa"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/b1/04d8dd3a08e95f7a15c77c75b8daaee15b16b4a7fc7209943ee9ab8f028e/mypy_boto3_mpa-1.40.0.tar.gz", hash = "sha256:1503ab85dcb150f46e624765462f404bc848cab48a6697c095627e50425731eb", size = 20944, upload-time = "2025-07-31T19:47:02.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/b2/d6b2ccb824eaf38074964542ffb624274f86f561c1c95863ba83a320a699/mypy_boto3_mpa-1.40.0-py3-none-any.whl", hash = "sha256:fb100d119b6c8a24e8255b28fd5fc0985f06a248311fcc82323497f8c8681929", size = 28188, upload-time = "2025-07-31T19:47:01.72Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-mq"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/cf/11/b22312c9733cc488ecc75f2121e595d29314b1f93e7e8b08749670eaae42/mypy_boto3_mq-1.38.0.tar.gz", hash = "sha256:f1d215610fb28d072192d86dd0745d56414b98a896704614bf08f6c191651302", size = 19867, upload-time = "2025-04-22T21:29:43.088Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/7f/4ffaa95d6acd0b08449a15691191afcc2e9ce04f4a0478f7987c2bdeb32d/mypy_boto3_mq-1.40.0.tar.gz", hash = "sha256:bdee50183f45dee959d47d8818c9a31c41ac8fdfa4bdc1ed355972df7e295c80", size = 19935, upload-time = "2025-07-31T19:47:06.006Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/23/a800e8240f322e593bf461745d5e8c272468dfd1095f9f24df75007c4a20/mypy_boto3_mq-1.38.0-py3-none-any.whl", hash = "sha256:3f95691724a53fb627bfbb3bf097c6698b4611229d00c3b7ee981041fcbb773f", size = 26511, upload-time = "2025-04-22T21:29:40.875Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/66/4b59a60378bfd788ff9d9fbf82ca42b4be3cf2642c119a5f4fd3ab48f2cd/mypy_boto3_mq-1.40.0-py3-none-any.whl", hash = "sha256:0d482b0c46a83373f6f1e07afc761ccdf9514d56e5f2452bad678c9d0a6dcd3c", size = 26575, upload-time = "2025-07-31T19:47:04.415Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-mturk"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/0c/14/4b28ff65237d1edf87a1707f30e0f147b97ab83aa7403d815ca2c7949f6e/mypy_boto3_mturk-1.38.0.tar.gz", hash = "sha256:c00575507aad2df36cf9b87f3da5a1eb5a53fb0654edcc7775f723c313d1d26e", size = 27109, upload-time = "2025-04-22T21:34:39.962Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/95/9d0f7fe8928fdb2c044ebec53a6dd654a518ad69c3150ac260bb8f13cfee/mypy_boto3_mturk-1.40.0.tar.gz", hash = "sha256:2289c1ed90fbd0e84999b4b5846a45223646a4078191fa26afed744c7272751e", size = 27143, upload-time = "2025-07-31T19:47:08.959Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/54/10bbfa10126a552af971ecaa7348d7e47ee05d6b61000e7f20c3a7eee2f2/mypy_boto3_mturk-1.38.0-py3-none-any.whl", hash = "sha256:50b7a84ef1c2221b48636f5e71cef36cd71f3c36cfdfd93ae103f5aae34dc47a", size = 33742, upload-time = "2025-04-22T21:29:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/24/7517eb2d1d00a209edbfe7427c613fd5a89254666dd0a5754bd71091fff8/mypy_boto3_mturk-1.40.0-py3-none-any.whl", hash = "sha256:2352a24425f21057a9f76956d65c4052c35c2cbcf77a053253adf67886d1884a", size = 33796, upload-time = "2025-07-31T19:47:07.161Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-mwaa"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/23/75/bf5f4e36404b89d1f0c4b61a89b6eeee2866aaa35c900847262ab7b6565c/mypy_boto3_mwaa-1.38.0.tar.gz", hash = "sha256:da15794d82abae8c1b3aa4198b0d03a610d6d9dda5168f0f606a25caa7b0ce7c", size = 18558, upload-time = "2025-04-22T21:29:46.826Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/08/662f8675a07c05721be826588be1627ab66cfdea568dd92f01a28d831fe0/mypy_boto3_mwaa-1.40.0.tar.gz", hash = "sha256:c3f926d04abfac45f5f36b43b7156c1429b76cada952bd4587a667b17ead8402", size = 18668, upload-time = "2025-07-31T19:47:11.425Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/50/b57f7f4af042eac68000909ccdbc1a8459f9358c448a2832d84c50f8eb70/mypy_boto3_mwaa-1.38.0-py3-none-any.whl", hash = "sha256:39a65fd54cf8e4809e00f98cc0d21c7608f33405e27fc2dfa9fa1eb8719070ee", size = 24422, upload-time = "2025-04-22T21:29:45.109Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e8/185c69088db9576bec31f9f5d95e4caf829bf6e164680567087690983686/mypy_boto3_mwaa-1.40.0-py3-none-any.whl", hash = "sha256:2b369877f1ae6c34e14d8690c3f08683f146efd7e7b62a1e479d2ec63e45e5fb", size = 24689, upload-time = "2025-07-31T19:47:10.178Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-neptune"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/7e/0c27d9bf5bef7f65819428cfde0aa4c464cd8b8497134ec32668568aa7d8/mypy_boto3_neptune-1.38.0.tar.gz", hash = "sha256:75710c84f72a065033efec32e7d24e4b9c791f2d4fa1b0b731cba737fda869b4", size = 40497, upload-time = "2025-04-22T21:29:52.415Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/e9/490c39566ecd49e9092ece18b2be3157cf505c040e960af73e4a8a3ce16b/mypy_boto3_neptune-1.40.0.tar.gz", hash = "sha256:f2a471b2f760d0d311804dffa0ca8a91607f134fe550a334e2b38749e6f8fc50", size = 40959, upload-time = "2025-07-31T19:47:16.882Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/0a/dc82471daceb84105f1589c9cf5adc5badcba270124b9fd5849fd4a6734c/mypy_boto3_neptune-1.38.0-py3-none-any.whl", hash = "sha256:fb6c36ad0e43ee4b4272bc023a10963093d3ed7ff44d230aa69e730a48d7ecd2", size = 46347, upload-time = "2025-04-22T21:29:50.554Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/74/defdf141326c83c8451b84272c30ac6c4856537b34bd76213730ca34c540/mypy_boto3_neptune-1.40.0-py3-none-any.whl", hash = "sha256:ffda179fbab9fd0348553d8a4e1f92eb96336b8ca1ad2d4f46cfbe5cb21eb2be", size = 46831, upload-time = "2025-07-31T19:47:15.125Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-neptune-graph"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/b7/7bd61e21f23d1978670b408fe880a611a2b68ea6b1636a5a0806237bb801/mypy_boto3_neptune_graph-1.38.0.tar.gz", hash = "sha256:59138bb2f6999ac6fe897b648464b034d6a8a976af87a32e0176eeaa7dab8d80", size = 24920, upload-time = "2025-04-22T21:29:49.467Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/62/22aec5dc62fe2d8774399832014d811a19769203698ced45c41e38c87cd1/mypy_boto3_neptune_graph-1.40.0.tar.gz", hash = "sha256:d3a4b949333de9e03863789e5eac668ea4a3583a8ab93fa29ea66979fed5317a", size = 24948, upload-time = "2025-07-31T19:47:14.005Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/39/995ce421882c1ea6d59155f3baf9339e30e8a7ce3d2d29cf5c5037b7bbc5/mypy_boto3_neptune_graph-1.38.0-py3-none-any.whl", hash = "sha256:559f577c4d4dd94af7e1d55ef221ccc0651f5838f6120ee302083db366220960", size = 35828, upload-time = "2025-04-22T21:29:47.973Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/07/f5edef3fcba2402d143d95192a43244dccf5e7e20cf68937ea43a03de4bd/mypy_boto3_neptune_graph-1.40.0-py3-none-any.whl", hash = "sha256:e5af2652c89e6f0e44a3829cba160796f1cbf50bd23d7b4fae23cd438db13c9b", size = 35883, upload-time = "2025-07-31T19:47:12.653Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-neptunedata"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/93/92d64ae8d8975e8cdaaaae3b5611726c38db4496a3e59489c16d8a0f480b/mypy_boto3_neptunedata-1.38.0.tar.gz", hash = "sha256:5347cc24dc99a6ac1894cbaa4c14990a002d96cec8bb22a78d604027eeab4d5f", size = 21888, upload-time = "2025-04-22T21:29:56.319Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/d6/c30fb5d4cd4f057a93ac23f83898b0bdf3cf8356aebcc3bec30cf6712f5c/mypy_boto3_neptunedata-1.40.0.tar.gz", hash = "sha256:e5a0fff400a00ffefa6cfa5b665a875e7d1b893c6bf70ca22e94f221dc4c298b", size = 21939, upload-time = "2025-07-31T19:47:19.66Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/ac/5da2dd911b88c38b77988e23d06af5ba0a2a37fec744757bda1b27430d05/mypy_boto3_neptunedata-1.38.0-py3-none-any.whl", hash = "sha256:c6b56a3b3f65d36e45935dcceb15a36ecda1e70c820809ea5b3365add132f299", size = 29498, upload-time = "2025-04-22T21:29:54.724Z" },
+    { url = "https://files.pythonhosted.org/packages/74/b6/9e9932849d164981488eb26711091c53f96af0ce97c8113e1a481edc2458/mypy_boto3_neptunedata-1.40.0-py3-none-any.whl", hash = "sha256:adb758512d00866fc93752eb4023b5b372cf684cbf6141a5c520f4e6117b0d30", size = 29621, upload-time = "2025-07-31T19:47:18.115Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-network-firewall"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/9a/ec/037c1c1190cab4a294f046bd0911ab067fceead7e9ad769539fdbb4808b6/mypy_boto3_network_firewall-1.38.0.tar.gz", hash = "sha256:4f2ef3fed6d491cf19bbf62974aacbfbb65b26820fcd53af14a75b82b4bd6da6", size = 34783, upload-time = "2025-04-22T21:29:59.002Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/61/c592656eb8fdee6618965cda53c158af689dcf1bc88fe3e30d7d23428d12/mypy_boto3_network_firewall-1.40.0.tar.gz", hash = "sha256:63e3a40924a1f55e1fb6082ca52ae07e0c1a46cd1bb12d10153b8e1f97aec45c", size = 38238, upload-time = "2025-07-31T19:47:22.28Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/f7/19b152d451cdce1c431c7b405c2c98ea2741b883f95a9355bc1d47d5abdf/mypy_boto3_network_firewall-1.38.0-py3-none-any.whl", hash = "sha256:7157d28250ff527e7aa6324779368676aebe54656bd21af06bd9dbc8116f3619", size = 39849, upload-time = "2025-04-22T21:29:57.397Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/29/e3720d44cbbcc47c5271925be2777b9e4a02fe96f3f83ffd106c7bcb4aed/mypy_boto3_network_firewall-1.40.0-py3-none-any.whl", hash = "sha256:a089b25fa6bc1dbec3a9b435df3afa92aa04abf666f29b23eba8ad59c6e3d964", size = 43638, upload-time = "2025-07-31T19:47:20.931Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-networkflowmonitor"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/2f/4e/6f2df590242593a48b4c0eec3e332f681c21c371d1f11f0c077bd9ce9ef0/mypy_boto3_networkflowmonitor-1.38.0.tar.gz", hash = "sha256:15779731c628f9014c6ca12de02fe72252239a9b133098aa37d249ad5f7ea443", size = 20840, upload-time = "2025-04-22T21:30:01.593Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/dc/9db247856cdf4427e3d0b1cee0ba833654ea693ca5f01f7731c4eda83c01/mypy_boto3_networkflowmonitor-1.40.0.tar.gz", hash = "sha256:cf033ededefbed574201268cecf5fdf8528327ed457073408039499b25c4f35c", size = 20923, upload-time = "2025-07-31T19:47:24.689Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/30/0be21b95be8b1778dfc99a972f64d11a4bcd43d59dee9c7c25ef8b8f970b/mypy_boto3_networkflowmonitor-1.38.0-py3-none-any.whl", hash = "sha256:4479b74f8f568f9ccde5ece5ef8eeee7003fbbb349c2a576f15945ffa0f1dad0", size = 28671, upload-time = "2025-04-22T21:30:00.058Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/28/f9b6ab14c004352346ddcb0c5e9a8003b0a568faef3d5416d5101e83087a/mypy_boto3_networkflowmonitor-1.40.0-py3-none-any.whl", hash = "sha256:42c54106d40bb13b75fe3fcaa72a7386001904b03647a38dbc4bd3adb0b44085", size = 28854, upload-time = "2025-07-31T19:47:23.562Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-networkmanager"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/5a/5f/1dd82f9d6f38a6527676f95b2ad5c2691ff6600d4d8f3d52314a9d63941f/mypy_boto3_networkmanager-1.38.0.tar.gz", hash = "sha256:fef820f2d38acdafba83f0acbcc03b039c1c49693be9b0ef84b1e30be15642bf", size = 45452, upload-time = "2025-04-22T21:30:04.695Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/c1/573f55325d0563f8b5cb7005377992005ed236aed88941d75a7bcb26f907/mypy_boto3_networkmanager-1.40.0.tar.gz", hash = "sha256:ea5865a39d8059228504d5ca32bdb311917ebb2bed4421cd704e7fa8f47cc46b", size = 45575, upload-time = "2025-07-31T19:47:27.663Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/03/5c00c5a7204564fcbee111a5d07771ddcdb360e21a482575029ea39377c1/mypy_boto3_networkmanager-1.38.0-py3-none-any.whl", hash = "sha256:c4ec6376ed70e9dce3201d0c117dc622cd994219ecd31c7942f8e0da5a79be59", size = 49722, upload-time = "2025-04-22T21:30:02.666Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/c6/1c969d69940cc8465e8741b6ff4b68ab6185d8f0d3344ba060db05b42755/mypy_boto3_networkmanager-1.40.0-py3-none-any.whl", hash = "sha256:8390e408ce1e306d31cc75e78dccf8048167024ffc873af4608b6e2fd1f807ea", size = 49909, upload-time = "2025-07-31T19:47:26.178Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-networkmonitor"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f4/6b/925427d178dbeff60a19690094422b5fe058feac56180d0921a9df044b8e/mypy_boto3_networkmonitor-1.38.0.tar.gz", hash = "sha256:d3055588b526c83491e140b766a26d2223b5e794d79f5a9420358633a86705f7", size = 17436, upload-time = "2025-04-22T21:30:07.65Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/a7/4777684ad50d382f480eaad7757d481b3c64af7b70b2507c3a87bc71416e/mypy_boto3_networkmonitor-1.40.0.tar.gz", hash = "sha256:d84fd5c5ab852746075401be476c12bb2cc67360799af618da74388ded518092", size = 17472, upload-time = "2025-07-31T19:47:31.854Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/a8/fb9b34dad2f021e7e660480e84aa1fc1121549cf89c166243950c0ee94ce/mypy_boto3_networkmonitor-1.38.0-py3-none-any.whl", hash = "sha256:b5c52f25fdac48a42066a39e7a0da9823cd36023ae13537dfbfdb3fd52f043fc", size = 22633, upload-time = "2025-04-22T21:30:05.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/3d/a86bc01b08f3d13eb00ad098cc5ab00010ceb0a99314a097fb25deadd6d5/mypy_boto3_networkmonitor-1.40.0-py3-none-any.whl", hash = "sha256:b64f37328b7a4e440d83bff68de111f0d60b7fbcd5537014411f5573a914e292", size = 22692, upload-time = "2025-07-31T19:47:29.571Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-notifications"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/3b/5f96e3f1182f760a8d308af369cc9aea100b9c5021dc1ffb221126c22f40/mypy_boto3_notifications-1.38.0.tar.gz", hash = "sha256:a04d98fb56944aee7a1895c2c1fd76b5b7959091e29569587b5f2c76d054f1e8", size = 25559, upload-time = "2025-04-22T21:30:10.649Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/23/a45e1a21aac85a453e01d52805e552ba722ece09eccbde8820a93819b6df/mypy_boto3_notifications-1.40.0.tar.gz", hash = "sha256:31c82c681e7b97ae1a92e76caf1867b6597cbf7d31024d79a20204011e4758bb", size = 25608, upload-time = "2025-07-31T19:47:35.557Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/d4/a1e7dc5f16286c26287f2f2697d33d8eacbf37bfaef265391ddbd156ee71/mypy_boto3_notifications-1.38.0-py3-none-any.whl", hash = "sha256:4ec4eac6c57fa208ce3fd4d387bead7019aae5247a21b7c7dca9623d631605ad", size = 32354, upload-time = "2025-04-22T21:30:08.755Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9e/52a36405d8b11132109e975ff8adf0a7483feca83f5316cd8594a01e52cb/mypy_boto3_notifications-1.40.0-py3-none-any.whl", hash = "sha256:5373b38346781e5c757bc26dca84a24f1d330391d5043d2d37bb522d01d594de", size = 32413, upload-time = "2025-07-31T19:47:33.742Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-notificationscontacts"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/0c/99ac626f04241e77dcf0e0a3dbeacfcf52c42658f80d89a1c866cff0ee82/mypy_boto3_notificationscontacts-1.38.0.tar.gz", hash = "sha256:d42aa136caff742641c81de26fa26a5f5df747402097aa94a46caa84da7f402f", size = 16742, upload-time = "2025-04-22T21:30:13.288Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/68/496b9675195776e843469a8c3d00365fe1ddec46d2de4bb40f76041cd57d/mypy_boto3_notificationscontacts-1.40.0.tar.gz", hash = "sha256:404c3be4a8311abb432eaef9ec5297ae47c557017fd0ca6811afbf3c079eeaab", size = 16846, upload-time = "2025-07-31T19:47:38.176Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/69/9f22607822882a4898ce6d692ea771a5c13b21417622c58b05a854ae35e0/mypy_boto3_notificationscontacts-1.38.0-py3-none-any.whl", hash = "sha256:fc1cee39ee8464315c603b49578a109e8fefa8072bd9748860d9144df89de8d9", size = 21926, upload-time = "2025-04-22T21:30:11.68Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/06e2c6554303174f042ac65ff5a7dc9f269344b8098e1178e676321e6216/mypy_boto3_notificationscontacts-1.40.0-py3-none-any.whl", hash = "sha256:2d062f826221dda3d042f99dff8d90448688b74e895f5b555b862ecaca0882c1", size = 21979, upload-time = "2025-07-31T19:47:36.794Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-oam"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/27/c42cd5d1670f71a9f9b156189345aa8770a27837f92ac6341856b1feaafe/mypy_boto3_oam-1.38.0.tar.gz", hash = "sha256:16803b285b11f60a3e8a35e30b50e51fcf774bf395bbe691fcb0db6dca7ca147", size = 18197, upload-time = "2025-04-22T21:30:16.135Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/b2/08fd000c0924f3e64972d5a5c6d4edef310fa61e375a95601ed307cc060d/mypy_boto3_oam-1.40.0.tar.gz", hash = "sha256:0dbded6fdaa150db5da8a55582ad99f34c1558203d83b07c629a91d459a095e4", size = 18242, upload-time = "2025-07-31T19:47:40.579Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/27/497dea7dd2a86b6f5d197e38657217d97fd82831e85ecda7313380ceddc6/mypy_boto3_oam-1.38.0-py3-none-any.whl", hash = "sha256:9f093d6c71d687919def371133360afeb3db6abaef32f1c972c0c6ce6355e201", size = 23679, upload-time = "2025-04-22T21:30:14.773Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/8d/7242becdd3618eeb26a62f49a6ce718f844f978552824e77bd755c9ab66e/mypy_boto3_oam-1.40.0-py3-none-any.whl", hash = "sha256:259c84a02930db51d5c01fc924371b1d8a939248a799ca7e2d8b1fc7f9086701", size = 23780, upload-time = "2025-07-31T19:47:39.561Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-observabilityadmin"
-version = "1.38.0"
+version = "1.40.1"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/20/96/e2e0ac1d55dd88fb13bf1cadbd473c37415240d62f7314ffcd7561f06efe/mypy_boto3_observabilityadmin-1.38.0.tar.gz", hash = "sha256:abc63abc30f6dc5efeec3bee4a6992d62120a83ab0cfeeb01689f5e487d114e0", size = 17155, upload-time = "2025-04-22T21:30:19.392Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/dd/9b8c49af0247399fbd8f4f70f19de0a7888c0842adc93acc3e61496d803c/mypy_boto3_observabilityadmin-1.40.1.tar.gz", hash = "sha256:2287e49250a90a00adc3d39bd24cb5a08455d5d78c3f0f5ccfaa601c141074e8", size = 19150, upload-time = "2025-08-01T19:29:23.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/19/0c498bc90733c2f91ef0ff0eda9f39d375d6c02a26f271743b14f5b4e219/mypy_boto3_observabilityadmin-1.38.0-py3-none-any.whl", hash = "sha256:f99e13a1639aac555327c76e751dc5f5010c157f018915d465900bc199fd0b97", size = 22526, upload-time = "2025-04-22T21:30:17.557Z" },
+    { url = "https://files.pythonhosted.org/packages/64/fd/bc45da0afac3c8d80f8d3a9e0f1eb84fba85bde339ee0377a813d3eb3577/mypy_boto3_observabilityadmin-1.40.1-py3-none-any.whl", hash = "sha256:c5e9c5993a62989e715a6ab1351ee23ba1460c0adc904f2c562f063bdf027559", size = 25780, upload-time = "2025-08-01T19:29:19.49Z" },
+]
+
+[[package]]
+name = "mypy-boto3-odb"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/fa/ba69c34371245083d41a558d7b911366a6eb7c540a7ccc88108388066945/mypy_boto3_odb-1.40.0.tar.gz", hash = "sha256:0d569dfe9fdfcc155f5b4a4be36aa8c53487a5dcfa998c91cb61480f872c33ae", size = 32366, upload-time = "2025-07-31T19:47:45.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/b4/003119c04b22a7abf2e84beeaf687f842d9bca9ddb22b345666c57d06dc8/mypy_boto3_odb-1.40.0-py3-none-any.whl", hash = "sha256:95631ee1476212b1365f89804630cdd86395248aa31f63048371f914ba09bff2", size = 37303, upload-time = "2025-07-31T19:47:44.352Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-omics"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/37/0d/2058c6731ec30159b9e8f39ce727199e6ba38cb662fcdab221b545d4a29c/mypy_boto3_omics-1.38.0.tar.gz", hash = "sha256:910a5fb761f989576a88631a6c1bf9f05e035cb0ca9718fdd38955156ed209cb", size = 53328, upload-time = "2025-04-22T21:30:22.057Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/06/573af02f97941d3990549d7dfaafeff4c987316ae9d76a148fb98287cd4b/mypy_boto3_omics-1.40.0.tar.gz", hash = "sha256:ad00d1f5cceca71791b3ce24a520beb5455e5ed0178ace9908ddaabbd2113668", size = 54046, upload-time = "2025-07-31T19:47:48.192Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/1d/873e1af20874ef0808cbe4182ffcb3fc705afb20883537b1c26edbb1610d/mypy_boto3_omics-1.38.0-py3-none-any.whl", hash = "sha256:68415772d5283a7a9827988c052d26932d9a07be705bb3f27b8b39733ec81d6b", size = 59118, upload-time = "2025-04-22T21:30:20.508Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/76/fc2e1d0570384f518db3e0409b4bff8d22542ff04c278a06f7d920ed0350/mypy_boto3_omics-1.40.0-py3-none-any.whl", hash = "sha256:a8ac3a4fc7ec61137374fae5ff6d6fe13dc136665f1aec36972218b17b53e6d3", size = 59937, upload-time = "2025-07-31T19:47:46.982Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-opensearch"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/ac/4d/57aeeb64bac07c6fdb987cb19b1cc29b5a2d0b88738a2f73785560901f4f/mypy_boto3_opensearch-1.38.0.tar.gz", hash = "sha256:b7b9094702d0b7e42e032789a5a774a288289723cc87789553a837b061de2f57", size = 44939, upload-time = "2025-04-22T21:30:25.089Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/9f/1d2c60a91f30a614c52b68a7fee1cc60ff293b5f12ade5ed800dd544165d/mypy_boto3_opensearch-1.40.0.tar.gz", hash = "sha256:0ddb9156c5a16193d7fa64008f58f5900d34ae29541ca0384a799e8604b88585", size = 45084, upload-time = "2025-07-31T19:47:50.79Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/c8/2d2710d1e284f22f9cb3286e7493fcabb4ff5f13cb2c6b35e1d9486a2f63/mypy_boto3_opensearch-1.38.0-py3-none-any.whl", hash = "sha256:7fc8404bb37ed8421133882b8e5472582d76dab5aa5def9d2d43efcc4dd1fa6b", size = 50230, upload-time = "2025-04-22T21:30:23.373Z" },
+    { url = "https://files.pythonhosted.org/packages/39/18/4014b286f17e22bae46fea676ab5f8eb776e1ec4f227c25f790cc6156f98/mypy_boto3_opensearch-1.40.0-py3-none-any.whl", hash = "sha256:b6c47e9354ced2c1e7f2071a356ad0c19a8fe6c90aec6d878b34e99b1894d72f", size = 50440, upload-time = "2025-07-31T19:47:49.493Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-opensearchserverless"
-version = "1.38.0"
+version = "1.40.4"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/ad/fcda6096f829ea4d8efbf0bcad8c60174e0567817c38b138afe2f9c5696b/mypy_boto3_opensearchserverless-1.38.0.tar.gz", hash = "sha256:edc5e064fb8fde8e6c33c5418e93816b0a393738bd385c328a78c7a33e6c71b1", size = 20605, upload-time = "2025-04-22T21:30:28.635Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f5/fbfb5ed220f122e4becf9cc707621f16abeff2078f39677fc29e70c54c7c/mypy_boto3_opensearchserverless-1.40.4.tar.gz", hash = "sha256:9e4b7af1b90d45f28c78ef53255fcfe4f1b3cbca6ce0266961c1762e60d4b367", size = 20948, upload-time = "2025-08-06T19:46:11.856Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/10/b9836b2329236ee6eb09834fa802eb8eb46fd7e46a5e2ed04668a80a470e/mypy_boto3_opensearchserverless-1.38.0-py3-none-any.whl", hash = "sha256:714f6c6449af4e3bc2396c2ec12a731c6392a83928d3b06a19057c4122440614", size = 27185, upload-time = "2025-04-22T21:30:26.159Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d6/3ef9144a4b8f236f0306c5a03bf2cb3827a21d23aaf83626684fe151147b/mypy_boto3_opensearchserverless-1.40.4-py3-none-any.whl", hash = "sha256:19d01ea3824556a72f2a5314649ae118d9da37989371a3cd4e39776941f0d39f", size = 27911, upload-time = "2025-08-06T19:46:08.579Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-opsworks"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/5a/6bf3dd0e52750ec507d74c6d4016e8a91b3afc5a06abf3fd311ff8d8a125/mypy_boto3_opsworks-1.38.0.tar.gz", hash = "sha256:ea368bc207fb8434757ccce3922c1caa14dbf723962dc3a2ddccab7a7980c571", size = 39945, upload-time = "2025-04-22T21:30:32.763Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/d7/f089bc54636932487e0f2c1f106534b16938d8b362dd5ed7fa46e7b750b4/mypy_boto3_opsworks-1.40.0.tar.gz", hash = "sha256:66e4959436a54a357230655e9b4d879256c098365725e5a7776181acc1492875", size = 39975, upload-time = "2025-07-31T19:47:56.194Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/c0/770e84b869623ac98b32be784ae8e06a92b786c3041e17eff8e160daa47b/mypy_boto3_opsworks-1.38.0-py3-none-any.whl", hash = "sha256:b6baf473e36378f8d2594b739f9d552a2794adc49a2a34efa0f2995390eeeb3c", size = 48137, upload-time = "2025-04-22T21:30:30.616Z" },
+    { url = "https://files.pythonhosted.org/packages/52/bd/abad5b3e508d5a0bdfc41ec66f441af60159952c67057d1aca207aa239f9/mypy_boto3_opsworks-1.40.0-py3-none-any.whl", hash = "sha256:367a3e4f1781841da8131e2573558d01e890bfcdfc3db6794fd2a9ce2a9393d8", size = 48187, upload-time = "2025-07-31T19:47:54.416Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-opsworkscm"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/64/b0/3da25ff7fd58fad7445a5fe1e5c5b34a9e4a4ae328741906590932ed2697/mypy_boto3_opsworkscm-1.38.0.tar.gz", hash = "sha256:20dc315f3720e8a0f0ea0a355f43cf237b23c206ab15fba5972a107c0ccc9454", size = 20206, upload-time = "2025-04-22T21:30:35.969Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/32/1f59b4472c901b21fb22b380fb76851bad9c9142811474e5810e04dbf09d/mypy_boto3_opsworkscm-1.40.0.tar.gz", hash = "sha256:244b848e8d21b53b83099c769cd24ad99ab9f68494aa431fe01acd6a67ab7d59", size = 20230, upload-time = "2025-07-31T19:47:58.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/34/f4da52fc9cf08420c24558f8f5748504f8c688ca1fd8048e06ab9dd197ca/mypy_boto3_opsworkscm-1.38.0-py3-none-any.whl", hash = "sha256:d39b0116f9b230b71a810328403f11b52048c230fddbb1db58bdca9f34da12a9", size = 28558, upload-time = "2025-04-22T21:30:33.848Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/78/faa57298decc24dab7c4bd1bc51f9d1a5b31d76fee5351de257ba82f7e53/mypy_boto3_opsworkscm-1.40.0-py3-none-any.whl", hash = "sha256:b3c48ce7fd02d87a30f60ca609da22502bab9d660c42bb79d7b5ddb960b08b58", size = 28574, upload-time = "2025-07-31T19:47:57.461Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-organizations"
-version = "1.38.0"
+version = "1.40.8"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/72/98d5ac2548d5cfbec23b01fa118adfbe0514ea7ac0722a083c99050ff07f/mypy_boto3_organizations-1.38.0.tar.gz", hash = "sha256:0fa4a47057d6840e179a5f851debb442d82019d9123ee4b533c63ee27e5c1d25", size = 31342, upload-time = "2025-04-22T21:30:38.927Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/43/4d67e0518d15415523fce6962e08349a7ea4268521d2706589dd46c70292/mypy_boto3_organizations-1.40.8.tar.gz", hash = "sha256:a30f43d7081d1e9664c99128cad7cc5fc1cccab2715c6c3768a9cd64422b9f55", size = 32597, upload-time = "2025-08-12T19:28:52.686Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/83/a1938f8865ac19d85e8377bf848f6cfa2cee2b9347627068451562aaf33b/mypy_boto3_organizations-1.38.0-py3-none-any.whl", hash = "sha256:a2fb8f42be1e7091f52e872877eb96a18a05a2c0ba4361c9a75d680597833941", size = 38961, upload-time = "2025-04-22T21:30:37.127Z" },
+    { url = "https://files.pythonhosted.org/packages/65/40/9e19dd3e78edf63d49bfa886c5326cb8e87272bd9c54814b4e1a4f7d6b49/mypy_boto3_organizations-1.40.8-py3-none-any.whl", hash = "sha256:56563e8b2a2b7c505bfa758286b971ef6f5079ae362d67645f86a6c40ad04006", size = 40790, upload-time = "2025-08-12T19:28:43.366Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-osis"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f4/5d/05d40a237ad00f7b44e835d7d871657a5795a652f079a0bcf6caf283e3a6/mypy_boto3_osis-1.38.0.tar.gz", hash = "sha256:c5900e7e694defa1b74346416d280b06ceda0168d5355f5c5a4fc41699521532", size = 17529, upload-time = "2025-04-22T21:30:41.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/90/1b1c9f4d54f2bdfdd473b393604a657d02bef448ef729c3bfca3510466c1/mypy_boto3_osis-1.40.0.tar.gz", hash = "sha256:5140b365f7585e517d39990303e048ead2b5a5f4eec9a019f422507519dad6cf", size = 17565, upload-time = "2025-07-31T19:48:04.227Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/22/57bc410d732a2ec4221d01fc0c7cf26b24df4824f5ba2d040246dfc843e9/mypy_boto3_osis-1.38.0-py3-none-any.whl", hash = "sha256:4e1d52c3822644ab835171e4b47a20139b6f7f79e5e45f7a3c7d726b411ac498", size = 21780, upload-time = "2025-04-22T21:30:39.998Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/56/dbe137737eac14c96fda34553b48d253184bdc6d81cd340ce0ab68878fae/mypy_boto3_osis-1.40.0-py3-none-any.whl", hash = "sha256:d3b195f1f7c6b851c868db0e7b10d74c0979d2bd33e4d0ec725d75348e818b04", size = 21855, upload-time = "2025-07-31T19:48:02.879Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-outposts"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/2b/58/e3ec9a398f75ff5019fee7a40ec0ba99e5759aa3f706668ca0c47c68260e/mypy_boto3_outposts-1.38.0.tar.gz", hash = "sha256:668862eb89f01b8c50ac420ec5e495128febf73a8bf02834060f039e9d222446", size = 24373, upload-time = "2025-04-22T21:30:44.735Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/be/f6b7b3f084f092b13ad162cafb27ab275e19008e2985f0825608504caaa9/mypy_boto3_outposts-1.40.0.tar.gz", hash = "sha256:899f2bcfe7ac04ebd0483c1f6c5fde686516b790ef7e1fa516f0a7ed75cae016", size = 24884, upload-time = "2025-07-31T19:48:06.97Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/b8/1de55e6b9690725fead49458926230262a901d86c4b127a4c787d274c647/mypy_boto3_outposts-1.38.0-py3-none-any.whl", hash = "sha256:b6339e696e07291b47aada81ffd95e15b6bd2fb933c78e239d71a4bd20eca09a", size = 34217, upload-time = "2025-04-22T21:30:42.779Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/94/e1873deea8ef7a9d0043871fcad814fea463a2a22daf8e07f3fd5f4ba159/mypy_boto3_outposts-1.40.0-py3-none-any.whl", hash = "sha256:c22ef9a56eb333e70bd425478a3294d54548e337a0aaeee6f34da927d392fa16", size = 35237, upload-time = "2025-07-31T19:48:05.518Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-panorama"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/bb/ee6ca1ff4b8abf442d2b729e312f40fbf97abf36b157ffb94e32723b2989/mypy_boto3_panorama-1.38.0.tar.gz", hash = "sha256:594078aade0b6a3cef29742787362d5ae165fa459852824bda48f9aac365f46e", size = 21267, upload-time = "2025-04-22T21:30:47.595Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/63/329f549e04a08d0763177bf42917bed4b077aa0debd097f06ff5b6f7af30/mypy_boto3_panorama-1.40.15.tar.gz", hash = "sha256:3e05dadef78ed6a1b1c5407065ed9bc5ab85353de77348fcbc4564d10e0db555", size = 21384, upload-time = "2025-08-21T19:43:43.113Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/bb/1aa4ce195d4dff1db0a607fc4cb5be10e8f8b7688453c2b8a17811cfd0bc/mypy_boto3_panorama-1.38.0-py3-none-any.whl", hash = "sha256:6587ba18703bb0a44ed70d94f9016a6d834e0c8e2e8ebfdeb15bc6ad6a1f33a3", size = 28385, upload-time = "2025-04-22T21:30:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/59/41/cd3d92bcd58574db295d7ed6df4069241ee9b715730c65e44fc1dbf40158/mypy_boto3_panorama-1.40.15-py3-none-any.whl", hash = "sha256:6c713c603f3b9fe302310e8e833abf324736c971e2978a09c6064729d9f7d72e", size = 28523, upload-time = "2025-08-21T19:43:41.013Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-partnercentral-selling"
-version = "1.38.0"
+version = "1.40.9"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/b4/08/bcb3bc78ce6859ca80952f388344420c00e6bee32579a86a5768a386e566/mypy_boto3_partnercentral_selling-1.38.0.tar.gz", hash = "sha256:be2131c03e390c85622b4c91fcbce368a3bb3d8cccfd673236cd93843bca0d22", size = 37369, upload-time = "2025-04-22T21:30:53.481Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/46/2401c1ba65dd0b9985a432a17d23b25e8b8d8423746a97416f5ce4e56b3d/mypy_boto3_partnercentral_selling-1.40.9.tar.gz", hash = "sha256:037e48fd2c5ba6b9e1023fe7c46009b84b34a29c71d2363b4c42005844adfafa", size = 37365, upload-time = "2025-08-13T19:29:08.572Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/84/c449ac8223a88cf1aa5486797decb7921d5a7643c771d934e67e68977131/mypy_boto3_partnercentral_selling-1.38.0-py3-none-any.whl", hash = "sha256:73b2860c77a7d843a1e6e92eb7ce572dba362751abc413bd212b89cb4dec2068", size = 45755, upload-time = "2025-04-22T21:30:49.305Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/0b/ccd57b2e6f251d2d91c3f7444e1adb2ace7f925e31b3f63bd71c8b3444a9/mypy_boto3_partnercentral_selling-1.40.9-py3-none-any.whl", hash = "sha256:c7da88983f94ce3e8cadd0cde4fe3310f66c1fedf1b080d3bb4789ca15d88a38", size = 45819, upload-time = "2025-08-13T19:29:06.971Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-payment-cryptography"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/2b/1d/32117a1cc35e9f4cc68476d4cdff961ea6160083b23fca8139f112c387f9/mypy_boto3_payment_cryptography-1.38.0.tar.gz", hash = "sha256:177a0a7f1551dbd34c354821786f22f566610f297eea64d2644a833731c27505", size = 20742, upload-time = "2025-04-22T21:30:59.238Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/62/ee1b55dd422f042e7ff426cbc91f729051bd94f4aa779241d9e74e92fe5d/mypy_boto3_payment_cryptography-1.40.0.tar.gz", hash = "sha256:4cb0900d1a4637ad6d444e3d2e71f7c1d8b9ae5fcb57ae163bab43377d3eef81", size = 20857, upload-time = "2025-07-31T19:48:17.652Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/fa/be6c64b4ce2c1a828380d8e4dc61082a312be174b99dd138395bffc6ad07/mypy_boto3_payment_cryptography-1.38.0-py3-none-any.whl", hash = "sha256:622a0606749e409b5e187023c10503457c837cd7d8205efb07c2b04a3087492d", size = 28909, upload-time = "2025-04-22T21:30:57.443Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/da/1c4f28dd0d9ce0ad802dea8bf57fdcce59c7970471ddae2a4fa6ea9ecf2b/mypy_boto3_payment_cryptography-1.40.0-py3-none-any.whl", hash = "sha256:b36d9413ce63aa6bdb74e021a3cb74e160b6cd6ee19b2c06e305b7ef57999a80", size = 29003, upload-time = "2025-07-31T19:48:16.517Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-payment-cryptography-data"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/b1/13/fea6c9a7a8e0ad02763272610bb040b7d37bae81ed58fc73a137186196a2/mypy_boto3_payment_cryptography_data-1.38.0.tar.gz", hash = "sha256:5ef50b423857ce7d5b9a36844b0d52ea2d9d5dc625a690022fb4b66723677bc1", size = 19681, upload-time = "2025-04-22T21:30:56.119Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/cd/5f3f7df81f26d6ca6e8d982b433e8b32c9bad0341a4a185e03c3624bcf81/mypy_boto3_payment_cryptography_data-1.40.0.tar.gz", hash = "sha256:a9e84b8c2ef857ab20a3e54624b3556e018ee88f4c4135d93f706d4060a3c6d1", size = 19720, upload-time = "2025-07-31T19:48:15.401Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/a9/c46e1533a7fe0d33a6655846af85afa8a7225aef4bafb0e350a7f1b4ba93/mypy_boto3_payment_cryptography_data-1.38.0-py3-none-any.whl", hash = "sha256:3aaef96e371c93a780335437f7ee21fcebb651ef7f75d73195727b6a9d1a1330", size = 26051, upload-time = "2025-04-22T21:30:54.571Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/4e/37e27c36d8ee9e2db33447e49b3de76c6002d6bbe1198ae2462f98632c59/mypy_boto3_payment_cryptography_data-1.40.0-py3-none-any.whl", hash = "sha256:08bd77e02ffd3aa9415766a1570224cf591c5bc45430fc1929fc4275b7275750", size = 26161, upload-time = "2025-07-31T19:48:13.627Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-pca-connector-ad"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/15/80f69f87abe38fee1894aebcc8ffa8011ee5ca2dd58358be94375ca09560/mypy_boto3_pca_connector_ad-1.38.0.tar.gz", hash = "sha256:0d0d085474f9aa26fde9536c71ff2c740d5eb1cb5a8a4b2c25802e4a2cc41268", size = 22982, upload-time = "2025-04-22T21:31:02.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/ec/e9d878bd4b27a8817482a932709e85ea0e7f7b40450fde24824ee9ec8857/mypy_boto3_pca_connector_ad-1.40.0.tar.gz", hash = "sha256:ea40195b457fed75c4182425db86eb161477badcd9d05b60f1d4d4811378d225", size = 23018, upload-time = "2025-07-31T19:48:19.975Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/bb/46467cb90f1ab57db254aaa7598646ed6862fa8af4deb231f88c7e15a808/mypy_boto3_pca_connector_ad-1.38.0-py3-none-any.whl", hash = "sha256:7c08799d8f763627351e57dce47638ff4f27338ecafbe838d108aa16be642fa4", size = 32454, upload-time = "2025-04-22T21:31:00.63Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/61/7f46200163a50cd26244f859449c6d73401e2e7facd3e28f16e933a61a75/mypy_boto3_pca_connector_ad-1.40.0-py3-none-any.whl", hash = "sha256:bd51f679d3c9f3d1f40d276b016f8c0f07c69d30ad0a9e9c23879c70670e1748", size = 32509, upload-time = "2025-07-31T19:48:18.843Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-pca-connector-scep"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/17/41/0e0838c9ffc2c5d03be8570e31a5c2be003ee30bf3dba9cfcb9ba2423707/mypy_boto3_pca_connector_scep-1.38.0.tar.gz", hash = "sha256:a6bc3cb7dc184f1d6e6876a7048c08f16273f36e9fdf110fdf5b27bd3490976e", size = 17945, upload-time = "2025-04-22T21:31:04.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/ac/dacb0ea8eccee87fc28b608cfe2f4d80a791a1c6ea817ab441400e00f942/mypy_boto3_pca_connector_scep-1.40.0.tar.gz", hash = "sha256:b06a2847ad98df98741d9e99b1da92576e764c3a1e730e6a5398ae08a5691728", size = 17980, upload-time = "2025-07-31T19:48:22.425Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/62/926c62e1346ca94aa1ab9bed61dbe52fed14e091e0f9654d904eaf563709/mypy_boto3_pca_connector_scep-1.38.0-py3-none-any.whl", hash = "sha256:7833d15a6ee393fe20219e2f859ced701fdd2e15d72c8240ef3487cf9c3d7db5", size = 23764, upload-time = "2025-04-22T21:31:03.692Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/48/a1b3d95e823f158e63b7c88d89207888cfcb6f5a06be5a71a17e0fcbcddf/mypy_boto3_pca_connector_scep-1.40.0-py3-none-any.whl", hash = "sha256:94956a434c66aa4416a87a1cf1ca136d317211e3393314c3460b3e3bfefa66c3", size = 23823, upload-time = "2025-07-31T19:48:21.217Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-pcs"
-version = "1.38.2"
+version = "1.40.10"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/97/fb/6aef7d6183c5ff95a06af8b1013759b891d46a3f88d3f4403353a78d35ee/mypy_boto3_pcs-1.38.2.tar.gz", hash = "sha256:46fb328318f52369c7549bbecc8d33cbe565f88fed6effb26e6f17300edb1ccf", size = 19436, upload-time = "2025-04-24T19:42:41.948Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/35/b60c9e642f521c84703ed7fdcc149e1572b2f24629a2849aedd6d31e1d63/mypy_boto3_pcs-1.40.10.tar.gz", hash = "sha256:aecded3350cbf05b4f5e2d554f44161a0c2515fb2d1eb13e56980ab03d7ba07a", size = 19624, upload-time = "2025-08-14T19:27:46.502Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/91/bd8545ab1d64ab8b52af1cd2a13ad7edc2b16f286d0b9391a35fa684801d/mypy_boto3_pcs-1.38.2-py3-none-any.whl", hash = "sha256:16d51fd2d080b61cdf52a6022565ac1b65473cd2fd853dfd612fd3fa09ef9e01", size = 25844, upload-time = "2025-04-24T19:42:38.626Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/07/74dbfcda1c1dc5e436d18640ae8e10ffbcb1ae86e8baab7fc44c5f36fff1/mypy_boto3_pcs-1.40.10-py3-none-any.whl", hash = "sha256:5d7a8212af695be9dd1efe9a543cdb3cabfa673d068230b84e99925ae934c4cf", size = 26225, upload-time = "2025-08-14T19:27:44.75Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-personalize"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/36/50/014ecccebcbc990cb056cb893b58e45341fbb47c00f393e171d1affc92dc/mypy_boto3_personalize-1.38.0.tar.gz", hash = "sha256:c0a34ef416e6294bcb41cc1b36076951518651a5368ef72f29d2c9ac859fc92c", size = 37929, upload-time = "2025-04-22T21:31:14.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/89/7b67a3db756583db3b09fa478aa9d4f574c52d55b18c2418861131a54662/mypy_boto3_personalize-1.40.0.tar.gz", hash = "sha256:b82264834f001df59e4a7310a3d63dfe81b0c5bebea7b9006506d31accefdceb", size = 37968, upload-time = "2025-07-31T19:48:31.539Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/b2/2c7008b29ca5d6f35f6770df40c74a77dd6b0eda1139c56174fe6acc8866/mypy_boto3_personalize-1.38.0-py3-none-any.whl", hash = "sha256:b3d34563dc66dc80e9cd8894212dcfe59c7d7b302668598b505cdad565ba3011", size = 42571, upload-time = "2025-04-22T21:31:12.362Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/67/f9d18c4ae353584b61ad56db4d8f269fe182b572b4519d0e15b205745e87/mypy_boto3_personalize-1.40.0-py3-none-any.whl", hash = "sha256:7cf87484b9d72700b97f728839bceb9fd2b32c2444ba1a58e8f4f9a73f9edf5c", size = 42628, upload-time = "2025-07-31T19:48:30.048Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-personalize-events"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/ff/67/ad360cb8522793172173a7c99891812604f36430d635057d389a99de61e5/mypy_boto3_personalize_events-1.38.0.tar.gz", hash = "sha256:6e122c4b21412344d2ad9d4f73481baa2a3731ff4de3f044bf5e3a128f92bcb2", size = 15502, upload-time = "2025-04-22T21:31:10.71Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/70/75b16476378f50cefe2e03bb3a36b916f28f68cfa9bf8e09636c2285a5c4/mypy_boto3_personalize_events-1.40.0.tar.gz", hash = "sha256:9858e26424f1dfd0699d50c9923a079ce28abdcb595e855e9435cc1ba9339f26", size = 15539, upload-time = "2025-07-31T19:48:28.741Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/10/2f248d0771dbbaf98af1ec94eb9d543c268bcdf8437758fde84d94cad176/mypy_boto3_personalize_events-1.38.0-py3-none-any.whl", hash = "sha256:21cb72549c934c4e4461e92d65c09b1526517d54d27567444df1708850d40495", size = 18651, upload-time = "2025-04-22T21:31:09.32Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/23/3eeddcd990a43433bc91f4448c728e56b1ee53a43e55ec1659db2eb11b0a/mypy_boto3_personalize_events-1.40.0-py3-none-any.whl", hash = "sha256:94f734412da8417069cc576bfa86f8248e42c4d5c5c8e349335b33c8cffec789", size = 18705, upload-time = "2025-07-31T19:48:27.502Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-personalize-runtime"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/e8/e321a7c190690f3aff31760c923f017643031e53894c78774c567941943a/mypy_boto3_personalize_runtime-1.38.0.tar.gz", hash = "sha256:382af48e66cd382a8bfa0d8bd475ba25d2b6f8314f9ed98a40fafa5cafbfc9a2", size = 15418, upload-time = "2025-04-22T21:31:16.868Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/b0/817902c3500ab3fb10a6cee2895ebb4adb73eb3d4f6ca93b4d4f6d8191df/mypy_boto3_personalize_runtime-1.40.0.tar.gz", hash = "sha256:95c2dd2f3d78b50dca4d49e02d34388983968c94ddaaea08b6a29105d7f866a5", size = 15448, upload-time = "2025-07-31T19:48:34.622Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/7f/0cb1480d02ed302bae2d37f7d0bed3a84b2e9486f05ee3ae9e19ac59eb37/mypy_boto3_personalize_runtime-1.38.0-py3-none-any.whl", hash = "sha256:acc442b35d02989d452a282ac73c0ccf87f2bcb4a007de3e22dda26322567fd0", size = 18589, upload-time = "2025-04-22T21:31:15.34Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/d7/18cc9aa873177c22034769fb15a65f301fb961ae72f7d13da2c588056438/mypy_boto3_personalize_runtime-1.40.0-py3-none-any.whl", hash = "sha256:536902e9e8749135cc6d634fac73b42d1bd5c8f8588878b61131e5eaaef71597", size = 18643, upload-time = "2025-07-31T19:48:32.828Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-pi"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/16/403726aac2af04b5404439cfe13383eb4c949674955d902c2d3340bd09ad/mypy_boto3_pi-1.38.0.tar.gz", hash = "sha256:60eba55759e153cf6059ff4ce80468d25d4aee930369d4dd658253125fe1781b", size = 17821, upload-time = "2025-04-22T21:31:20.695Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/79/253981a7ab0303429e7efbae5436e332e06116bc70b1843d3569d6c40a26/mypy_boto3_pi-1.40.0.tar.gz", hash = "sha256:70e4146e04495d5618953e116a8ae6bb1ef762d04738c9d3399bbb17dae3f626", size = 17848, upload-time = "2025-07-31T19:48:38.662Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/11/1721c8ac95c700dbc78740b67d03f452a445b9398eba577f25b5c6223d94/mypy_boto3_pi-1.38.0-py3-none-any.whl", hash = "sha256:d02ee32dea9b9206edc2d5f68691e0da8d358d2107de9e608b8826caf8d6dca2", size = 22365, upload-time = "2025-04-22T21:31:18.426Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/dc/c1b82a9b0d0f0c015a430877afd6b25f278bb0cc0dc99966243f048285fa/mypy_boto3_pi-1.40.0-py3-none-any.whl", hash = "sha256:837dfefd25cac136e09588f501297107177286ae3ce90fa44a2eb16345c1c233", size = 22430, upload-time = "2025-07-31T19:48:36.031Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-pinpoint"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/69/7893987a4e871071bd61d51f427da72202ee47c98a2b0a499e5c7dd4c07a/mypy_boto3_pinpoint-1.38.0.tar.gz", hash = "sha256:9e0b6975c9e0b5114c9c41e81ffe3622f36f996983f98d20603959b8a80dd0ae", size = 51248, upload-time = "2025-04-22T21:31:27.703Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/06/218bbd5502b797df4e0cdd3877f67aa4b9e42934f297f8d0065a76ed8a0d/mypy_boto3_pinpoint-1.40.0.tar.gz", hash = "sha256:ec7d25c920accd6669afb61ec864b49df51e2995f9d6f7fa20b3ed1e796d1ec0", size = 51287, upload-time = "2025-07-31T19:48:44.312Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/0f/715d05a22f9b655d8d3b867d9321a14ab448f16c0e00b7d64a1072f3259b/mypy_boto3_pinpoint-1.38.0-py3-none-any.whl", hash = "sha256:79619282acc7e0a9606a953825729058c330a2e37830a73bd7a40c806be79e95", size = 53499, upload-time = "2025-04-22T21:31:25.577Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/88/b65a95cbd16edf8e506dbd0005b11f6d17c70681dce614af2f7ab020699a/mypy_boto3_pinpoint-1.40.0-py3-none-any.whl", hash = "sha256:77edacad19be071745cf7abcb48fb323603057eb785b92e41813d470b730c28d", size = 53551, upload-time = "2025-07-31T19:48:42.4Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-pinpoint-email"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/0d/efff7e7dac6e021248b056f92803cc3f4a997944e71572f9ddc265f8165c/mypy_boto3_pinpoint_email-1.38.0.tar.gz", hash = "sha256:6e55e35de2a376842f0b2bb1ed18c4b594fe2da2bf1ece0f8441e779d7b784e9", size = 26592, upload-time = "2025-04-22T21:31:23.869Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/29/2e437cb00b64416d0a91903c512aa3997a8505cf6fe6d788ac267ae695cc/mypy_boto3_pinpoint_email-1.40.15.tar.gz", hash = "sha256:319dc52c9772a354685058fa6da62ee1d47d4fcff49c28a593945167ed30bd04", size = 26646, upload-time = "2025-08-21T19:43:46.175Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/37/6854058c47bae516ca5ddfab64ef0d62fcc578a6220557e4a5ad362ee1aa/mypy_boto3_pinpoint_email-1.38.0-py3-none-any.whl", hash = "sha256:dfa200331dcdc15f6cc10df9f6eb38bea09367c0f23fe7ad5c75679976b61bba", size = 33705, upload-time = "2025-04-22T21:31:21.964Z" },
+    { url = "https://files.pythonhosted.org/packages/20/ca/f515ffa6bef32786cf31bbda7d8ba18f0313e4c4300781f5e16711baea28/mypy_boto3_pinpoint_email-1.40.15-py3-none-any.whl", hash = "sha256:7a74d311f1faba208d85cc83c354b578072d084bab5d24130f0df0e3b1a1bcd7", size = 33837, upload-time = "2025-08-21T19:43:44.166Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-pinpoint-sms-voice"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/ce/4e33e265e3d46743b109c30752cea30c4a5cfc036be28a8ec72d140c0eef/mypy_boto3_pinpoint_sms_voice-1.38.0.tar.gz", hash = "sha256:59f6a6536845266f66e8f70697897e285b3989d3997f4f2ba60614cd9f99e2f4", size = 16098, upload-time = "2025-04-22T21:31:30.639Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/c1/4962198305fd5fc793d56f1855b3dde83fad5c8914e785eb2cfe3ebede3d/mypy_boto3_pinpoint_sms_voice-1.40.0.tar.gz", hash = "sha256:228ffcdca906fb0f896a15448855fd1a63724ffe87f2a062b1e9a6629461e1f9", size = 16132, upload-time = "2025-07-31T19:48:45.979Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/01/11187205a7fb7944928da7ef77206e2f384f8b9b8d489e144e66f952613c/mypy_boto3_pinpoint_sms_voice-1.38.0-py3-none-any.whl", hash = "sha256:2f6493ec40c45c2a17f4b133007dcb9b84617a84f1a90da3a40c35a5834c3973", size = 19748, upload-time = "2025-04-22T21:31:29.102Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a6/2c3a8ad0cecc6c67bc5ea01e260c79f7a5815acfa4b02d9dda41308947c0/mypy_boto3_pinpoint_sms_voice-1.40.0-py3-none-any.whl", hash = "sha256:e1fc125a93d88d1d090273618f7e01505825fbac5c986b6be592e4522e82d7a6", size = 19805, upload-time = "2025-07-31T19:48:43.398Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-pinpoint-sms-voice-v2"
-version = "1.38.5"
+version = "1.40.14"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/94/7a5619da3949f80ed29511c2155b611a6db6730ed837da6077339c739f27/mypy_boto3_pinpoint_sms_voice_v2-1.38.5.tar.gz", hash = "sha256:54a3846ff78f6fd45affe139dfc1556f8854cea8e85c119f3e8295d4296e82a4", size = 48462, upload-time = "2025-04-29T19:47:13.719Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/b9/4cc6230bf212b8a87a5fabdbc897794ed7edc8bf5d2eb01f0dd39a6f4099/mypy_boto3_pinpoint_sms_voice_v2-1.40.14.tar.gz", hash = "sha256:26881f7386dd4a0a3ab9f463917fa30bab4272317640417959ce5aded6718cf3", size = 48579, upload-time = "2025-08-20T19:27:40.089Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/92/ecce536c2dfaf080037a5a4dbea7be7327033b30a59b6df4d7c120e6f616/mypy_boto3_pinpoint_sms_voice_v2-1.38.5-py3-none-any.whl", hash = "sha256:e2c0cf2dc83e026fb7dfd81e16658f0020a2fe9ed428073a277937b60e027015", size = 54321, upload-time = "2025-04-29T19:42:18.126Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/42/a945f45cf90b3c05ec7af5e056a1616aa163936ffb1a7ef8a3ef4a1dd15a/mypy_boto3_pinpoint_sms_voice_v2-1.40.14-py3-none-any.whl", hash = "sha256:0c34ecdccf85708c7d7eb9bbfb9d65d4a73a2d2ef8dd8e107d7052d431be83b6", size = 54492, upload-time = "2025-08-20T19:27:30.756Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-pipes"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/c4/040eb47b6f2609040ac9837f5adc048113a70efb9c6ded59a933a82c8908/mypy_boto3_pipes-1.38.0.tar.gz", hash = "sha256:abc30d147f656cce9ef85f7cac190f9266549c0026f04c7878f43a191ae5a2b8", size = 25225, upload-time = "2025-04-22T21:31:37.149Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/39/602b2e3553d970e8bcfee9936e0d21ff3bc6af4ae7cf676d7898b9fd1502/mypy_boto3_pipes-1.40.0.tar.gz", hash = "sha256:018f071f63ab3afb1c111b2454b60ec7c73c3109ed104b1e795c2937a709b9a6", size = 25250, upload-time = "2025-07-31T19:48:50.149Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/bd/f9ca11a701f54e19fe35ca15d8ddd30ac0ff6f2153fe3dbe238782ff89a2/mypy_boto3_pipes-1.38.0-py3-none-any.whl", hash = "sha256:f7d8ebde040c979c4b4216a719ec23b5e69e970f3cd9db42deb06a6b9ed1075b", size = 30205, upload-time = "2025-04-22T21:31:35.683Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/23/433afd03f84fd353e741df50c22cbae77075d6a92aca7643cdde1052127b/mypy_boto3_pipes-1.40.0-py3-none-any.whl", hash = "sha256:c5ee0982e72dab68a9e11592d2ea932539f9a241f625b5cc0dea167bc5ae70b4", size = 30262, upload-time = "2025-07-31T19:48:47.784Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-polly"
-version = "1.38.0"
+version = "1.40.13"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/56/fde9c1fb2e9a2243edcdd3b576dddc245620bde3b016b734b9c643fb3e2c/mypy_boto3_polly-1.38.0.tar.gz", hash = "sha256:1bb9d095ab455f596296ecfee993e16595b448f58372594f70e0c7b192536b2f", size = 19023, upload-time = "2025-04-22T21:31:40.689Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/7e/6630639464f9bea1c0f454eb84b5e28a49198acd8cde9d82d5491d08c622/mypy_boto3_polly-1.40.13.tar.gz", hash = "sha256:bb3acdd5afe31f374de3bf5bdcee37b6b80bd506b2dc641b5967474e2c08d517", size = 19141, upload-time = "2025-08-19T20:45:12.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/e3/5e46605855ffc093a2d2815ef52efd9eef9349774a5f09fa507f281a959d/mypy_boto3_polly-1.38.0-py3-none-any.whl", hash = "sha256:7a25ef96333b84538772ff3742cb567f6282d356cbf249abe0e652c4578df935", size = 25544, upload-time = "2025-04-22T21:31:38.427Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7a/e857016c68fb6b2ba703ece661e574c9454b60f58c744a9d8d83d26eba71/mypy_boto3_polly-1.40.13-py3-none-any.whl", hash = "sha256:3e0b4cc929363bad36cddd7c7c235dca032f24b4b272148116c46f2c048e3355", size = 25680, upload-time = "2025-08-19T20:45:10.96Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-pricing"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/90/82ce2afab71b6d919219b510b7b8208000c798d4bcc9f701ad732f804e2e/mypy_boto3_pricing-1.38.0.tar.gz", hash = "sha256:24d5e623cb9593151d3b3bb53ef3610c4561d3b11a2dcbf5b63db6ecb3e7917d", size = 17278, upload-time = "2025-04-22T21:31:43.369Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/67/c7f0a21e90367150cea7c0d583304fbb106ac1f317871ad86b403b3a21ae/mypy_boto3_pricing-1.40.0.tar.gz", hash = "sha256:7a16f12154d78c44adc34314880d179a4d7756155fd3b367529de1cbf3e3504b", size = 17350, upload-time = "2025-07-31T19:48:55.095Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/cf/eb58ce02f6afa1bd37eded4b24275873dbf1c5bb07c83815172fd7725c33/mypy_boto3_pricing-1.38.0-py3-none-any.whl", hash = "sha256:c7c3b4bdb7a264b1ce0183527d83f9f5dbb230cf3893cc87deb4dca2b510aeee", size = 22469, upload-time = "2025-04-22T21:31:41.826Z" },
-]
-
-[[package]]
-name = "mypy-boto3-privatenetworks"
-version = "1.38.0"
-source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/f5/e93a62c22f342339484e32b38c20588cd32a9dcd2819a7ab23aa0e2d8824/mypy_boto3_privatenetworks-1.38.0.tar.gz", hash = "sha256:4f4e227100be5f041985a004056462a9f09469ac973f5b33a5b2dd006ffbb779", size = 20869, upload-time = "2025-04-22T21:31:45.947Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/e1/4e398cc0269ba531d5d9ab952cb37fcc1608ccfbdf96d4c4ad56e0f5ee82/mypy_boto3_privatenetworks-1.38.0-py3-none-any.whl", hash = "sha256:7f4e83dce9ca76fb94b8ba05caf93dcaeaa68a5f38feca892ac0bec9622d147d", size = 28459, upload-time = "2025-04-22T21:31:44.622Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/7f/782334b3351bd6db9c326790dea3ced2d4a061cbc27108ca100bd33413f3/mypy_boto3_pricing-1.40.0-py3-none-any.whl", hash = "sha256:cc5e73dede417f9bdc9c4e6f551e47e044cf56b2fc90ff6d5aeb678eb80fa86f", size = 22592, upload-time = "2025-07-31T19:48:52.349Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-proton"
-version = "1.38.0"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/85/ccf7090e1f481aa657aa8704cd639ccdb82487a2c84074d2c03a6397e476/mypy_boto3_proton-1.38.0.tar.gz", hash = "sha256:d9ab55b36470a19f7b72b07f9a68e4f52d57db708294c1e4245fd0dff526ad2b", size = 45019, upload-time = "2025-04-22T21:31:48.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/b5/c8bfbded1519f496595ab9da8fa6c40a7944b12f92d2377c2b681ea85c2d/mypy_boto3_proton-1.40.16.tar.gz", hash = "sha256:e87b9f08d1b03bd42c109a1f6445a1c85c2e19ee6b03486e9c0aae74f5cbc38a", size = 45080, upload-time = "2025-08-22T19:43:02.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/6b/06b52d62c2a782f17afffd450a7dcda31ad7ef7d6385debee702238ac147/mypy_boto3_proton-1.38.0-py3-none-any.whl", hash = "sha256:0bfb654c89ee8467180217a0dd11a4fb89de77f4fcbdffe4aa298a432fee385b", size = 50101, upload-time = "2025-04-22T21:31:47.275Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5a/4c65e6120480254b466b9dbd8f8c9ff775d25064d4b6565521bf3b744260/mypy_boto3_proton-1.40.16-py3-none-any.whl", hash = "sha256:63cac3a17a965669d046c9985a24a0954aa1cbbdd6bd397e8f23da4bb224bea9", size = 50239, upload-time = "2025-08-22T19:42:57.385Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-qapps"
-version = "1.38.0"
+version = "1.40.10"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/da/91b3a78382b594932d324ddf79f53e29c1b4e68932ccdcbe363a162a5584/mypy_boto3_qapps-1.38.0.tar.gz", hash = "sha256:25b955fb171c33ba5cf79bc633476e695cf89facb48bd8571776e9f773a77f9f", size = 22432, upload-time = "2025-04-22T21:31:51.463Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/32/f26d1515289f12216531ba83e4cd8e6ed5afbb152108f3946ad765232203/mypy_boto3_qapps-1.40.10.tar.gz", hash = "sha256:46c6de9d035c16bb7721739537a021c9a5c8d6a8cf277e966adcdd35a4aaad80", size = 22479, upload-time = "2025-08-14T19:27:47.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/87/d7c343a93b1f982d8e2be5dd6632b7a9f5219b0ce3c2a8e02cc9e364b735/mypy_boto3_qapps-1.38.0-py3-none-any.whl", hash = "sha256:d695a2eca9cef4bed5f94245b15d5dc8ff2c7a3abd14c24e5e64edafa1d9835f", size = 31313, upload-time = "2025-04-22T21:31:50.075Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/48/80b8238a90d68a1954b26d1665083c57aa62c9206d8324daa1b4cb6876ba/mypy_boto3_qapps-1.40.10-py3-none-any.whl", hash = "sha256:2becc695d95fe5c50801cc0a546324e953f3c31a5a499713d7dcf990af9ca8e5", size = 31426, upload-time = "2025-08-14T19:27:45.298Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-qbusiness"
-version = "1.38.5"
+version = "1.40.4"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/56/d0/76ff536288e9882f1df4ca42d6883c7ec129a26d49511b45e5b45186b4a5/mypy_boto3_qbusiness-1.38.5.tar.gz", hash = "sha256:d773947eca449422a94aaff4833c5df1e1975586876e3ea21a62c1e20fdb26a5", size = 49938, upload-time = "2025-04-29T19:42:30.671Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/59/a0593fe2d5bd12eff837ad43400cebbc8eeb76d035d7723536142ca77522/mypy_boto3_qbusiness-1.40.4.tar.gz", hash = "sha256:6a74087a2badb2141117915d329eb4be2c1985d112592f0958859b709d20cd72", size = 52137, upload-time = "2025-08-06T19:46:22.977Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/db/e42eef420ed87c1d91552c6d464d1e3fac725374a43ae9ab5de47ce00e18/mypy_boto3_qbusiness-1.38.5-py3-none-any.whl", hash = "sha256:122a4a0666840d007e9a31bb1cb1cd34475fd5e5697c4e20bed84bb3b024ccb9", size = 56869, upload-time = "2025-04-29T19:42:25.611Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/20/8de52562afb544a7afe5c19e8cb3c98baf2bb3b83ac04a164e15a280b103/mypy_boto3_qbusiness-1.40.4-py3-none-any.whl", hash = "sha256:e85f04fc7cb3d738eb308e908e4670e0e19bc3e22377d751be800a074b7d2139", size = 59505, upload-time = "2025-08-06T19:46:11.284Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-qconnect"
-version = "1.38.0"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/65/ddb8dfbcd1a0b176771464a0a7ea19e7984716f7c66b04cbcd4bf678762e/mypy_boto3_qconnect-1.38.0.tar.gz", hash = "sha256:3992d1d2c970697fc48164dc27979ff3b76d4870c9f39e5d3b81d1a37a218120", size = 51448, upload-time = "2025-04-22T21:31:58.215Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/6d/c35050a389cba481a3cea824d11ad17c2056c0f112e8e6949215313dc371/mypy_boto3_qconnect-1.40.16.tar.gz", hash = "sha256:b243567ab7ee1736b07a780d7df581be645e2f41d16d6ed96dc6d9983231120a", size = 51511, upload-time = "2025-08-22T19:43:06.579Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/b5/9b5a7eff4a1bbfa13abc0405094a0232dd0c76568527dc502ea9326951a7/mypy_boto3_qconnect-1.38.0-py3-none-any.whl", hash = "sha256:a8720adfe2e3f163188b6768d941454581dce7ed62f6fcf669f14270ef243aec", size = 57829, upload-time = "2025-04-22T21:31:55.986Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ea/6e1a7c9b5a37424b946f6ec703542ea4d5e3ad060cd4516dfed6f2e2d956/mypy_boto3_qconnect-1.40.16-py3-none-any.whl", hash = "sha256:55ade0d70942dd1d6aa2f6e1eb4ec9b73c8169f0cf79f473965ff9db9380590d", size = 57931, upload-time = "2025-08-22T19:43:03.707Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-qldb"
-version = "1.38.0"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/8d/96/5edc05999510964989413036c99c9daf07b585cd54f34d6e20f33cb0666a/mypy_boto3_qldb-1.38.0.tar.gz", hash = "sha256:1fc7cf7bf30f6713f8733fe89de41a64ae433d13b324d720981eb8b0dba54e0b", size = 18112, upload-time = "2025-04-22T21:32:04.618Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/19/1cae2c022baf147c2dbbed622fef89753ef3e4e163df44d8032911e9ea79/mypy_boto3_qldb-1.40.16.tar.gz", hash = "sha256:21a1199b995b9ae5a0fd8e811c9e8004a04f950b2f082448064424d716dcf4f2", size = 18177, upload-time = "2025-08-22T19:43:09.881Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/f4/bf90d196a7783320f813b048e45ef43958fc4e1d9c05dacea8110db591a7/mypy_boto3_qldb-1.38.0-py3-none-any.whl", hash = "sha256:c9fbc9bbc37ff9ebf47878dda5e9a6a756c21ae616288d9c9a3a0ad15def6b63", size = 22887, upload-time = "2025-04-22T21:32:01.114Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/80/ec9597b13a8cf3c28bbbb126a0a99611b91d7b3b0d8ed160f7b0845042b5/mypy_boto3_qldb-1.40.16-py3-none-any.whl", hash = "sha256:1a1d70e9a763b195b3476d782d3beb445dc2f3471a363f707aab99187e783d67", size = 23020, upload-time = "2025-08-22T19:43:04.902Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-qldb-session"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/61/e6/8f6962d239324d969e808c96cb1494c0e32d84eff24682ad1a6d83112a7d/mypy_boto3_qldb_session-1.38.0.tar.gz", hash = "sha256:50a06577e9c4e3a3198898656d8ded6e20b120b4a8fd31238435b8cf88d376ad", size = 15686, upload-time = "2025-04-22T21:32:10.85Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/fb/4452ae598cca1eb6f39863961938b6c87f29fa2ef453baa982669ceb209a/mypy_boto3_qldb_session-1.40.0.tar.gz", hash = "sha256:f2767b66b061e936ea00c3970f9e3a14188db5d46159efd4197aea7857b5e6f4", size = 15716, upload-time = "2025-07-31T19:49:06.482Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/d1/a71308ef027e3af9a8b1aabdc5629d3a6b4e7641e8190176e38418d749b6/mypy_boto3_qldb_session-1.38.0-py3-none-any.whl", hash = "sha256:665a976571c55def3a21dcde364968891cca32ae00fcf667852a0b44726a0f46", size = 18767, upload-time = "2025-04-22T21:32:06.988Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/1a/ea2be92fb3856b91bde5270cba881a07d59660447a25bbaca5c461e48aee/mypy_boto3_qldb_session-1.40.0-py3-none-any.whl", hash = "sha256:d2794e692c658aae629389f7afba17dbd0c39466f1dece48110cc3fe85a297e8", size = 18827, upload-time = "2025-07-31T19:49:04.322Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-quicksight"
-version = "1.38.0"
+version = "1.40.7"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/70/87/2969fa0cb827e3d09f453746516a3421bc5146d6e521520f075d3386b943/mypy_boto3_quicksight-1.38.0.tar.gz", hash = "sha256:9900534fa217f66b2c0469e9098aaada828d1df8deade38c470558b1e8b6338b", size = 169600, upload-time = "2025-04-22T21:32:18.204Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/26/26be74227d9313247e1658704e4bb3f3d550d1329c43ead237ead605b860/mypy_boto3_quicksight-1.40.7.tar.gz", hash = "sha256:b1c9c845a9b298c20148a707161c67c43012aa3390bd59bdcb0022bd461637ab", size = 170091, upload-time = "2025-08-11T19:30:58.753Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/b9/07f88f48a3cd352367352617c72c750fcaf6e9096853a61ab30352d2e829/mypy_boto3_quicksight-1.38.0-py3-none-any.whl", hash = "sha256:037f9b3fc42084baf9730a881d25679b02267a488902cb22481fb3d24ba6320a", size = 170732, upload-time = "2025-04-22T21:32:15.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ff/3ccc6a31ec4f19c5dc44a04be4d80c50eb8e074d679b6f058ef3a0a34e87/mypy_boto3_quicksight-1.40.7-py3-none-any.whl", hash = "sha256:d89d5b2db0d804d127393c0ab55f7db3b8c4cd0a7077f8cfb2b6a97e32ea01a5", size = 171283, upload-time = "2025-08-11T19:30:55.497Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ram"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/e5/4c0613e08b3d6f42a2b9bcacf67acc5d9ec7d3579fd059a6a0f09cd25695/mypy_boto3_ram-1.38.0.tar.gz", hash = "sha256:a5d255f05d135235de363776a221a2095a0253a30814ff328b70c7caa1570701", size = 22593, upload-time = "2025-04-22T21:32:23.455Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/34/f4e6a8f4127795e4158db62b3333ad6f7320d5bd78def5a7a543f8f53f85/mypy_boto3_ram-1.40.0.tar.gz", hash = "sha256:f047d34d73203b297110a0e2b7e34f5d4692d959aeae7385c33f1f05f072cf92", size = 22628, upload-time = "2025-07-31T19:49:10.937Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/05/baa9802e58db408262d0c48179b7465013d4ada7d53631970f5e93222552/mypy_boto3_ram-1.38.0-py3-none-any.whl", hash = "sha256:f31520b4db3e1984739cd57ef54d719463cfda047a055d709fc9bcbd28dbed93", size = 31124, upload-time = "2025-04-22T21:32:20.72Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/be/e7c63c0f9b3af86d34ff14496cc1a6364e0d700da1c320b6d15698328b74/mypy_boto3_ram-1.40.0-py3-none-any.whl", hash = "sha256:32d236295d93adf7263051e7f7bd6b75c7872f7c299f4f0dc16703a10d789978", size = 31187, upload-time = "2025-07-31T19:49:08.386Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-rbin"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b1/7fd08de4c15ca99e185e7d16f51dc750c0fcbb18b329e9bcbfa598e8726a/mypy_boto3_rbin-1.38.0.tar.gz", hash = "sha256:66079c98edddcfaea2d823925f3063c940ad4e41868bd827bdbfc734d12ad401", size = 17219, upload-time = "2025-04-22T21:32:27.491Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/f3/657c92890ce46a5e72ddf4a095b4ff11dcd2c40a30a78a0c86dd796cf51c/mypy_boto3_rbin-1.40.0.tar.gz", hash = "sha256:d722ed369ce3019cc5d8bf3b3af4ec5cded5870c90b77280d58a51c4f3e3346f", size = 17255, upload-time = "2025-07-31T19:49:15.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/91/bb366cfffa41ba5a69dd164d741d970439aa931a608fced86ff56b83d734/mypy_boto3_rbin-1.38.0-py3-none-any.whl", hash = "sha256:c4e5cc4880feef1ac1636f326767f2100668e82a9569335c0722273b0fe43715", size = 21964, upload-time = "2025-04-22T21:32:25.315Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/1e/aa7c6250782364827f6dede44097da359a6a25061bd915306ff60edbb7fc/mypy_boto3_rbin-1.40.0-py3-none-any.whl", hash = "sha256:585ebcfd19ff13ed00789938411439a2a6faa2798f32890ce7d005972d7e259d", size = 22031, upload-time = "2025-07-31T19:49:12.794Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-rds"
-version = "1.38.2"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/f9/bbda28652276081c5298404b3634f3233b66734e1123e3c424f78896b26a/mypy_boto3_rds-1.38.2.tar.gz", hash = "sha256:bdf65180965f71a3eb7778706f87b1ce2c9f1340cf3ab136f1903a60074e49cc", size = 84348, upload-time = "2025-04-24T19:42:43.844Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/ca/8fc5a33e3c907b9be62702be7492feda1af04dbec210278397aa86cfe9ca/mypy_boto3_rds-1.40.16.tar.gz", hash = "sha256:f95b416ed32861580c8e4bd39fc83d458babca30e0ce1ece94a5cbb639653ca1", size = 85241, upload-time = "2025-08-22T19:43:12.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/36/a4bdcbfdf16a6eca869b22abc399449e6f08df72d074295cbdc47fee45af/mypy_boto3_rds-1.38.2-py3-none-any.whl", hash = "sha256:75d5124c3a49c7932d2218f82b7566c62160add2fd7aecd3f413ab47eb7d902a", size = 90520, upload-time = "2025-04-24T19:42:39.15Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d7/c3c85b792ad53bc719641e6732a55ff02d66e640cfefd7c36733e5f179a1/mypy_boto3_rds-1.40.16-py3-none-any.whl", hash = "sha256:397445d14885defe11fc7fd83d8cd3dd6cd3a56cd08ea9dcb1d28e19f4024b2b", size = 91552, upload-time = "2025-08-22T19:43:08.039Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-rds-data"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/77/b3/4334b02225855a3d44171d6f43b6822a5d220a04cf2eb578cc324a938ea7/mypy_boto3_rds_data-1.38.0.tar.gz", hash = "sha256:49f7691303b893a85439c5dfc744ee17bdce4ca25e139363478772bc141608b8", size = 16749, upload-time = "2025-04-22T21:32:32.098Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/78/4e2932bc2212a09c477d846c90c4c93e22add907aabcdd77e5f8ea56d003/mypy_boto3_rds_data-1.40.0.tar.gz", hash = "sha256:123b92237bf88b83d14e6710b6a45345d81f057041cc5f4284957dc7a54276d6", size = 16775, upload-time = "2025-07-31T19:49:16.447Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/69/1b07ed97cce57aa91f3f13e8ae3e1372dd1faf885bf58ef802eb07c042da/mypy_boto3_rds_data-1.38.0-py3-none-any.whl", hash = "sha256:42700f2babd62f54292ae48f17ab98e87c2e80605902a178dcf171e74f14bebc", size = 20746, upload-time = "2025-04-22T21:32:29.4Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/48/89e26f2ef1e8654e57b3965ee41e9801a79af63767eed04e5c043e1ecfad/mypy_boto3_rds_data-1.40.0-py3-none-any.whl", hash = "sha256:8030142259067ae9f7d22d44f84cf67042a1158000dc1e302f9467d2dd2c3d1e", size = 20794, upload-time = "2025-07-31T19:49:13.266Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-redshift"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/c2/b005740491b36224c550dcf9dae2c721bf2699fb525a544b40e73d91e293/mypy_boto3_redshift-1.38.0.tar.gz", hash = "sha256:35981aae2d2c397d711ba1a423c2042a3d58f1a100fd1252e526b2a0419c4afc", size = 70847, upload-time = "2025-04-22T21:32:42.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/0b/495a944dfa494b3511bd272bc0e04e05e9b0f394d2ff02cbc4404bb19037/mypy_boto3_redshift-1.40.0.tar.gz", hash = "sha256:48314d05d5e8cb273e1196cee38924d6e0a13bc6acdd2798709bf0c0fccf6074", size = 70899, upload-time = "2025-07-31T19:49:23.997Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/a2/ffd104e5a8f466ea9e6c271983bfce4cb700119c2e2e76802046a6569cd7/mypy_boto3_redshift-1.38.0-py3-none-any.whl", hash = "sha256:7f033d96c9f1e9f17e640bd6a97f858f3a655abfd4565ff944bb4537c8bcbf33", size = 77532, upload-time = "2025-04-22T21:32:39.005Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d3/165a3242bf019d73e60a130eafcd48e14c9001257839193b08e49ce007da/mypy_boto3_redshift-1.40.0-py3-none-any.whl", hash = "sha256:81dc03c75d790640537902c7ed43cc423f0045d9a3aa73387198a0fa38c316b3", size = 77589, upload-time = "2025-07-31T19:49:22.154Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-redshift-data"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/9b/f901c28d729d014857dcd455c42a664c9ce5ce22c1c583e21afceb0fe7c1/mypy_boto3_redshift_data-1.38.0.tar.gz", hash = "sha256:d260fd688eca19b6e349ab489f692a37b72a374e6602be45848697022e893365", size = 19469, upload-time = "2025-04-22T21:32:39.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/67/9a22eed3746ccd13cf53b0b9eda792ecebd8d61cb8c7094367f43488b91c/mypy_boto3_redshift_data-1.40.0.tar.gz", hash = "sha256:ac99c42bd5bccd9ea1c69e58bf2b116b1934d6f682bf7fb3a44f4649d45bd630", size = 19498, upload-time = "2025-07-31T19:49:20.66Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/ec/c5361140dd9414e0edb872b5ea12ae24e5c748f0e943727162e2a7aefff3/mypy_boto3_redshift_data-1.38.0-py3-none-any.whl", hash = "sha256:65352a25a2ea81c117a83afc7b97a0fcb9561bbd8bee59215cd3118dd46c8271", size = 26180, upload-time = "2025-04-22T21:32:37.939Z" },
+    { url = "https://files.pythonhosted.org/packages/86/84/d077c6c93680989fb6c4e1c5c2caebce17260128f262f4f0a9ebbe7caf99/mypy_boto3_redshift_data-1.40.0-py3-none-any.whl", hash = "sha256:679f5e207a9f1ad2e5429c9314ed3b0030379d1a7b2b96f9e37f0b56e5db080d", size = 26236, upload-time = "2025-07-31T19:49:18.292Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-redshift-serverless"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/0d/78aed94518a18276ce0694848e05a2bb4f368033c23c89258a8577c64e4b/mypy_boto3_redshift_serverless-1.38.0.tar.gz", hash = "sha256:67829112f5cc3cdf3be1eb0463da98f5d29f9ac701b6238de049d4e5fb2e0f1b", size = 34237, upload-time = "2025-04-22T21:32:47.667Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/a9/ad092a094b7f9600645938ee7ba453bbca3ad71362a69bda82899448312d/mypy_boto3_redshift_serverless-1.40.0.tar.gz", hash = "sha256:8918fa6abceaf6b06c6ee226956752b476ece68e43e1ff4ca30746e4cef0e920", size = 34292, upload-time = "2025-07-31T19:49:24.652Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/1c/e209e66aed111b5998b2cd79648e17ea9ec321e93b51eeff5bc2249b4d38/mypy_boto3_redshift_serverless-1.38.0-py3-none-any.whl", hash = "sha256:3d26bff2d3a40ed49c4349b03916d6b255d5361fd1b93153741d79fde0dc3308", size = 39517, upload-time = "2025-04-22T21:32:44.266Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/48/bef02d1284575208de37003000d1cb36026d3c666e4725ad6d94641c0a79/mypy_boto3_redshift_serverless-1.40.0-py3-none-any.whl", hash = "sha256:711f2f32ea9f9d60046d6748c84a829cb58d445d788e5de7d25fd58fb69aa5df", size = 39575, upload-time = "2025-07-31T19:49:22.555Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-rekognition"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/14/b4c0a31a66ea45c8177b4ea55e22e233d7ae8af12dc316ace47d94636526/mypy_boto3_rekognition-1.38.0.tar.gz", hash = "sha256:030a295b584a80a982d995df128517839ec5c163a4812bb67b6ab6d2e92881cf", size = 45947, upload-time = "2025-04-22T21:32:48.737Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/09/7345c78441ccea398adc4478a95f53fce1046bd7101dc9dc5c78e6cf7ff1/mypy_boto3_rekognition-1.40.0.tar.gz", hash = "sha256:b954089375f147b9b077fb18e53424ea3cba9b9ab3af4a4cbbfd10e1f22dbb75", size = 46310, upload-time = "2025-07-31T19:49:27.604Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/1c/479e9c2f89f9adbc0d7accda85d4eaf391458b8196c303f268c76c7fb01e/mypy_boto3_rekognition-1.38.0-py3-none-any.whl", hash = "sha256:1a57f35b9d98967e4a601b2995918c5ee977454c2b53e1006a94d334b71b4e7a", size = 52851, upload-time = "2025-04-22T21:32:45.423Z" },
+    { url = "https://files.pythonhosted.org/packages/91/00/89fa47fa3fbf9a08bcf8444118882096fd2fc70b0d83e0dc8422eeeb8720/mypy_boto3_rekognition-1.40.0-py3-none-any.whl", hash = "sha256:b6c54d4cbca197cf1c2efa561d37b2f374553d25bb70229d28724d6ba5c3ab79", size = 53249, upload-time = "2025-07-31T19:49:26.188Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-repostspace"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/13/ca21e33a59a1bf5ef7dbb0fa28119faddf89aba1aee82917305e0e02d604/mypy_boto3_repostspace-1.38.0.tar.gz", hash = "sha256:264ceb1f772cd072f293143f55f38fe607265f56e7afe5eb033a7c57a2f8d112", size = 17587, upload-time = "2025-04-22T21:32:52.751Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/d4/0b4e926b163485b0df4f197d97111a565eb75aab64fcb6350728919daf17/mypy_boto3_repostspace-1.40.0.tar.gz", hash = "sha256:96c3021c1ebb5d9c90c85d7bbec266a8bba246d58d6d2eaa8aff145a68a7ca1a", size = 19802, upload-time = "2025-07-31T19:49:28.937Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/4e/89bc65a6bcec8fd45469c7d13950d7af0e66f7da42e2c7b15c22124f5c14/mypy_boto3_repostspace-1.38.0-py3-none-any.whl", hash = "sha256:a540e6cdf157b9970bbda8c949e774b1b29c6171ea899d7002f7496e254027e6", size = 22945, upload-time = "2025-04-22T21:32:50.439Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/90/c74801b6f2f07299f57d6b1ec98adf61ad40440b00c5af428b463792ade5/mypy_boto3_repostspace-1.40.0-py3-none-any.whl", hash = "sha256:e4e5729f496bbe8ea8439d0acbf48f753f96c01e01168fc62b15ae173f03b2ca", size = 27770, upload-time = "2025-07-31T19:49:26.686Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-resiliencehub"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/42/454471f633f89176224a8c694ae08d004deb306f1ad238840bf71a54546c/mypy_boto3_resiliencehub-1.38.0.tar.gz", hash = "sha256:c49490e26dfa5c2f7ca81ef04a029c8c82b89271ef7fba4be3bc712222889ec7", size = 35866, upload-time = "2025-04-22T21:32:54.374Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/1e/9b2090211d559fc5006ab9953508cc7f9676b4f42b64abd50bb6938c97ee/mypy_boto3_resiliencehub-1.40.0.tar.gz", hash = "sha256:3da06b99367f1291431fde1bc3fcd0a9170b890ace4252ab2074205dcb91d10a", size = 35903, upload-time = "2025-07-31T19:49:31.625Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/4b/263435944ab065c742710aba637ffbfc10301878df43552e76cf28ca4799/mypy_boto3_resiliencehub-1.38.0-py3-none-any.whl", hash = "sha256:972e092549af3bf0e32dbf0557770142fb08845c94b8fdd8cabee8674a2afea8", size = 40919, upload-time = "2025-04-22T21:32:52.132Z" },
+    { url = "https://files.pythonhosted.org/packages/36/50/a9248897dbef69a0b68e48b653e65cd4dae2254a4cbcb31c614fc0d3ccc9/mypy_boto3_resiliencehub-1.40.0-py3-none-any.whl", hash = "sha256:5f2f039949f8c10b0138b0516aa04925c6d89ceaff27d7281179755569253b59", size = 40969, upload-time = "2025-07-31T19:49:29.486Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-resource-explorer-2"
-version = "1.38.1"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/e9/baae1d79d33e17916993a53d1dca923284c29f0119d4ca24448799afa5fb/mypy_boto3_resource_explorer_2-1.38.1.tar.gz", hash = "sha256:4c86a1442f9c3105e976ecf0ea24260515e1fe5eef0cdb0b01fd0e9710cf4825", size = 20884, upload-time = "2025-04-23T19:26:32.104Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/93/a7c461e9856da23e962c88556cece57743c2c37af77355a4d33b35f4350e/mypy_boto3_resource_explorer_2-1.40.0.tar.gz", hash = "sha256:aa5805dee9bfe2344100cb1bf51bbb37cb26e157a4701921482bc9c3a4bfe149", size = 20958, upload-time = "2025-07-31T19:49:32.798Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/5e/8321afb48c5549f85c773f24368a60abcf9004b671c6ba75903b1bd0da04/mypy_boto3_resource_explorer_2-1.38.1-py3-none-any.whl", hash = "sha256:95d90f9a363ca9549d5bfb602d15ac6cee80a515891a8a9605b10b68d031e750", size = 28890, upload-time = "2025-04-23T19:26:27.659Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b5/9a4c5d48ed7da24bb537ba50f80cb13d4585e0a1bc94128680f04980bf8b/mypy_boto3_resource_explorer_2-1.40.0-py3-none-any.whl", hash = "sha256:f2ba5109850ad48e7d0271f3b556077d94154d48cc88976681b4634798959b0e", size = 28941, upload-time = "2025-07-31T19:49:30.954Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-resource-groups"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/97/7e/19cd92acc9a3c198c1b57ae9d5ac15fcb16f03f511df0b67b080b095fb3e/mypy_boto3_resource_groups-1.38.0.tar.gz", hash = "sha256:830028a1192559fae7aac6a9ce9f3f722b6f1cb49ca83eb5e8748e48bbfae4d3", size = 20700, upload-time = "2025-04-22T21:32:59.896Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/14/7c09e0ff6c741d9b576acfc4736a0132e273c529c8907292da2661ccf470/mypy_boto3_resource_groups-1.40.15.tar.gz", hash = "sha256:aba4aaa8912c0eb41f8d8a62169d52dbe0a70232945bec01b0b5528d89e0f591", size = 20759, upload-time = "2025-08-21T19:43:47.537Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/58/d89113e68cadf1d81f6608a998340b34ce8f931cfc5ad58438cf89aefe51/mypy_boto3_resource_groups-1.38.0-py3-none-any.whl", hash = "sha256:398887417dea5e65f0e4cfea9f639f305e33b0350e9c9c0bf32f7e2d8bb4bcb2", size = 28247, upload-time = "2025-04-22T21:32:56.608Z" },
+    { url = "https://files.pythonhosted.org/packages/93/d9/343b0d25a4adc555c9a3e7a4e18e676dfbc2ea10054b09f71ead830d065e/mypy_boto3_resource_groups-1.40.15-py3-none-any.whl", hash = "sha256:87bba101cdbb975dcab920ca6a0050db35e91510887345a68e9f9b986cb273e1", size = 28381, upload-time = "2025-08-21T19:43:44.572Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-resourcegroupstaggingapi"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/c2/d9874ffcbe501b6682b6bd8ea7795a12407daba0295206ac877977610d07/mypy_boto3_resourcegroupstaggingapi-1.38.0.tar.gz", hash = "sha256:5fc75db0aa922a31d7d4d7b15b2fd793b8b57b9eef9dd837f575f84740afffae", size = 18301, upload-time = "2025-04-22T21:33:03.981Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/1c/723452714e20dc6a6216b7767ad0fff1866eed0852075f37b41fbc51ba3b/mypy_boto3_resourcegroupstaggingapi-1.40.0.tar.gz", hash = "sha256:351356bc58f78dbec474aa941211971f6cd57ad167f8671da2464943a24cb149", size = 18296, upload-time = "2025-07-31T19:49:36.8Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/37/6bde4016bcf54be0d65f74df1ec61e9005adbbd22207589f885fa5deb17e/mypy_boto3_resourcegroupstaggingapi-1.38.0-py3-none-any.whl", hash = "sha256:2b5d7f7be65efd32c7cca5cd27252abdb614d09e3c528949be8284a0dff8fc9c", size = 24646, upload-time = "2025-04-22T21:33:01.218Z" },
+    { url = "https://files.pythonhosted.org/packages/54/89/a6a684da64f4250f7db1395938c2389c2cbfee786544774a755752e3382a/mypy_boto3_resourcegroupstaggingapi-1.40.0-py3-none-any.whl", hash = "sha256:8e57ef17ad9ac19ea7b374997199db714a1c02a4fe2b286bb497ec55859dc0c5", size = 24716, upload-time = "2025-07-31T19:49:34.581Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-robomaker"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/2e/72a5ebb97215bf09d8e71b9c0ee3d5d0b16ac7a3b1785f978eaadd92f56b/mypy_boto3_robomaker-1.38.0.tar.gz", hash = "sha256:44089b361c1f5dc10b464904441a14775af412138704f8965a79ed5506536ef4", size = 33884, upload-time = "2025-04-22T21:33:05.92Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/be/f1fc92ebc785285c094138a8262cdd31f8b7d6c181440978b4a90a9b88f4/mypy_boto3_robomaker-1.40.0.tar.gz", hash = "sha256:dc8a7ba8b6b72c22a3a0ce1db8e0d4b7c7c0d0e08c142554bd99262bce13460b", size = 33925, upload-time = "2025-07-31T19:49:39.893Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/49/c35d74434c03ee793a56b727d30fde42990e6aa6ac04e900989c515cf14f/mypy_boto3_robomaker-1.38.0-py3-none-any.whl", hash = "sha256:00d4180491ce4cba40988989984be1d00317ebe73c00dc25621e88c580a2fa69", size = 38482, upload-time = "2025-04-22T21:33:02.3Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2b/b114e028ddd69fa04f93bade312a217747d9de75b5c8e78509a604c1204f/mypy_boto3_robomaker-1.40.0-py3-none-any.whl", hash = "sha256:caccca22c3b1a1492b7785438917c21a3215afa1dab38fc42eccc3a405963593", size = 38537, upload-time = "2025-07-31T19:49:37.662Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-rolesanywhere"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/9c/7d/cdf4dd013207ae9c4f20fffb8f275758b82bc17febd3cb1b02ea48adda86/mypy_boto3_rolesanywhere-1.38.0.tar.gz", hash = "sha256:7080c48d01a5db7192e8063b03bfb4db3f97c0c0ab628498216b98a01c4a8def", size = 20167, upload-time = "2025-04-22T21:33:11.015Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/36/6431d2f7e6c1b000956216958e17b61cc853bb52c82053778efc9ebe9f3f/mypy_boto3_rolesanywhere-1.40.0.tar.gz", hash = "sha256:f407cc6267c68056316c61755182c112d0a4998b653cdb43d2ad8c1e66c9516c", size = 20233, upload-time = "2025-07-31T19:49:41.465Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/89/18069b1c57b44b0ca2be02be7ec3144a1e049655b33241acc8d79e67ddbe/mypy_boto3_rolesanywhere-1.38.0-py3-none-any.whl", hash = "sha256:2ab396fb9b787d5f10881e90a598079312b9357b43c7d54608a45bcaf3abde85", size = 27351, upload-time = "2025-04-22T21:33:07.016Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/56/cdf4cd9c0f161a3a6f0cf1819f76a76938dce1a71cba78902477ff82da9f/mypy_boto3_rolesanywhere-1.40.0-py3-none-any.whl", hash = "sha256:66bd9f8e7653297cc76c2e3fb3e721076c7bc4bc0b0911282e59a63a32843f6f", size = 27414, upload-time = "2025-07-31T19:49:38.935Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-route53"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/15/e9c82cfe3243075539a702defa8d9ed72eaeab4eafd99df7a6050ad2cd0c/mypy_boto3_route53-1.38.0.tar.gz", hash = "sha256:d747cc42f8b2ef7df02542373bb1399b85a32624e1952c6218f61dde8da43a5d", size = 38487, upload-time = "2025-04-22T21:33:12.618Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/64/dc1bb329bc613d50188f7965a5c21c8558a51fd2358be45cde5f862e18f6/mypy_boto3_route53-1.40.0.tar.gz", hash = "sha256:edc21f9e976b354072a26a64c7ab27701a5897fb38a456f05059877ef834ed0c", size = 38515, upload-time = "2025-07-31T19:49:44.17Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/39/6aef721c4ccac34fbc64abaa7df664e4585f2be37407ade81a059b2e6371/mypy_boto3_route53-1.38.0-py3-none-any.whl", hash = "sha256:04a37d28bc0beb5fed7f57f6e7a0f3c5cf5fc50fa7b6147049c001e380771626", size = 44372, upload-time = "2025-04-22T21:33:08.122Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/67/373bc6987bb847581004a926ea4cebcbc99226fbbe4d5c6bf982ae5ae0dc/mypy_boto3_route53-1.40.0-py3-none-any.whl", hash = "sha256:9402c6077318d1922298622ec96c10f95f8e64771c287267c85c76e18b69d898", size = 44441, upload-time = "2025-07-31T19:49:41.899Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-route53-recovery-cluster"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/66/d5463b0fa2acaca61d33623f18278beb126eb837fb2a17982fdddd966e14/mypy_boto3_route53_recovery_cluster-1.38.0.tar.gz", hash = "sha256:c9e0ea52078d8ed8f54e910a3bed5de032863df2f8a79ed49c2c8f0b8dc71b8b", size = 16421, upload-time = "2025-04-22T21:33:17.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/27/a18afbb31ebbe7867a6d6512b61c37fdb5b718dc0fc781d2ca5fe60c913b/mypy_boto3_route53_recovery_cluster-1.40.0.tar.gz", hash = "sha256:6e5f6d040e509a7b4709831c6212d6f0df30fa84d34adaf7dc9e42f246d79d9b", size = 16474, upload-time = "2025-07-31T19:49:46.131Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/52/3abfb84a5ae2b90ae82b27df0b8b23c22a93c02797ba670f50520d9bc423/mypy_boto3_route53_recovery_cluster-1.38.0-py3-none-any.whl", hash = "sha256:ece9a93608e012496fdd9142a478f8e244ae7431a2e7df91897d274f70e1cbb6", size = 21575, upload-time = "2025-04-22T21:33:15.319Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/71/91abf889e64e939fee20b1801331697fb8084190e9580e8b92d6a5f25e82/mypy_boto3_route53_recovery_cluster-1.40.0-py3-none-any.whl", hash = "sha256:af6386ad466b525cfafc0f29238e74993fdac113d18546740edeeeac3eb4a665", size = 21630, upload-time = "2025-07-31T19:49:43.276Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-route53-recovery-control-config"
-version = "1.38.0"
+version = "1.40.14"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/38/57/066555ca7c46b8345b32e88678c973eb656ab7ef681def250c43552b0cad/mypy_boto3_route53_recovery_control_config-1.38.0.tar.gz", hash = "sha256:c93cbcc2a362fd4a61b32580226e1c4a16421f69575e607534e52510c6a3ddf8", size = 21929, upload-time = "2025-04-22T21:33:19.593Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/5e/19a735766196600d1f95a29c84d1fca92f21c05e36c343e77bc41a525fbf/mypy_boto3_route53_recovery_control_config-1.40.14.tar.gz", hash = "sha256:c47a3cbcbb12806302337b9562fd6284b00ea6449cdd78ee3e02962c54ea0e49", size = 21992, upload-time = "2025-08-20T19:32:26.81Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/4476fc0c64d3308f5fa659512ed59345db4a1977a767c36f117410473b90/mypy_boto3_route53_recovery_control_config-1.38.0-py3-none-any.whl", hash = "sha256:cee08c6682fa3e562199da8107134fe7a68781f67f02d955dc8b21ec33de1a9d", size = 31200, upload-time = "2025-04-22T21:33:16.62Z" },
+    { url = "https://files.pythonhosted.org/packages/13/59/23cb76ef7fce6d4209f1c9367d6f8cad5dc1684ea8a605fd82d7d0443057/mypy_boto3_route53_recovery_control_config-1.40.14-py3-none-any.whl", hash = "sha256:17dae2e685b6af8028c129460dd3b2354dbd2dd6332b83e32ca2653a4e506ce5", size = 31330, upload-time = "2025-08-20T19:27:32.557Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-route53-recovery-readiness"
-version = "1.38.0"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/b7/ce921bf60a617a696962e0d827d7777872005e545c6892aa584ac12a3642/mypy_boto3_route53_recovery_readiness-1.38.0.tar.gz", hash = "sha256:4631aa2a7636d66908743b28bbfc68e1e8e3ae09cca649dfb8ef357863358e4c", size = 22028, upload-time = "2025-04-22T21:33:23.513Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/0c/ccd6c4920fe5484208f86e9e4b16589f2a7cb693320b0b91f65c3e93e380/mypy_boto3_route53_recovery_readiness-1.40.16.tar.gz", hash = "sha256:a28e95a6ee927ee24ac356aa5fcc7aa0894b5096c76b694d7cfc7991f40ca3c3", size = 22126, upload-time = "2025-08-22T19:43:15.787Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/58/f0562621b877b7950d7f2de85adcfa117ed8508180de4b196f96be7e41f9/mypy_boto3_route53_recovery_readiness-1.38.0-py3-none-any.whl", hash = "sha256:5f135da3b10fd2d4f6a62e023d4c8f75ec8377660b7569ffecd0f6beeee7d039", size = 30255, upload-time = "2025-04-22T21:33:20.118Z" },
+    { url = "https://files.pythonhosted.org/packages/97/b2/f0556c150ab3bfe3c52df90ffc59546bf516fa8c7407adf5be24f1a7c019/mypy_boto3_route53_recovery_readiness-1.40.16-py3-none-any.whl", hash = "sha256:6be19e5aa0f98484d14870f6c1677b63e6910ed9b6fd2fdaf1214a72aee662a2", size = 30388, upload-time = "2025-08-22T19:43:12.783Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-route53domains"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/83/19/12bf0df3d5e3f5bdbd0483e1c85e217b0ea3cdaa2d4e11dbe56aaef43344/mypy_boto3_route53domains-1.38.0.tar.gz", hash = "sha256:5112437527e9c2ada57e97677f95380a9409a594eda59b3073494e0e46f659f7", size = 23840, upload-time = "2025-04-22T21:33:25.01Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/2d/0abea59da2055204ab9519bfca7edbac00a200591046a9331ffa2e191980/mypy_boto3_route53domains-1.40.0.tar.gz", hash = "sha256:0d47210de1fe2541ed40d351806956ad689ce651f3d95928be546ce015368d9d", size = 23877, upload-time = "2025-07-31T19:49:52.425Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/22/427c9b383d8d100f2897ff65796e66e3580d9e8540cbfb350d564a901076/mypy_boto3_route53domains-1.38.0-py3-none-any.whl", hash = "sha256:f6131e3eccb4dea196857a77c6c6678069035352bdaa2152db52bde7c9854775", size = 33790, upload-time = "2025-04-22T21:33:22.258Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d3/8a1118d2128db7137b1c71f676c84d99dab8534273879d424aaf5a9949a7/mypy_boto3_route53domains-1.40.0-py3-none-any.whl", hash = "sha256:062d7d57e556d60eca67043468dedd4ea244223c1cd604735d1054856c1d4c1d", size = 33842, upload-time = "2025-07-31T19:49:50.431Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-route53profiles"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/ef/679a913b713aa3c9f91508278b9e1b15a5c9b5774db0866449d406ab1880/mypy_boto3_route53profiles-1.38.0.tar.gz", hash = "sha256:31fa9b6cff5baff0eb773100704e95a70d753869a6cda8408a24395f78b36b7d", size = 18499, upload-time = "2025-04-22T21:33:29.159Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/39/f99e1b7064645805c9b69587b45d3db938638a528c12a22ac66ac5def713/mypy_boto3_route53profiles-1.40.0.tar.gz", hash = "sha256:6e87f8977b8410095f3874bb5926f666eeb32902b23f3c3b6cf3ce41bb75b302", size = 18549, upload-time = "2025-07-31T19:49:53.551Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/d2/d033f91f730d76a3fb782ee36f175d1699965481ff827a430ae880784d20/mypy_boto3_route53profiles-1.38.0-py3-none-any.whl", hash = "sha256:ad9f8a882ad925b31e28fb642eebc4c703a6fcae48f8fea135bbf29418bf80e5", size = 24327, upload-time = "2025-04-22T21:33:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4a/e81537ae4c81fdb80d89f879a1ee75edac8dc9bed68caf9c342d0ddce23f/mypy_boto3_route53profiles-1.40.0-py3-none-any.whl", hash = "sha256:7037335af4893877e16f11d1aca8139c0c5136ced356f74d46f5ca2d48ecc0bc", size = 24405, upload-time = "2025-07-31T19:49:51.59Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-route53resolver"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/0f/b79102679f51950f6de2b328ab601c9f4fe55f7049f449536047db77c230/mypy_boto3_route53resolver-1.38.0.tar.gz", hash = "sha256:0cdf25f806e0bc663f541f0eb9f168abeef9bbc88c58c22f9d7f349df770813d", size = 35995, upload-time = "2025-04-22T21:33:30.043Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/d6/ed3296fdab4583771c0e308296e73a1bd877445df2643e2af9067e694869/mypy_boto3_route53resolver-1.40.0.tar.gz", hash = "sha256:c18d72a414b427fd09bc627badcf072f9da89f0ca90b4160912e19cfa14aaa98", size = 36073, upload-time = "2025-07-31T19:49:56.266Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/80/4c70b5a139422d0233350eebddd615a8c29e3fb559d36013c8748dcf51bf/mypy_boto3_route53resolver-1.38.0-py3-none-any.whl", hash = "sha256:b54a870851a2b05d9a0ee021bcfacaf9628406e60d7f6182f61b09d33bc4a10b", size = 41286, upload-time = "2025-04-22T21:33:27.4Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b5/5fc8650e6a0521e6c4c02038cd89d036820cf411be7df4e100289f0ef2bc/mypy_boto3_route53resolver-1.40.0-py3-none-any.whl", hash = "sha256:7c429a3f0c4f1b067a6e63c7aa6911b157a1a9a1910d82486a5ce095575a7dc9", size = 41415, upload-time = "2025-07-31T19:49:54.06Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-rum"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/09/2c2c6d819882eb6c23733251640ad1cda90007cf229a6caa43760bbdc215/mypy_boto3_rum-1.38.0.tar.gz", hash = "sha256:801923c644a66a8951701cd811b53046f699a4470f483e1c99fc7f9a2ed53cce", size = 20228, upload-time = "2025-04-22T21:33:34.327Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/f4/fc7e1b4c9cf1d1b412c034bc94f338a32438aa09463bcbf697a6aeaa8dd3/mypy_boto3_rum-1.40.0.tar.gz", hash = "sha256:f9f8225fcad28f9defb89bae4ce5f6eac8a95b7c62143b7b8a4eebeb96a51dcc", size = 20271, upload-time = "2025-07-31T19:49:59.286Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/e5/10e2d1d5f222a2af1298d18183aea18fe327ed85517ce037920e12d0cdba/mypy_boto3_rum-1.38.0-py3-none-any.whl", hash = "sha256:dd6e714cee42e7e395c18bb21e135017e657b6950472b0c34a01781d2ed2c06d", size = 27380, upload-time = "2025-04-22T21:33:31.44Z" },
+    { url = "https://files.pythonhosted.org/packages/37/63/0cebeca22912e99f3234056b1a2f93057918889b1ce761a7056028ffbfbe/mypy_boto3_rum-1.40.0-py3-none-any.whl", hash = "sha256:6dd133c83012af36285f69a524840fc39b34cc95b322cd8f58af56d66e8f6289", size = 27449, upload-time = "2025-07-31T19:49:55.549Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-s3"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/04/7b7f5709a092097a4a915b23f43b6dc9cc3b8e098c81d86a384eea071984/mypy_boto3_s3-1.38.0.tar.gz", hash = "sha256:f8fe586e45123ffcd305a0c30847128f3931d888649e2b4c5a52f412183c840a", size = 73699, upload-time = "2025-04-22T21:33:36.716Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/d7/b2100702d2f200fdb3468e419c729790bd8543ee0af6f6d63d8dfdab4e28/mypy_boto3_s3-1.40.0.tar.gz", hash = "sha256:99a4a27f04d62fe0b31032f274f2e19889fa66424413617a9416873c48567f1d", size = 75924, upload-time = "2025-07-31T19:50:01.979Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/59/24de9ac5f1974164712ab89edb510d21116a69d36373dc6588aeb26ab81d/mypy_boto3_s3-1.38.0-py3-none-any.whl", hash = "sha256:5cd9449df0ef6cf89e00e6fc9130a0ab641f703a23ab1d2146c394da058e8282", size = 80301, upload-time = "2025-04-22T21:33:32.297Z" },
+    { url = "https://files.pythonhosted.org/packages/43/4f/4d32cd202d8c8c7e11e44dd288f66b8985e6ee4402b9a0891b7b94ff6cc6/mypy_boto3_s3-1.40.0-py3-none-any.whl", hash = "sha256:5736b7780d57a156312d8d136462c207671d0236b0355704b5754496bb712bc8", size = 82710, upload-time = "2025-07-31T19:49:59.713Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-s3control"
-version = "1.38.0"
+version = "1.40.12"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/11/172f244dfeb0df81455e3026d34d6fe642517e0d879f5f15981e6a059b3b/mypy_boto3_s3control-1.38.0.tar.gz", hash = "sha256:2acc4d4b29f9f7706e4e349c22dd0ca3ba141a1517d79d308bfa080e7031fbd2", size = 44513, upload-time = "2025-04-22T21:33:42.103Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/80/d775927966110136ecb9910341d3aa0988f5372ec4502655bd0a7664e939/mypy_boto3_s3control-1.40.12.tar.gz", hash = "sha256:942e5754fb5250c69be76411aafea8f7eda0af31137458e9b1c8c3c2fa8636f1", size = 44881, upload-time = "2025-08-18T19:44:31.572Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/b1/91f08ffbcef4cbdcc188ee3507ce3c307f1ca377cb0f5f2e48d4e7f73315/mypy_boto3_s3control-1.38.0-py3-none-any.whl", hash = "sha256:b497059cba5229f1c6dc1d953679535fed693afe6da58a1bfe2be0f167381f62", size = 49478, upload-time = "2025-04-22T21:33:39.119Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ca/69e645a19c7983796580d99016d2887a69cd318854eaff520bdf15231993/mypy_boto3_s3control-1.40.12-py3-none-any.whl", hash = "sha256:6d424b741520f018ac1e3d48463f0895287be8ea1dd71dcf4f39a159bbbe2c08", size = 49934, upload-time = "2025-08-18T19:44:25.381Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-s3outposts"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/5d/6e/bbcbdbaaaca064bf5d32d1d33213f2690a9d65db4900d014652e6bb8def8/mypy_boto3_s3outposts-1.38.0.tar.gz", hash = "sha256:9415997ac8082989e34a350e3c1845e0636c352934f580d21325f4ab0793de23", size = 17325, upload-time = "2025-04-22T21:33:44.844Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/94/9dfb9f05bb69fd964849669be1d1cce581cd097d8a879463d53e0a8265d4/mypy_boto3_s3outposts-1.40.15.tar.gz", hash = "sha256:1cf032530bdf50d665dd3b371f47af54eed489f0228b0ac33f2609e2d8ad92a0", size = 17392, upload-time = "2025-08-21T19:43:49.753Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/d7/9881ac350666b3cbbff87df32aac2aa374b9892993ad0787fddb9db2e623/mypy_boto3_s3outposts-1.38.0-py3-none-any.whl", hash = "sha256:663fe24d7dc815dc6beb94de860bc542d591c927332c2441e3563b92ee27ed7b", size = 22332, upload-time = "2025-04-22T21:33:39.632Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b7/2811fe910675ab608155bf5d500d04fff7976e5cfd33a1ead8fde5a7a05c/mypy_boto3_s3outposts-1.40.15-py3-none-any.whl", hash = "sha256:1a88ed0ce43cd488ea7fb75a9a243d28e99cdbf1932a1f69612921a0b9612d4c", size = 22465, upload-time = "2025-08-21T19:43:48.036Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-s3tables"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/71/688d96c4ddf01eeca93f7df19571f489d90ef1497c345bfe791e217ab089/mypy_boto3_s3tables-1.38.0.tar.gz", hash = "sha256:0a1c62ed9b37d36f87311fe65e641cc55d2cbbb61d9c4515b42277927fd26f5e", size = 19651, upload-time = "2025-04-22T21:33:48.194Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/46/ecb240eb5be0666e5ab36e82f2446c00af9dbe8458c3fcf2a17151910b8e/mypy_boto3_s3tables-1.40.0.tar.gz", hash = "sha256:7a44a96e46b72c0c9ee6667864935092e878a3676776bed256c6d18280d113e3", size = 19855, upload-time = "2025-07-31T19:50:07.875Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/44/2faaf6258f7b2994494dc42868ab246dfeb4ff88d02ce17e4be148bb7498/mypy_boto3_s3tables-1.38.0-py3-none-any.whl", hash = "sha256:6f8d0b10847c8298d73fa5cf6a60ba760160f2445b31955b3a3945c03d126294", size = 25997, upload-time = "2025-04-22T21:33:43.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b9/df8ac09610604cc1f0ab9b2367c64ab87d80006288362a58d43d20dafd83/mypy_boto3_s3tables-1.40.0-py3-none-any.whl", hash = "sha256:63c2c8c6f28856848200182ed5ceb038c06742740896adaa640d3411e5c5803b", size = 26332, upload-time = "2025-07-31T19:50:05.557Z" },
+]
+
+[[package]]
+name = "mypy-boto3-s3vectors"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/ed/960bbff2fe442e31fe31250ab3feac9815e352cb33f4493025b29290a516/mypy_boto3_s3vectors-1.40.0.tar.gz", hash = "sha256:be5d6bf00acee6ca33799e697963cbd105d79e01ae2df30477e4256ccf311c71", size = 18155, upload-time = "2025-07-31T19:50:12.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/00/7b6e608f1996b99dc67b553635c541ccb487c71a0ce25daa4daee286e725/mypy_boto3_s3vectors-1.40.0-py3-none-any.whl", hash = "sha256:78df51a480291280e019fce538384aa991d210e66242a05cefb84e142e230e5e", size = 23529, upload-time = "2025-07-31T19:50:10.859Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-sagemaker"
-version = "1.38.11"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/46/f6/e65be57f203457e40739368ad2b5636c46a45bf364546921ff58461542bc/mypy_boto3_sagemaker-1.38.11.tar.gz", hash = "sha256:8c89ae81c25207e2c8699b14053cae23dc8ddfe0fc1b0e3d9798fbf152b8368c", size = 210393, upload-time = "2025-05-07T19:42:45.289Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/76/cdf0e355d3243dfdf481c811ee6f06ccfe49906e851770fbbfd7eff0e61b/mypy_boto3_sagemaker-1.40.16.tar.gz", hash = "sha256:1061ae6f2124c09c81159cba04f8baa33c16ec42474993b0ffc48afc51c873ae", size = 219640, upload-time = "2025-08-22T19:43:22.873Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/b3/4503f15f6027c01559be927ba750e888a87e43cc9656a5a5099b04f7ab87/mypy_boto3_sagemaker-1.38.11-py3-none-any.whl", hash = "sha256:e8aa24ab3dfe3868a7e3a490cd4e632ad96e0854449eb67cd6eb1952dea2886b", size = 213959, upload-time = "2025-05-07T19:42:40.902Z" },
+    { url = "https://files.pythonhosted.org/packages/35/63/360257f75359ddca1856d915dea58a8c77fef7a192a81eb4916d8192c98f/mypy_boto3_sagemaker-1.40.16-py3-none-any.whl", hash = "sha256:fecfc9d83a83fcd1b81c96cd1087baa6fac80cdc63819f89539d2955263fc5eb", size = 223231, upload-time = "2025-08-22T19:43:18.606Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-sagemaker-a2i-runtime"
-version = "1.38.0"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/7f/b8b06d93ee8a7822493d2cfe3872c5eb244019272b2f2ea09cec5d3e3357/mypy_boto3_sagemaker_a2i_runtime-1.38.0.tar.gz", hash = "sha256:872974b05729eb3165e1babbabe1bec921bb646d99ad0dabbdb671be3326087f", size = 16635, upload-time = "2025-04-22T21:33:50.73Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/95/ec09f82eabd7de755e8b9ed0cd96e5e3bb74d9884d8e0741a72423981b5b/mypy_boto3_sagemaker_a2i_runtime-1.40.16.tar.gz", hash = "sha256:31a6ff70ed36a9b855ca52d61cbe1a19f80c02bba379c5e9b0e81f306ece2d39", size = 16676, upload-time = "2025-08-22T19:43:18.035Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/23/d006233b9f200f50e8ba1848d3f62c853c0813e5ca78960955efc3b4b5e0/mypy_boto3_sagemaker_a2i_runtime-1.38.0-py3-none-any.whl", hash = "sha256:68f5d753ffc29e571322e8ed287d98c4bb9abb3c9b73f974228397544d145251", size = 22034, upload-time = "2025-04-22T21:33:47.061Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a7/6b32f5e925bafdce975a86ef6fda2f7b307676ff45582f933f95c6fe81ea/mypy_boto3_sagemaker_a2i_runtime-1.40.16-py3-none-any.whl", hash = "sha256:a47de75a2eef5709504b9fb8d8258cbd88d6822e1f0bf76b8a483e2a4bf43332", size = 22165, upload-time = "2025-08-22T19:43:14.898Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-sagemaker-edge"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/31/71/b80660ce48ee0bcbb95fd657652c6b120fa7ec1e21b98200bfa5acaa5fae/mypy_boto3_sagemaker_edge-1.38.0.tar.gz", hash = "sha256:8a3b67051da71ed24eabf98f44dcd75a5e917f97f219b9860af54d19b6b2f23d", size = 15790, upload-time = "2025-04-22T21:33:55.159Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/8a/ad13cbb5c963fbee2c4e60d3c70f586f509ef09be5d9f407ffdd775a44af/mypy_boto3_sagemaker_edge-1.40.0.tar.gz", hash = "sha256:caf64619203b443266e5f396b8e49ec91ab3e6ba44d04d1be2bf2764256de98a", size = 15820, upload-time = "2025-07-31T19:50:17.992Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/7d/1172308991d0a72b6a9bb378c06db0dc950960a698ce369acdf158578dcf/mypy_boto3_sagemaker_edge-1.38.0-py3-none-any.whl", hash = "sha256:7a6b020c3569227d4065d6559fd5ccc0fe32df80015a294fd38630b79ee4d6e4", size = 19306, upload-time = "2025-04-22T21:33:52.458Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/07/933f8e1d695870f54a8a1a5ab615f294e383158ede4c142ca28b49b3ce12/mypy_boto3_sagemaker_edge-1.40.0-py3-none-any.whl", hash = "sha256:a42e033a75bff07c74c8c43c2879a8028fbf0921de766622740274e82314407f", size = 19364, upload-time = "2025-07-31T19:50:15.665Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-sagemaker-featurestore-runtime"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/ab/1d3e0e0d271aa38fa985d972301bfd3a4cd8c626b9303e711611988a7078/mypy_boto3_sagemaker_featurestore_runtime-1.38.0.tar.gz", hash = "sha256:a21c8103883ef9df3b5ad7c308e0ff65816fa63855c96ebd72d39edea2c9f2eb", size = 16093, upload-time = "2025-04-22T21:33:57.374Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/a5/acbedf80b921775e565171afe4f73c4daf97235e5c6f81ac668345d8c2f1/mypy_boto3_sagemaker_featurestore_runtime-1.40.0.tar.gz", hash = "sha256:0b0f5be2a3c4d9c3f21e8bc43fb06ce7fb8e17ba7a3be2afe01e4e452b63421d", size = 16116, upload-time = "2025-07-31T19:50:19.949Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/28/84f6830bbe6bd7d20f58edc4f6e57b6b53fd281eeda7cb93599013f5b420/mypy_boto3_sagemaker_featurestore_runtime-1.38.0-py3-none-any.whl", hash = "sha256:0e9d73fd22662f23d742332b2a3f2904fd519c79df0e3a983d02cf3e4fc3fdd0", size = 19938, upload-time = "2025-04-22T21:33:54.232Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8b/b77b03d9d370d167963c0a7e238d591307205e98628ab91a953523c22e9f/mypy_boto3_sagemaker_featurestore_runtime-1.40.0-py3-none-any.whl", hash = "sha256:b502f0e9d82dc3a7bf919cbd301b937098d72f41a82d7076ed591bc4be07cb22", size = 19995, upload-time = "2025-07-31T19:50:17.183Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-sagemaker-geospatial"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/39/d41dd0f40c741601f5b2ef6926ba10f17383536dc4acc941e590f84f8037/mypy_boto3_sagemaker_geospatial-1.38.0.tar.gz", hash = "sha256:d8ee2ea764e5cc80c4ec49d1f594e91eb8de9fd46425f8dd0761d39ed417250d", size = 22426, upload-time = "2025-04-22T21:34:04.756Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/be/c5bb7fa5abdfcd622bb0fe0707188d84be3b86355d42028f65ae74afdfbe/mypy_boto3_sagemaker_geospatial-1.40.0.tar.gz", hash = "sha256:3c7cffffb7df3e749401d2d48f90b38ed6c9e1762f5d8f3fee18bfec76784568", size = 22456, upload-time = "2025-07-31T19:50:23.738Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/16/3cfda4fa44f36109800243dccd68648856ea16ad09be8fa45708e3c3dedc/mypy_boto3_sagemaker_geospatial-1.38.0-py3-none-any.whl", hash = "sha256:e0cb344d296be92105c93d1dfb411f6c4d366614cf34aed3ffb0cfbd5f5b956d", size = 31571, upload-time = "2025-04-22T21:33:57.911Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/85/4fe42900d87a02e400733904bacc9341c7bc52b25dceb3942ffc82c11578/mypy_boto3_sagemaker_geospatial-1.40.0-py3-none-any.whl", hash = "sha256:fb3a9985277b485f8f65199c89c65176dba1f40033020b5a6799f10d94ecfde3", size = 31621, upload-time = "2025-07-31T19:50:20.466Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-sagemaker-metrics"
-version = "1.38.5"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f4/80/eeb8df3a81ddb1c66c785ee9b930640eed555d4662a16b9a933a68d45049/mypy_boto3_sagemaker_metrics-1.38.5.tar.gz", hash = "sha256:97e17774532236587755a851b65f3a103c77d71c6f1972d591dfce0d737fec0f", size = 15672, upload-time = "2025-04-29T19:42:32.755Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/04/57280f73c0c0dcb6f618f35c15cf51848b98942106bb818945cbccf1143e/mypy_boto3_sagemaker_metrics-1.40.0.tar.gz", hash = "sha256:69dec3a28011805f1a3a93a4bcc9d48a0ff31c70113d97bc63a7e47abbc11945", size = 15732, upload-time = "2025-07-31T19:50:24.871Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/21/83c4b5847e706ddf64dfe735e55c39829e23b2095cc3569b5abadc77d377/mypy_boto3_sagemaker_metrics-1.38.5-py3-none-any.whl", hash = "sha256:b147f7f23c8388422aa00f0a4d98f4044b7c6ffe456005c13cc333b425faa958", size = 19104, upload-time = "2025-04-29T19:42:27.529Z" },
+    { url = "https://files.pythonhosted.org/packages/40/60/fafe3416428081e25d916d98b7c84a7d0f48af18aba507bb9db6cdcd113f/mypy_boto3_sagemaker_metrics-1.40.0-py3-none-any.whl", hash = "sha256:c58bf703b2bd13d57cb5909eb58b7bcf1b902d8f2b4084236a623d703aaa38f4", size = 19151, upload-time = "2025-07-31T19:50:23.055Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-sagemaker-runtime"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/7c/0ce3afb61ead2b0dcc1b20d60ee5956fb67bacdef704a1e1a384743014a4/mypy_boto3_sagemaker_runtime-1.38.0.tar.gz", hash = "sha256:7d137ee2fe3f0724f16b30974b5a60aabee58576ec9d0c64a45d519de5f5ef22", size = 15805, upload-time = "2025-04-22T21:34:10.355Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8e/959f6eb6b1d03ff4ae44b7d604f9219f45c82418ce2a5202944086182f07/mypy_boto3_sagemaker_runtime-1.40.0.tar.gz", hash = "sha256:828acbeb0f9ada5e72ad5181cbecce948363987efb05dca6b08c63f185988a8d", size = 15832, upload-time = "2025-07-31T19:50:29.495Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/dd/16a16117c09537547ba1a17414e5d4523b2a702d6b36901e4d6599ff418b/mypy_boto3_sagemaker_runtime-1.38.0-py3-none-any.whl", hash = "sha256:552bfa5d850c67b9356a3f02830952b0688894d30652fb86afc50c701353d913", size = 19272, upload-time = "2025-04-22T21:34:08.15Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ba/e1325c9bcd6b236579cd4ea1f4b9e64d5f94c6ed9140314ec3908b2dd30e/mypy_boto3_sagemaker_runtime-1.40.0-py3-none-any.whl", hash = "sha256:bfc8fc6bf47f30c280a60517b37152d7091a98c9620ec964934110036fb6e8f9", size = 19350, upload-time = "2025-07-31T19:50:26.564Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-savingsplans"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/ac/7e4c38e921ea32b799d86e782316a51d07c544c23e0fa999d6a79623dacc/mypy_boto3_savingsplans-1.38.0.tar.gz", hash = "sha256:ee895ddcf00e05cc64f964ca539f56af4460a834ee6835a88bf0ed0427fa4d8d", size = 17117, upload-time = "2025-04-22T21:34:12.02Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/a8/5d280d0d4fd6db1688d91a2c8ba4a72e3241a7f3277e073244f5039bee9f/mypy_boto3_savingsplans-1.40.0.tar.gz", hash = "sha256:bd07772868f9c362236ed61f8b31b4000045eba17bcfde3861a475e7ac7e6121", size = 17199, upload-time = "2025-07-31T19:50:32.658Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/e8/8e2eb0c68d319c382383f337738b7c56616b7b4868a55dd93f0c1acae465/mypy_boto3_savingsplans-1.38.0-py3-none-any.whl", hash = "sha256:eaa329fd62384be30d2600fed5d24ffbf5ada26a14f0ab8bb877a06a5f3a66b9", size = 21320, upload-time = "2025-04-22T21:34:09.456Z" },
+    { url = "https://files.pythonhosted.org/packages/26/d9/698070b55a86be2f78975a651a9635296a7d96af41c1877e900f01d5a4a2/mypy_boto3_savingsplans-1.40.0-py3-none-any.whl", hash = "sha256:c7f8d5c4dc952f538bda9b2f9fb0f3bcca8947a3b81c6c5a7037d4b9879cfe64", size = 21378, upload-time = "2025-07-31T19:50:30.576Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-scheduler"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/f3/85a453cccccc765c30dfc70ad99521df6f8e447b438bdd9d23bec019c46c/mypy_boto3_scheduler-1.38.0.tar.gz", hash = "sha256:dee0faa4e3b2d86a1d6aef83f148703dd0467d736c74be33a92d7f039d77c334", size = 18693, upload-time = "2025-04-22T21:34:14.348Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/8c/92d02bfe855da726021e3fb9680897f565005c9ed56a70be65b6388c61fc/mypy_boto3_scheduler-1.40.0.tar.gz", hash = "sha256:e09886ea797fd5a6c35ca45bb6d1d571caec1d93c236af0b2494f4715c993446", size = 18782, upload-time = "2025-07-31T19:50:34.412Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/b2/fc3fe12c132e7b2c5a92b8f29734c5801a95617e9f6c99223b79a9543687/mypy_boto3_scheduler-1.38.0-py3-none-any.whl", hash = "sha256:84b8f360fb9d2765595aa7c3337eb0ec9ffcf9786159ff73658ceacb7a794a7a", size = 24875, upload-time = "2025-04-22T21:34:12.535Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7c/ad91c78f8c509c35dba2d1014874cb3eba95c4cb1e25e3033ce8de053f5f/mypy_boto3_scheduler-1.40.0-py3-none-any.whl", hash = "sha256:d6c80339aee97768b53435ab79342f3daf43c30b938e83eb7c6891c59dcb90a4", size = 24970, upload-time = "2025-07-31T19:50:31.748Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-schemas"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/59/6b/34c24abeecaeec8e69513486b60715266e3c67b99ea4ea94d5a1e7507e13/mypy_boto3_schemas-1.38.0.tar.gz", hash = "sha256:e4f9f7ffb5d7e44c5642bcb8e68734d6dbc7dc01bde707f02aed0b2348bc0c22", size = 20837, upload-time = "2025-04-22T21:34:17.321Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/54/6c1e3e5bf950308659c8d34b02a7998d5715605bbf23130029eab3a6703a/mypy_boto3_schemas-1.40.0.tar.gz", hash = "sha256:c82c0f130462fc3046350acc6ce71eda64c8b8846e461db6ee1e093ac536929f", size = 20868, upload-time = "2025-07-31T19:50:37.484Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/68/1bd07f4f0a6252b034582586a685c8d4b57026071d33e43fba9da976ff18/mypy_boto3_schemas-1.38.0-py3-none-any.whl", hash = "sha256:295a0daa5eca61b0ef3f2f6b52b15bad0e6eda40c87e90373e9dd4990b8304ec", size = 28871, upload-time = "2025-04-22T21:34:13.662Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/5f/1ac500d21d96a5e83dca486770ea446bae64d6add1ffdc68ac36845d6304/mypy_boto3_schemas-1.40.0-py3-none-any.whl", hash = "sha256:1e0dc34aee4328d41e00c0dddcc88800f1dccf3c22433aab8123c98c8a2875a6", size = 28930, upload-time = "2025-07-31T19:50:35.422Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-sdb"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/44/6f59e7cf86fc79a8cfd74088c90afbc16a43e04d5c1d90bd94030571915c/mypy_boto3_sdb-1.38.0.tar.gz", hash = "sha256:ef7d5c53de75ced84524cd198d39948dfe4a8c14622aa28b2dee2ac0b7be5f88", size = 17343, upload-time = "2025-04-22T21:34:20.429Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/b2/d332dbf27b73ac8cbb485f29ba969dbab2eca47004e1dbd57e41e02c6f38/mypy_boto3_sdb-1.40.0.tar.gz", hash = "sha256:d0887f863ccb13ea5ff5d5df4c72e58b93d8032446393ab9821c4d72930dd110", size = 17379, upload-time = "2025-07-31T19:55:30.424Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/f2/f905accba8b54a32572670185998f11fcae2f71ce4ede8abaa43ae99b5df/mypy_boto3_sdb-1.38.0-py3-none-any.whl", hash = "sha256:8ed2b0fd446dae8e99729da0be0f8f4d58636f0fa0dab09cce02408255ba31c8", size = 22162, upload-time = "2025-04-22T21:34:18.475Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/4d/37b232f685651ecd626c65ec1e5b30102fe60803a96731b773c948587a84/mypy_boto3_sdb-1.40.0-py3-none-any.whl", hash = "sha256:70fad993b1d469b1a9420cd6bb83bcf68165f1cc6dcfa7754ec93b6eca4c563f", size = 22217, upload-time = "2025-07-31T19:50:36.515Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-secretsmanager"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/9e/fe/0302a42d4fab765215f517f9c98e6ac2b226ee0387e85816d9dda8aa93a0/mypy_boto3_secretsmanager-1.38.0.tar.gz", hash = "sha256:1666108e70f03e4dc1de449388d7facb77aba231a026bac0c3240fc27fd31a98", size = 19792, upload-time = "2025-04-22T21:34:22.19Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/d4/046dd85e0914a924ec95449d698e1ae15e698ed880e1a95ae8bf8c8d8a1b/mypy_boto3_secretsmanager-1.40.0.tar.gz", hash = "sha256:f6509365d5d4fe3260703badcef5a1c45455ed454e5f03f3573a5023cc176644", size = 19829, upload-time = "2025-07-31T19:50:41.504Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/55/bd09d6bc81df4e4dd4e8c4616752efd6167518ba10355d8d6348caa6c4df/mypy_boto3_secretsmanager-1.38.0-py3-none-any.whl", hash = "sha256:48d5057450ee307b132ce2d0976233a2c5331616fabdf423ecbc103f7431dd5e", size = 26762, upload-time = "2025-04-22T21:34:19.546Z" },
+    { url = "https://files.pythonhosted.org/packages/96/aa/647f9acd061022a5f03791ec631fef69c186f3362d9445e3a8e1d6edf734/mypy_boto3_secretsmanager-1.40.0-py3-none-any.whl", hash = "sha256:be624629e76d929c952e80e45faabfd7b512652ce1270c7e03c3ae247738eef6", size = 26826, upload-time = "2025-07-31T19:50:39.598Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-security-ir"
-version = "1.38.0"
+version = "1.40.9"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/39/92/5b33026607db3e03b289c3c5ad74928b0dd460fc9217244301dd993f06c2/mypy_boto3_security_ir-1.38.0.tar.gz", hash = "sha256:88dc694e88433ef0816240d311e0c7fc0d46bb6d58ce164cc274be1235c9f9ab", size = 20236, upload-time = "2025-04-22T21:34:26.569Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/2a/4efcb0ab50fee63b5536ad454678932c1d60e4be6c5aab95e4468d34e7ee/mypy_boto3_security_ir-1.40.9.tar.gz", hash = "sha256:c64a4ed8eaa1af1402bd72687630a9c0f6b7677e6c19f28d92aefa35ff49382c", size = 20445, upload-time = "2025-08-13T19:29:12.278Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/40/6971fca1dbefb0870c456512b02149e93524afcc8a8a2c4f5368fff22b3f/mypy_boto3_security_ir-1.38.0-py3-none-any.whl", hash = "sha256:d80afc69efc5eef232ff96e47676fba8ec00b150de8ae231023e0a3f1fcc1cc8", size = 27615, upload-time = "2025-04-22T21:34:23.276Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/6e/8c0c893b85a9a72bd3dba3772a2e551c1a1ca8094a433ebc8d5975cf0426/mypy_boto3_security_ir-1.40.9-py3-none-any.whl", hash = "sha256:49ac113aa78dc517de8b945b189242088ac6a910a10ec675e0fdd78c060e1899", size = 27995, upload-time = "2025-08-13T19:29:07.852Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-securityhub"
-version = "1.38.0"
+version = "1.40.1"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/6d/99/17937eba83ca504e5044bac1426e56175715e22c1933d9f49bff27cc30ca/mypy_boto3_securityhub-1.38.0.tar.gz", hash = "sha256:7e80a6fa00a9b4dda51cb497481ece6329ffdb8271edc27a482c5de08b47ccb8", size = 135923, upload-time = "2025-04-22T21:34:28.455Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/44/487ccfb28d7d279cbe71153e49d7553bd2490de9a6fd4713d8b4dbd6d9ce/mypy_boto3_securityhub-1.40.1.tar.gz", hash = "sha256:c0d187a526dcc55adbe146022c340724a674fb6a81ecf29a04cf4648df5d17f9", size = 148306, upload-time = "2025-08-01T19:29:31.679Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/ae/e1679bd160988edeb28c0c1ba040167db06ca029bfd3cfab5d4aa15e3840/mypy_boto3_securityhub-1.38.0-py3-none-any.whl", hash = "sha256:2efed0b4ee60bbad87720f2699c67dc6bd553a0f929884dd1e52c905ea17d0ed", size = 143562, upload-time = "2025-04-22T21:34:24.812Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/3c/1b115a61cf247532666d0d7de762c993453dafad0d66f8d292215c37a4bb/mypy_boto3_securityhub-1.40.1-py3-none-any.whl", hash = "sha256:a4ad82bc26333df57354d9ee8e60e946a404674cd685e5e3105fa4450b3f9ca5", size = 155008, upload-time = "2025-08-01T19:29:26.019Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-securitylake"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/cf/ac/b1383a4c6a2bfcb1d874707c7daf830b898154bde8235f1aef4fedaa2314/mypy_boto3_securitylake-1.38.0.tar.gz", hash = "sha256:6779594cbea60dda856290b16aee8a861455be3dd5f9a01dd6df9e933b3954b4", size = 21459, upload-time = "2025-04-22T21:34:32.174Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/15/fdf890fbc3d6324583ea2b5b24f40aa755f76cf9ef6e580f658331ae3343/mypy_boto3_securitylake-1.40.0.tar.gz", hash = "sha256:0eb9838c5c7c37da6a2f6b629167753c3d2abc15f6a08d98f7e5a20ef0253a01", size = 21502, upload-time = "2025-07-31T19:50:53.487Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/4c/6f968a342ef1f6ea22b69a0369bd2d63378e595c814ea4b18539367409d4/mypy_boto3_securitylake-1.38.0-py3-none-any.whl", hash = "sha256:c70c8ffc025ae0e2dba8ae8ac2eafa6224dc7a5e3a2c19ecfdbbc5269b51a363", size = 29734, upload-time = "2025-04-22T21:34:29.546Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/da/60968813a4d2cee34a4aec94c156410e8527185b748e8e664ed826f6729c/mypy_boto3_securitylake-1.40.0-py3-none-any.whl", hash = "sha256:502142d5ddc0ab6f91ba9e554389c9a903650c75df74166ab4e34cf618c08de3", size = 29787, upload-time = "2025-07-31T19:50:51.443Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-serverlessrepo"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/00/f751b5d37310ae696c10d1b1e6548a55e70f9ad6beed0592c2204081ad71/mypy_boto3_serverlessrepo-1.38.0.tar.gz", hash = "sha256:ee8680c27864e3ddf3665cd917a54bdab776916230ef6a23508eec120c1ab935", size = 18829, upload-time = "2025-04-22T21:34:33.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/c1/cdc06ce0b937db072e0fce48ec32120d293edbb3f3b9c04bc991142d43da/mypy_boto3_serverlessrepo-1.40.0.tar.gz", hash = "sha256:13940d38422ae784cb0adb2a0998359881559e4eff933bcb7ff2bdbe1b8eccc6", size = 18853, upload-time = "2025-07-31T19:50:56.629Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/7e/6d51330d211fa8ed625fa75c83613be899a19616c58a836710255e04ec9b/mypy_boto3_serverlessrepo-1.38.0-py3-none-any.whl", hash = "sha256:d94a0541a9c5be57ef861108f4518811fd20585c13371b51f57147a3c3b661de", size = 24936, upload-time = "2025-04-22T21:34:30.169Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/5f/5446606e0bdaa746a9c90f4985c48f70f142f46a371d6c3879f5e229792c/mypy_boto3_serverlessrepo-1.40.0-py3-none-any.whl", hash = "sha256:8e110666885a05540eab71b697369b885f5e4a48de4a1f02ac9231452e798b80", size = 24990, upload-time = "2025-07-31T19:50:55.1Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-service-quotas"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/3a/fff38ba79f4ed80980931dca88b79ba71ca8467b24a4f8109af423ba84db/mypy_boto3_service_quotas-1.38.0.tar.gz", hash = "sha256:22bfb53a54074d8dc1a957994015ceca7f99555f992c86dcc0e594eb72ce71bc", size = 20227, upload-time = "2025-04-22T21:34:37.208Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/54/990ac0617a24445f66f329dfdb57214d0ea6d2802d2e3473db13753ad5ab/mypy_boto3_service_quotas-1.40.0.tar.gz", hash = "sha256:65097322d29130da4c8c10ec31d617799c5ce77180e0e0ec6174fc43f45f47b5", size = 20311, upload-time = "2025-07-31T19:51:00.762Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/fc/41d4e36c4ad2e830916ee0537e636b74f500951205c82160357c24c7889c/mypy_boto3_service_quotas-1.38.0-py3-none-any.whl", hash = "sha256:5354c72efbfa8c33b2731644e74ccd82e18726a126b3eff341b98c44749066ed", size = 27491, upload-time = "2025-04-22T21:34:35.239Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/7d/860f7bb516599b28428103c05b00988e4236816336fa65524f3cb14019aa/mypy_boto3_service_quotas-1.40.0-py3-none-any.whl", hash = "sha256:551feee1392b23578943ad16e479ed442498be1a9e8524251d189bd9a267562f", size = 27705, upload-time = "2025-07-31T19:50:58.597Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-servicecatalog"
-version = "1.38.10"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/69/7af06daf8f57ba6da66edfe1bca278a2023a5761ec6cc502a324dc4ad2f4/mypy_boto3_servicecatalog-1.38.10.tar.gz", hash = "sha256:bac4fbe455e396ed9802680bac75495884a73e63d7aa0ae5ddaab7b0f31a98c9", size = 43016, upload-time = "2025-05-06T19:42:37.701Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/31/f77305e981eb9413c7fcf75a3a805fed54d325c95dff47f37ccaa5ada294/mypy_boto3_servicecatalog-1.40.0.tar.gz", hash = "sha256:350a4100dd62480812d1370a59ef06511c312957639ac95c7e4a45f2b10bdc6e", size = 43034, upload-time = "2025-07-31T19:51:07.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/f9/e4fa1863df5724011b3c8f99a1f5d7b3952a2adde4455360d1b66340962d/mypy_boto3_servicecatalog-1.38.10-py3-none-any.whl", hash = "sha256:4a7f5b8f890db4f37ef02dc8ab269ef8d7e9199b024b80968069acacdbcaf654", size = 49309, upload-time = "2025-05-06T19:42:31.522Z" },
+    { url = "https://files.pythonhosted.org/packages/79/43/3445a5a04ef211e6259f7a8a1b89671a584342bb8ef6cb352fc96da6a5d7/mypy_boto3_servicecatalog-1.40.0-py3-none-any.whl", hash = "sha256:5ad0bbdcb53a4da4573bb786f2b4dced691901b634af5d12a21fe9d31ebe44cf", size = 49348, upload-time = "2025-07-31T19:51:06.068Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-servicecatalog-appregistry"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/05/b38728edb7f8c3e25d28e18d2b8af452b46763657dd41b34f316a490e119/mypy_boto3_servicecatalog_appregistry-1.38.0.tar.gz", hash = "sha256:dd862003ceb9c130a579a443d809bd1f7098434c2bb13f91b1e39486cebbf11c", size = 20667, upload-time = "2025-04-22T21:34:38.195Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/77/52fb4b290928cab463b0c89092c6b1fa0eff507bffca5c5f6579a94d066e/mypy_boto3_servicecatalog_appregistry-1.40.0.tar.gz", hash = "sha256:113da9ac7cc78b410191607d32599db9d69a2616b2e629f9fab7541744fabde1", size = 20688, upload-time = "2025-07-31T19:51:04.382Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/2c/477b459ab84ee76ed0bc20748761cd97f192c7be4e469ef7afba79c0cf92/mypy_boto3_servicecatalog_appregistry-1.38.0-py3-none-any.whl", hash = "sha256:0520c3cd0ddaa74b92f42740f90cae4bcb56249c02639d95700a0cc071a9a5c7", size = 28307, upload-time = "2025-04-22T21:34:35.824Z" },
+    { url = "https://files.pythonhosted.org/packages/de/82/fa5036128d923222165b007dddaa89f9a8c8c376af26c0a1e279492ea9d4/mypy_boto3_servicecatalog_appregistry-1.40.0-py3-none-any.whl", hash = "sha256:097ee068ffa6ea5348253243f2c7ddb7d72e44f38d274e4b2b6ec6693ca33a6e", size = 28359, upload-time = "2025-07-31T19:51:02.512Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-servicediscovery"
-version = "1.38.0"
+version = "1.40.10"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/c1/69/6cd713c1b7d01b0d8db9d8979d06549613a093542e7dc71f05666ede4c40/mypy_boto3_servicediscovery-1.38.0.tar.gz", hash = "sha256:daab0c0614154dde72cc685c5f9987e12f4f80e7815f1139ffdc3172e917a4c9", size = 21704, upload-time = "2025-04-22T21:39:42.675Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/aa/d6afbfcf9ce0a9b961ea0a43cbfd207373265d0ad470a2249655d8f26fb5/mypy_boto3_servicediscovery-1.40.10.tar.gz", hash = "sha256:fc6caaf5d8028de22b353c54a84fe6bdf3ebfb873e0279f9f9ea77fcd261ad6f", size = 21819, upload-time = "2025-08-14T19:27:52.087Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/aa/097dcdce0f09987e755d902a6341531d49823b168722f98f729de66969c0/mypy_boto3_servicediscovery-1.38.0-py3-none-any.whl", hash = "sha256:be2df782295811c3dde89d3b14ca1455930c29dc0493c9313e5509e21d9fbff7", size = 29944, upload-time = "2025-04-22T21:34:40.904Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8f/2c245aa84d69e46c14346ac5254bfaa69d8841ab3689669e94d1b8718a32/mypy_boto3_servicediscovery-1.40.10-py3-none-any.whl", hash = "sha256:3539f9b7f86e91f33974fbe71890c3ee36280fb374f8519e0a2c278d0d5397f9", size = 30218, upload-time = "2025-08-14T19:27:48.373Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ses"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/d8/735e5694761363fbe090973d5afca73ec92b94c7d3dc48607725b08db19a/mypy_boto3_ses-1.38.0.tar.gz", hash = "sha256:1741e3cbace8454b121d93d22d49c8238be955eb9db602f6561d4222a6e3df30", size = 31252, upload-time = "2025-04-22T21:34:48.549Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/71/ade6e60922fa9df192301f7e0ea00976cd59b416d8b0c44ce05d21329027/mypy_boto3_ses-1.40.0.tar.gz", hash = "sha256:abac11726aed03425bd5ad38226289174ac1305f9d23b0a09882fd499a36ec1d", size = 31365, upload-time = "2025-07-31T19:51:16.079Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/49/501610eecdc85a41126fbb83eb98d776e4d8b62cdaf6f3e221fa64f432ba/mypy_boto3_ses-1.38.0-py3-none-any.whl", hash = "sha256:e4fb4785caea4743dedbb0827bc697ec43bf674311d5cdef6b5e09abc5a230b5", size = 39385, upload-time = "2025-04-22T21:34:41.623Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/91/4b0d316aeb9fb9a4acc21ff2278e7706bd05edebbd93e6bbe805407d580d/mypy_boto3_ses-1.40.0-py3-none-any.whl", hash = "sha256:ba730594ae35e42acfc6836c2c34e1185871e9e4e79495fdf57958be4758fcc0", size = 39453, upload-time = "2025-07-31T19:51:14.177Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-sesv2"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/d8/cb962e76def46d71e008a32b9491117db7ccb150b11b761cd66a8ab1feb3/mypy_boto3_sesv2-1.38.0.tar.gz", hash = "sha256:112c3ddbee03a4b0bbfbbdac1d06fe907187c7a86d43e0a64a777a0da2d2ccc1", size = 42692, upload-time = "2025-04-22T21:34:50.292Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/df/8f1ccaacb68e65b363945627595eced58c8adeeefe782e4a5ab2b9b507af/mypy_boto3_sesv2-1.40.0.tar.gz", hash = "sha256:6862b8e3e7d32b04fee68e1b72acf51af3a6ffd8293f7a17f3612d6bfb9773cc", size = 46597, upload-time = "2025-07-31T19:51:20.069Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/be/ef3cf0ddeb17cabb7f38623f245ad19d472b49fe854ac3b5a34153a930ba/mypy_boto3_sesv2-1.38.0-py3-none-any.whl", hash = "sha256:7b4dbe682b38e22e251091dd017535e852655365f9db0095ed0a46943a116f1d", size = 47262, upload-time = "2025-04-22T21:34:47.578Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c9/bc8df41c06ec3cc6cc22b653859ebae070d2f54f30a2e9c9632e2d8273b4/mypy_boto3_sesv2-1.40.0-py3-none-any.whl", hash = "sha256:493569840df0a55ba8c616635a1154f60f9802fe793862fef00b0231bb27768e", size = 51741, upload-time = "2025-07-31T19:51:18.213Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-shield"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/1a/da0b358bf771febb63e1896ee8cd978e68f9221ae7313495c23345ccd264/mypy_boto3_shield-1.38.0.tar.gz", hash = "sha256:239c12dad444f45a3dfa024a2e030fda00c0e8116a17e0ac27ed4f0829ba47b5", size = 21266, upload-time = "2025-04-22T21:34:53.889Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/30/b1607b98807fbc6bf6584039909d0af78d6a62b409d2db685b246712ec95/mypy_boto3_shield-1.40.0.tar.gz", hash = "sha256:9f081a49aaa2d4f79b1b83c4728ee8e89d1b5f6f3e36955b62203e4979363abf", size = 21328, upload-time = "2025-07-31T19:51:23.77Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/c5/fdd87410507c2ad1aee6e4cced0f1b9db350221f61bfd3448cf524ed1613/mypy_boto3_shield-1.38.0-py3-none-any.whl", hash = "sha256:831a089b1d8068031e1c3d8bfe2a6fdc8a6728e842ea9181c009e9b8801b51c9", size = 29407, upload-time = "2025-04-22T21:34:51.346Z" },
+    { url = "https://files.pythonhosted.org/packages/15/9d/162a21c183c13b4aa4e20d4ecdabd45129b5b5d4a093012bb11fcfdc2909/mypy_boto3_shield-1.40.0-py3-none-any.whl", hash = "sha256:870badb7b2e71f8d77483fbceb728f383693f0082f9e35812d9dbd29e50d6fe6", size = 29463, upload-time = "2025-07-31T19:51:21.938Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-signer"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/4a/f38981d5dfeb0a998c4d6e363e567257bb805b2aed647e9123f111b9f2f2/mypy_boto3_signer-1.38.0.tar.gz", hash = "sha256:68875fc90ded54ddc6f97aaa17c7c51d1241a459cad84d135322de597ff9f90b", size = 20648, upload-time = "2025-04-22T21:34:54.703Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/f2/9ae2e9bdf0c315f9f7f56ba6c6411c9407642f630d5e325361376d1f23a7/mypy_boto3_signer-1.40.0.tar.gz", hash = "sha256:4bbec4752c447c99f90b3c730568f1cd2635cedb419d2fe93d0d8d58a15033a9", size = 20681, upload-time = "2025-07-31T19:51:27.482Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/9e/0f0e0e7b299146cfcd744a834c231db558d74c2ae33cc015a4006080b628/mypy_boto3_signer-1.38.0-py3-none-any.whl", hash = "sha256:bf7ccfa630fcf61553bbc4a1ace95cf208fd11719e8484cf1bca44aa0d117d07", size = 28905, upload-time = "2025-04-22T21:34:51.906Z" },
+    { url = "https://files.pythonhosted.org/packages/56/11/59226c30f40a55b9c901a98eef1b2c85bb6dad26e44c78cadeeaa910f2c5/mypy_boto3_signer-1.40.0-py3-none-any.whl", hash = "sha256:f44810060c91d345d9566ce99c3cf58938a2648485d772fcd85d9dd2234aebbc", size = 28959, upload-time = "2025-07-31T19:51:25.699Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-simspaceweaver"
-version = "1.38.0"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/ad/22/2da4c6b56f96b4a2ef0fed2633a4429b47c7ead437a694c16b1d70c22b18/mypy_boto3_simspaceweaver-1.38.0.tar.gz", hash = "sha256:9a29f39e806aea4e7fbd1cc348e113cbafd27a54d9a66f95f9a8a7a3e1359a16", size = 17392, upload-time = "2025-04-22T21:35:01.603Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/5464793db85fc28f0b83b031e18008f3f57238a2e2ac72e337c30c6ba970/mypy_boto3_simspaceweaver-1.40.16.tar.gz", hash = "sha256:45f46ba12f31dca898e4ebf2469393f160a2dfb708e5851b663d8110eb2480a9", size = 17443, upload-time = "2025-08-22T19:43:23.916Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/e1/37c399f2575a65c7c5e64bf588a0c79522a1ff4cf0fccce21a1ef7af177f/mypy_boto3_simspaceweaver-1.38.0-py3-none-any.whl", hash = "sha256:210081a55b4bde701bcd2236471e8fc306e26af0a2ce23563af0c7375f1a1d93", size = 21730, upload-time = "2025-04-22T21:34:58.769Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e9/91e30c8aef44b0ad0101fb78f326b9a48011be01fe0e46f2c8898ae29dfb/mypy_boto3_simspaceweaver-1.40.16-py3-none-any.whl", hash = "sha256:cacef4544e3b95c5a4905ffeebc8e155115c5c82d22915407515dc8105782e39", size = 21864, upload-time = "2025-08-22T19:43:20.528Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-sms"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/ed/3d5c2f579327c092cb859af07df6d6b24893fca99a89811bd2e2f322d2bb/mypy_boto3_sms-1.38.0.tar.gz", hash = "sha256:730b3061329c8caabf2fafe72d827be0e43ba7264d78cc4dd721d0581a704f8d", size = 22484, upload-time = "2025-04-22T21:40:01.317Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/a3/98214b50d72af5071c0453ef6b300124b56a5079a749a894c1458f8c53f2/mypy_boto3_sms-1.40.0.tar.gz", hash = "sha256:655ac7de5b84a47c0e45afb52cd766823bb7f89532f7f17a8213731d95227017", size = 22653, upload-time = "2025-07-31T19:51:34.669Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/35/2fff6b0dc4d0210a9bec249cdd172a4715562a0519699d91de6035f137a6/mypy_boto3_sms-1.38.0-py3-none-any.whl", hash = "sha256:4ccaa65b3f668f677bb148c9615accf295225be95a211c43e27dcd49c84b0c42", size = 30964, upload-time = "2025-04-22T21:34:59.42Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/ab/48ef316fa9d9b3770457d0b08fcf44195338e53da1e6ab1ea7a6d45310a5/mypy_boto3_sms-1.40.0-py3-none-any.whl", hash = "sha256:64ef44e3b35458f21dbc6af14b6b116ed0806842e7dae82fe71dab307e8d9b65", size = 31018, upload-time = "2025-07-31T19:51:33.244Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-snow-device-management"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/0f/221ee46b0cc09d0cf7d16d50f3c12ab4eb8c76cc5a413b0687441294bd04/mypy_boto3_snow_device_management-1.38.0.tar.gz", hash = "sha256:cbe50d8219850b43bf49385355514cdbf95517428e81855902f841647688d000", size = 19320, upload-time = "2025-04-22T21:35:09.043Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/eb/da6c2660738f6f3061e3ff62d95848e6c54b358c09d4c48f05f5a28e8d93/mypy_boto3_snow_device_management-1.40.0.tar.gz", hash = "sha256:9f3f26093dc5dd39d4fd298ef4103227f434fe08715214d90a01ec5c7697f3e3", size = 19388, upload-time = "2025-07-31T19:51:35.897Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/a3/4acb2da7b7f7b4c349a1d7811d2a87bbf27f8a594f646c045e8ab82d2e2f/mypy_boto3_snow_device_management-1.38.0-py3-none-any.whl", hash = "sha256:27d0d7d7d2641ba644160dc0604798cfc975a10818df6e0197ed050e5aa17d4e", size = 26418, upload-time = "2025-04-22T21:35:08.056Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ae/7ac55e7fba7381110d49605062680dd231d33f7ffda25dda53ff0919ab44/mypy_boto3_snow_device_management-1.40.0-py3-none-any.whl", hash = "sha256:b625c62c1de3893d32f39465b96cf454491d06205f574f8f25b6443f572e14f8", size = 26476, upload-time = "2025-07-31T19:51:33.482Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-snowball"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ab/711d9884f3f61c9183403dfd9e63dfbd009240b5591bd5a8461d6fc957c5/mypy_boto3_snowball-1.38.0.tar.gz", hash = "sha256:cd77904cd49e8f7741214100cac0308e3d6ff783995816e56f6013ff56b6a032", size = 22755, upload-time = "2025-04-22T21:35:10.906Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/f6/7aebd168f2dea5f7590c7d16111b0f7cc7630501b14f30808c4fdb42972e/mypy_boto3_snowball-1.40.0.tar.gz", hash = "sha256:ed4173e473ade22298adddb93835ebaece8e2386cc65bc52eee13efa9b269f95", size = 22790, upload-time = "2025-07-31T19:51:39.751Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/1a/356997475f2e66fe98d80c7ae65f1b0c86dedf9bf701b97f983cd517bb03/mypy_boto3_snowball-1.38.0-py3-none-any.whl", hash = "sha256:f3bb253f896a1cfed879ba7d849ddeb66330369d827986e562871f6405d6619a", size = 31795, upload-time = "2025-04-22T21:35:09.78Z" },
+    { url = "https://files.pythonhosted.org/packages/be/08/ba6024f42961d925041e3d8ac70bc5111ce41025860878038a39804b11ef/mypy_boto3_snowball-1.40.0-py3-none-any.whl", hash = "sha256:178658d3964bb9e4fe6ce68ccc493a3c6275609606506d029fb0535d842449a2", size = 31850, upload-time = "2025-07-31T19:51:37.079Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-sns"
-version = "1.38.0"
+version = "1.40.1"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/18/1f/342f601133daff0c34364783060d6a95b657548bd39ee061fa64c03b4860/mypy_boto3_sns-1.38.0.tar.gz", hash = "sha256:0e7cbec9c591db0e3c5acbe3ad3c47dfb0e58ef96c13aad49c27c9fdea3d4628", size = 33208, upload-time = "2025-04-22T21:35:12.822Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/fa/8be4773dd636571c8b3620ab15862ebd501a76a0c193b2141acf23c15e82/mypy_boto3_sns-1.40.1.tar.gz", hash = "sha256:e06d89db10c83364096365c630a144d59ca3e0fdb663bbd6b73bd1816d1e53db", size = 33271, upload-time = "2025-08-01T19:29:36.321Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/44/eb6b7aee2a9e8cdf8fd09308c7f2b435c53db6a6c83d16e64043a0064939/mypy_boto3_sns-1.38.0-py3-none-any.whl", hash = "sha256:e9da0864fe8463a390a0b83c3731830c7aabe98baac61091f06442fcb796186d", size = 40079, upload-time = "2025-04-22T21:35:11.644Z" },
+    { url = "https://files.pythonhosted.org/packages/be/21/e826d138ccbc5d319e2f64bb2872fe583dddf24ad547f47baf834e6d8992/mypy_boto3_sns-1.40.1-py3-none-any.whl", hash = "sha256:538920699f461b6f142b6dd36492b6a27c2113410ed427422122c7da9d2c921a", size = 40184, upload-time = "2025-08-01T19:29:29.944Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-socialmessaging"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/bd/9ca8dd77685c612b91d45cd973e7a4c1603d5a2cc65eb7c8bc368ded53d3/mypy_boto3_socialmessaging-1.38.0.tar.gz", hash = "sha256:51c0b9d3cba0b580dcb2589c3434980d897a082faaf1b1fa238d1e81e63e8ec1", size = 18358, upload-time = "2025-04-22T21:35:14.957Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/06/5f90a9ef92806f76af7b5c88c6efcbe7c5e0eb7d98439364bf99adad8aa8/mypy_boto3_socialmessaging-1.40.0.tar.gz", hash = "sha256:b9e623fd85b37925bc08a764cedcb5398e83a527aa38be453ddc759a3c849c51", size = 20330, upload-time = "2025-07-31T19:51:47.38Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/26/8eae916f10dac3a7385dcbd19f53d87b1dba50e651de1f438256bdf57aa4/mypy_boto3_socialmessaging-1.38.0-py3-none-any.whl", hash = "sha256:410f52a13cd9f7ac431b9ee922d859f0e529c29cf849807adafc6788f5a59f85", size = 24556, upload-time = "2025-04-22T21:35:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/0e/01c972635bffa4a82e12d677ce774a7dbc76b23d6565d7f36f794afe0fce/mypy_boto3_socialmessaging-1.40.0-py3-none-any.whl", hash = "sha256:ed30cb3496974f0ee9d4818f631019dc2077aa5ab3c2ade087b3683aa38f774b", size = 27977, upload-time = "2025-07-31T19:51:44.915Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-sqs"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/a0/ef5c7bdb33af5d0a48029fed11401388fa68949c6c0f9b11b2e845f5fe0e/mypy_boto3_sqs-1.38.0.tar.gz", hash = "sha256:39aebc121a2fe20f962fd83b617fd916003605d6f6851fdf195337a0aa428fe1", size = 23541, upload-time = "2025-04-22T21:35:17.315Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/a7/5fb39650f9c7a8e1289cabf74725e22edde5e029f095b384881586163653/mypy_boto3_sqs-1.40.0.tar.gz", hash = "sha256:03d0b5b488e3d01f2419400ba245dd7b89bbe06a438a5d4f59d358eeead19bb4", size = 23610, upload-time = "2025-07-31T19:51:49.019Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/97/72fccc9aaa0e3c8f3f99b4edac580ede651808aefb47b0d2b52c18a3d16b/mypy_boto3_sqs-1.38.0-py3-none-any.whl", hash = "sha256:8e881c8492f6f51dcbe1cce9d9f05334f4b256b5843e227fa925e0f6e702b31d", size = 33669, upload-time = "2025-04-22T21:35:16.073Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0a/2f1e8b332aa94ca949ac4815c50ac261c00ce907e1d39ea4914c2341e797/mypy_boto3_sqs-1.40.0-py3-none-any.whl", hash = "sha256:af9055ccf1612bc53b7849beb761b751f5a7c94ee7562c03ebb16a3583945a40", size = 33728, upload-time = "2025-07-31T19:51:46.302Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ssm"
-version = "1.38.5"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/7f/b4/3b147e4fe968cbd88b3153641dcfacfb35218a3e5f15f1a74cd3ebfd8b75/mypy_boto3_ssm-1.38.5.tar.gz", hash = "sha256:e95bbad7d2f6b4849bc946eb9bbcc1f134cbdaafb172c365bedecdb3104eee0e", size = 94521, upload-time = "2025-04-29T19:42:53.237Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/64/c9e4830574c2e3e0027cd7158464cab26029dac371f7209cbdd6c4349f1e/mypy_boto3_ssm-1.40.0.tar.gz", hash = "sha256:4a656240ead29ffcfb28e95ce7c7ab6c9bbad71bbe7ce81f328ff9b214ff114b", size = 94639, upload-time = "2025-07-31T19:52:00.42Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/20/5e4b9655130674153c45febef9490e20e3739085341ba9bc085cbbde79cf/mypy_boto3_ssm-1.38.5-py3-none-any.whl", hash = "sha256:1bb0f932bee9038a53ab02781f959fc553a5d7f5e9d7cba56f998d0eb0a5878f", size = 95950, upload-time = "2025-04-29T19:42:49.723Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/59/b93f0a87a11fc126141ddb92d2d29b074d3a26e95c87b2ce204572661b3a/mypy_boto3_ssm-1.40.0-py3-none-any.whl", hash = "sha256:9f7d03feac4d5eb3e551871d49814994a216539845e5a223ea3f6c17945bcf05", size = 96071, upload-time = "2025-07-31T19:51:58.214Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ssm-contacts"
-version = "1.38.0"
+version = "1.40.15"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/53/de96f3b6cba576e530e7d8afee992656dd90bf11808cc792bc0fb8ef074c/mypy_boto3_ssm_contacts-1.38.0.tar.gz", hash = "sha256:1dfff6186bef5a3b8604b424dcc8fc7ecd0bc709c802b8bb0f5005f6c88ee1af", size = 26099, upload-time = "2025-04-22T21:35:19.512Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/d1/483296b3817c065cc7d233c2d6dc0bc334606c9d872615649eec8a188efb/mypy_boto3_ssm_contacts-1.40.15.tar.gz", hash = "sha256:e0ccb4198cf399616eb8880a58fc7151a0a2a6f4988fb9ec6f8e1bedad64adb5", size = 26186, upload-time = "2025-08-21T19:43:50.731Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/2e/e521fbe189355b1bd39165cc1fecc53d5971e8a4096ff395a21cc4f872b5/mypy_boto3_ssm_contacts-1.38.0-py3-none-any.whl", hash = "sha256:735b3fe1e2bf24a94eb1dddd4651b7b2994923ffddba50e9805deff803efa665", size = 32664, upload-time = "2025-04-22T21:35:18.518Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/51/53b4735e8bc4e969800f4908e4f1ad04b9df36973b51bb451e58c55f11be/mypy_boto3_ssm_contacts-1.40.15-py3-none-any.whl", hash = "sha256:f6ec62e1f08c6ede28fad9a59ccc42a2416581f615f3b85b3bacd1619176460b", size = 32819, upload-time = "2025-08-21T19:43:48.623Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ssm-guiconnect"
-version = "1.38.5"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/9b/c0/25ade0b197a8c7983c44043011865529d4714cb3fdc6c49e8d0e923264c3/mypy_boto3_ssm_guiconnect-1.38.5.tar.gz", hash = "sha256:f833a7658f4f31d261c6601d8387b2964eced902b8bad444d339eca4671c5882", size = 15370, upload-time = "2025-04-29T19:42:44.398Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/b3/a81045afdeee7862307756bc095cd1eb3de481c02a843d0cce8dfa1c6c5b/mypy_boto3_ssm_guiconnect-1.40.0.tar.gz", hash = "sha256:f77502dd88a6cdf3715c54a52a135559175d661714f211a593830b090e68ec95", size = 15407, upload-time = "2025-07-31T19:51:55.319Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/b2/caf57d284473b2b4b2416b112dfe755e84e4acec35cf25f0aa2970e13ac1/mypy_boto3_ssm_guiconnect-1.38.5-py3-none-any.whl", hash = "sha256:b8a50ce2a534c2dfdf2491591af1ff6d01ca409f60271ecef5e3f94e7bea598a", size = 18395, upload-time = "2025-04-29T19:42:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b2/06809be575432821864ebe75cedbd86ff685f2afe79e2cf6548470a7ba0b/mypy_boto3_ssm_guiconnect-1.40.0-py3-none-any.whl", hash = "sha256:907e65be6125c9f5c00b47a73d674e8b93851982f5513e95a02097fff0647b47", size = 18438, upload-time = "2025-07-31T19:51:52.607Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ssm-incidents"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/ca/adefca2f2ddc79e192b1db0bf4f7758db37f2f7987ac24250b461511de1b/mypy_boto3_ssm_incidents-1.38.0.tar.gz", hash = "sha256:651100d4c69f6b861c2469174d991c52e2ec6c4d5ba2e2b496a934cc103646e3", size = 23810, upload-time = "2025-04-22T21:35:21.254Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/01/527e92d9badf2a0e10725c277908f5bce1946d2ef33537d129cb1260d6e8/mypy_boto3_ssm_incidents-1.40.0.tar.gz", hash = "sha256:117e1ad11dcdea9599a726ec4687efb19ed9e5e402bbb79ccc4387cabd92fa1e", size = 23843, upload-time = "2025-07-31T19:51:57.626Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/29/ebbd6f8c06e61cf1ee2f3507e37e1da96998df0b2362b4b725b09be905aa/mypy_boto3_ssm_incidents-1.38.0-py3-none-any.whl", hash = "sha256:1edaa0573b8177393be93b57247cdc7a95bb1b8a4096e22be24ed608be3d0b22", size = 34566, upload-time = "2025-04-22T21:35:20.216Z" },
+    { url = "https://files.pythonhosted.org/packages/96/07/a2961077b6347e59c89d9fd545034520d2b8da9f456f2be8b8de3228be1b/mypy_boto3_ssm_incidents-1.40.0-py3-none-any.whl", hash = "sha256:637e798ae8535ec60a86739546db9579fa42f0ac9b11d58c271584c7142c4504", size = 34618, upload-time = "2025-07-31T19:51:54.383Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ssm-quicksetup"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/50/5b/97a330f218ac636c95a654408865cb35b0d64b47ecad8aae17b47b7f2c7d/mypy_boto3_ssm_quicksetup-1.38.0.tar.gz", hash = "sha256:0d0cf28690b3f0a28b6f1bb9f2500e0e7bef415f0db277d201e1afdfb0982903", size = 18191, upload-time = "2025-04-22T21:35:25.404Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/04/69a685f5aa1b0310bea5766e963fe586649398da295e58e7f88d809f9911/mypy_boto3_ssm_quicksetup-1.40.0.tar.gz", hash = "sha256:9ac98e3f44b5928934f96ee30368ee7269728a294621bc5c31229160ff0fc753", size = 18207, upload-time = "2025-07-31T19:52:01.706Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7a/629f483995111610bf52bed9fdba96db2997d02095ed1ac6bc5840f6858e/mypy_boto3_ssm_quicksetup-1.38.0-py3-none-any.whl", hash = "sha256:3bf5f7834ca986409271a8e09da0317dbca43b3059572e8377dc3237d2eeef45", size = 24075, upload-time = "2025-04-22T21:35:24.113Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/46/2729d5e9ce11d02a6e20ca4da8010ebfb761bd0c697d97f3b7c0bbb3c2c7/mypy_boto3_ssm_quicksetup-1.40.0-py3-none-any.whl", hash = "sha256:1da9b7db5dbcb114ed02bde572c647add83bd6f9737605bcd0d9672bd9a43b1a", size = 24134, upload-time = "2025-07-31T19:51:59.418Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-ssm-sap"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/93/9155c1bb553000caffd787b8d409bcef467c9908c5dae247ce57fe33803a/mypy_boto3_ssm_sap-1.38.0.tar.gz", hash = "sha256:759f30f21e94819a649dcd254cc4f570d806f38b8c9a041ca6dc3167c77ccf44", size = 20888, upload-time = "2025-04-22T21:35:27.089Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/14/d98f45a445d7d916cbd2d49d9ff4d91242510b87881edf04e1e1bdb8659e/mypy_boto3_ssm_sap-1.40.0.tar.gz", hash = "sha256:e0b6429ed57f0511befd8ebf8563e07ae14feda9f1ec78ec0b538c1d95e083ed", size = 20897, upload-time = "2025-07-31T19:52:06.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/e0/391a9e78230fcbef51cfc6033d66798b7e693997a52118f14428bde7e548/mypy_boto3_ssm_sap-1.38.0-py3-none-any.whl", hash = "sha256:dd18f955801b4cd52df74b45174aabda14f39fe18cd181cf165d4c256fdfa2e0", size = 28347, upload-time = "2025-04-22T21:35:26.13Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/78/4be7a5edf3a6a58c750e41c3b91a9b662d8b790ad50e933d1aa3ee26971e/mypy_boto3_ssm_sap-1.40.0-py3-none-any.whl", hash = "sha256:eb703b411f2e58f451ce42461fcbc08fd93cf78c58e9ed5d737961be4bd55728", size = 28406, upload-time = "2025-07-31T19:52:03.073Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-sso"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/22/e97415fcf9e0fd703dd49446fe4a012a9191e983cc88c5c2276929e92bcc/mypy_boto3_sso-1.38.0.tar.gz", hash = "sha256:aa21b57c01e507401f4b37505da2d6a72416f400760547d4fda5165ba35b2a5f", size = 16436, upload-time = "2025-04-22T21:35:33.595Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/29/257cf5488f769b381661d36c189679d86cb16cc872d1965a236b3b266def/mypy_boto3_sso-1.40.0.tar.gz", hash = "sha256:23ffe1e5a66e94ec72133e97e0d41cfab95b2a17e7a09a1d6cd5a5b0554fb45e", size = 16532, upload-time = "2025-07-31T19:52:14.886Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/76/830ef8f04fd854169e3365e9d0801e99c794e9910d06f6c5c56e0e26efd6/mypy_boto3_sso-1.38.0-py3-none-any.whl", hash = "sha256:2a8aff0cfaaf03717942b4946ea66cc5f108bf0c6509a23388273dda357eed04", size = 20864, upload-time = "2025-04-22T21:35:32.036Z" },
+    { url = "https://files.pythonhosted.org/packages/71/8a/267ee450a48f5fd4ddf46a5251b6f44e326771608487721857ea02854441/mypy_boto3_sso-1.40.0-py3-none-any.whl", hash = "sha256:4fe32e652ecddf0f5f94700377839b162904ebfa90117e75341fd640fea78559", size = 20920, upload-time = "2025-07-31T19:52:11.413Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-sso-admin"
-version = "1.38.12"
+version = "1.40.7"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/d2/6b144e24079b0e933b312e90524386bc25844aa0eace349711c375c64195/mypy_boto3_sso_admin-1.38.12.tar.gz", hash = "sha256:454f0815955570978ee2545af431bceee7b960f864aad241eaa8c1286e0565ea", size = 39409, upload-time = "2025-05-08T19:42:42.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/54/fe389839aec726ff2f091b9d6e4bffdd001967bf54804333e3f47564fc1b/mypy_boto3_sso_admin-1.40.7.tar.gz", hash = "sha256:69ab5eef0ac33c2fc6be0bb599d143695cf6e10a45330b138627067f8d5beea2", size = 39706, upload-time = "2025-08-11T19:31:00.771Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/91/8e3b2fa7231d8f32cc2656711e0afe8e9b2ef51dffe9495de6ff37d5ef93/mypy_boto3_sso_admin-1.38.12-py3-none-any.whl", hash = "sha256:c70a489a69b6c25b1b1b95bea8ea36edb4fc38c589d2bb52019470a71eb344c2", size = 43287, upload-time = "2025-05-08T19:42:40.063Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ce/db0d4c6169a50c8da4621c500c24104dc190ccc1e93c5b9398f67ed32ffa/mypy_boto3_sso_admin-1.40.7-py3-none-any.whl", hash = "sha256:37620b720eae3714823b8598725ab8fbf0915d4867dfa650bd2404e1c2ef276f", size = 43672, upload-time = "2025-08-11T19:30:56.576Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-sso-oidc"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/c4/2e/613f15acd5256226c13a079b653a6022194e2b7b83889f1f8294c88458e4/mypy_boto3_sso_oidc-1.38.0.tar.gz", hash = "sha256:a202b9b8a07e6349e3fe04c63caa145790630c79572d7c93c0aabc52f962d22a", size = 15739, upload-time = "2025-04-22T21:35:31.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/7e/15ea86cee9325f5a60ffe4cd9e691959ec7d2bb7df2c13613c7d643009e7/mypy_boto3_sso_oidc-1.40.0.tar.gz", hash = "sha256:96b1a06bd8f1b9450bfbbd6fce40c3d07295c44bbcc08a3d607885e39bbc9685", size = 15753, upload-time = "2025-07-31T19:52:12.296Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/0a/b4720802da43a53710bf0b5dc361a568a20df6631b16bfecd9c14a43e98b/mypy_boto3_sso_oidc-1.38.0-py3-none-any.whl", hash = "sha256:9ec6e5aea284805c21c5cec8748eba28a163b674ff744ef9a3ef3b1c377e4c24", size = 19025, upload-time = "2025-04-22T21:35:30.144Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c1/dafd138fa017deb5d2f60092f9b5e09e103c627fba6044632331421c3ee1/mypy_boto3_sso_oidc-1.40.0-py3-none-any.whl", hash = "sha256:70ed8bdcd85ff6f14a8734086a5608e8f022b839f3e510a0e226e96ed77a2faf", size = 19079, upload-time = "2025-07-31T19:52:09.845Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-stepfunctions"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/d5/b6/1273339e46c41747fbf7f3097ca866c9d10e3db77d49630ac131abce1614/mypy_boto3_stepfunctions-1.38.0.tar.gz", hash = "sha256:b0102265c49fa0537bdb5d214677da89737b784f57ec02340d72210528088a99", size = 31058, upload-time = "2025-04-22T21:35:35.89Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/57/34d2d380862cf8c130981edb8d4c185ef4da256b5b0d7a28a29926009b51/mypy_boto3_stepfunctions-1.40.0.tar.gz", hash = "sha256:b7ee316136d32e45d1a03cad78109596349bdefd8ffec04b2c4526a509ba53cd", size = 31073, upload-time = "2025-07-31T19:52:18.829Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/52/7f1b664881c6ef81c8123ea57b95ed4b10e91123a1f26347b598fbef824c/mypy_boto3_stepfunctions-1.38.0-py3-none-any.whl", hash = "sha256:3fd11db7a789de8ab523e1af24fb8f91a46281bb85ae3cfe51aaaff1b6b3c369", size = 35812, upload-time = "2025-04-22T21:35:34.347Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/b4/5787acff0654003bdc31bf7578c87949efc6e0b57c367dc52c1cb5eeb747/mypy_boto3_stepfunctions-1.40.0-py3-none-any.whl", hash = "sha256:bcbf4b7db172adcf41afa521f2bfb0ca5f1ee666f46024ec0a127e53f5ff9f92", size = 35873, upload-time = "2025-07-31T19:52:16.102Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-storagegateway"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/6e/ab/7f6dbc120c4ba1dd47dfdac7f0d85d7a31e75ff750a041946092ef2a5daf/mypy_boto3_storagegateway-1.38.0.tar.gz", hash = "sha256:b1fe0df9f0acba826d2e7a51cc08f465ef47e6ccc58a0d1dfb55db3bc2280a91", size = 43212, upload-time = "2025-04-22T21:35:37.848Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/e8/109a2858e57e539abea3985ee8c1caef373e6bab09f3108d429965ab5658/mypy_boto3_storagegateway-1.40.0.tar.gz", hash = "sha256:2f042a7dba6a45a1b2ae2742888ef72e3423b109fe87a19cd870eddc02adf1d2", size = 43246, upload-time = "2025-07-31T19:52:20.354Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/c4/405f50bda97b34c5a85ce7099ca6c2e3c8117f2b4c20e5148ad7ddde1412/mypy_boto3_storagegateway-1.38.0-py3-none-any.whl", hash = "sha256:5c2d026d2ddf33cf2d0d20d95dca3160f2f2618f358023539183207427d0d018", size = 48489, upload-time = "2025-04-22T21:35:36.656Z" },
+    { url = "https://files.pythonhosted.org/packages/04/83/d73553e81f99f6a2507ad54095248123c3aca64252f77539163f5dd319da/mypy_boto3_storagegateway-1.40.0-py3-none-any.whl", hash = "sha256:97ce3c54b173de4c25fa803e8db9bd462cc8145b96d2db6de2cbb8300079b829", size = 48553, upload-time = "2025-07-31T19:52:16.974Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-sts"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/24/638ceabff74e07855b59c3bb863b0c11e69ff7ec8fa8678ff6db9ee38318/mypy_boto3_sts-1.38.0.tar.gz", hash = "sha256:143a96f06bd17ec4bbb120e04b65e646cb4345e2d0d4c3c596f8aa0458d12707", size = 16561, upload-time = "2025-04-22T21:35:39.729Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/32/8dce999ed05c797000ce70287f3e82025a98514781c303c7f8fe42f7b327/mypy_boto3_sts-1.40.0.tar.gz", hash = "sha256:eb55e50960ae6194d09488464c302196392df712a6a5f4308b6a0e24244cfd5c", size = 16577, upload-time = "2025-07-31T19:52:23.924Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/1b/532ec318c368a3e34c18b92f3cf9254e571dc32e150e400f323d73ba3159/mypy_boto3_sts-1.38.0-py3-none-any.whl", hash = "sha256:61d7ef65677be52cc0e369e359c41ced12b4cc3919f550905af5f480806b89b4", size = 20125, upload-time = "2025-04-22T21:35:38.625Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f8/38dae2983d72ea4fff75b235d42d3b1ecad407e0136f4951bfd9016ecaea/mypy_boto3_sts-1.40.0-py3-none-any.whl", hash = "sha256:fff731694cab2474bf7e7d3344b049b4ac0272d76b72fc4f7e4ae543ead8a5e6", size = 20192, upload-time = "2025-07-31T19:52:21.353Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-supplychain"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/3c/c2832cfc0a101188c34acbf22c982fdf11cea7143a8f75f0b112ced2593b/mypy_boto3_supplychain-1.38.0.tar.gz", hash = "sha256:f663710333062a4ddd2b02d17925304c87ca8c53025fa8cd95f7be39d0561caf", size = 20119, upload-time = "2025-04-22T21:35:41.363Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/6e/ace64b802a0f8ff42c457a88c8bf829895abcf837e8b4ffa025e47438c4b/mypy_boto3_supplychain-1.40.0.tar.gz", hash = "sha256:1c9ad02240b0f7c71611963336f56595bce0aa2a8e703dfa4f1ab4ee5fb9885e", size = 22985, upload-time = "2025-07-31T19:52:25.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/74/5c3485f996d7d3f53707c58af970f787491b247cf8e2fff07249c0341417/mypy_boto3_supplychain-1.38.0-py3-none-any.whl", hash = "sha256:7812bdee58f9f36c1b02ee3a8fe51641d80ee85549f72215aa3473186e34a44c", size = 27391, upload-time = "2025-04-22T21:35:40.444Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/ef/868f5502a7eda4f4c1c9ed3b7313d803e9afccedc588f279d573f259b883/mypy_boto3_supplychain-1.40.0-py3-none-any.whl", hash = "sha256:caea11d5cf9279adad5e9a45ee6aa5aeb98fbdea7ef5350f61eb134dd0d3d267", size = 31741, upload-time = "2025-07-31T19:52:23.09Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-support"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/50/54/9b475a0897bbeaae1aeb61ed11bb5ea454daae7ca2a79a2adc131e88ab1c/mypy_boto3_support-1.38.0.tar.gz", hash = "sha256:b7af2799d6321f6cf80b717d8dd9fcce9c1ec05f6bf282d8b1c6c210fea1ab40", size = 19074, upload-time = "2025-04-22T21:35:46.123Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/d9/24cb8a6516fb0fe199b2b24a4a468820d763746b852fbfcd56fa20517210/mypy_boto3_support-1.40.0.tar.gz", hash = "sha256:90d0f278230339fe295793f774cb0aa2d00cac1551f8372df1a6cc4fb7879c32", size = 19121, upload-time = "2025-07-31T19:52:31.033Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/2b/1ce754c1940bb6eded6b45d290c97787c9ef33ec96b99e39dc401c8d8061/mypy_boto3_support-1.38.0-py3-none-any.whl", hash = "sha256:71258fb993d51703e5425cb3154eb12f71947ae99e755a66b8bf46416088c325", size = 25167, upload-time = "2025-04-22T21:35:44.78Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9e/1d79b22744ed0f068f46f3e0515e2f489012e73f067fbe4b463f3b8f0294/mypy_boto3_support-1.40.0-py3-none-any.whl", hash = "sha256:8c452f0d5b8e16cfb53a7e8dffe91af56d6441bbf006a6349f5338dc8a6bb002", size = 25225, upload-time = "2025-07-31T19:52:28.013Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-support-app"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/0c/7d/e922c7dfc5e754cce34aaf93d29edd8afced77d7afed7b9bdaa207ba5d4d/mypy_boto3_support_app-1.38.0.tar.gz", hash = "sha256:44d5b69b3ec9b826620c7afc9f5546febc5bbb087e6bd8bc961a70d1d105a442", size = 16089, upload-time = "2025-04-22T21:35:43.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/7b/1f6eaa362dfd76f8e5b16de22c54e2c1d51af517c13eebd0c5e3c5cfdbb1/mypy_boto3_support_app-1.40.0.tar.gz", hash = "sha256:fb2c6d3ff727c760a2414b39216e6489b7864ad3f43055c6169472eccdae2add", size = 16097, upload-time = "2025-07-31T19:52:29.115Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/5d/c2a5a120043237fd7777532d92b2ebd2c46f5a342bb38d943f95d99179d9/mypy_boto3_support_app-1.38.0-py3-none-any.whl", hash = "sha256:af794131a123080def4f482089c547deb142ced9e3d3b6d58b19094e9e1478a0", size = 19471, upload-time = "2025-04-22T21:35:42.124Z" },
+    { url = "https://files.pythonhosted.org/packages/30/58/d45d14529065a037e66b01bd0b52dd57e2bcfb8dc1111907eab25c3dd7b9/mypy_boto3_support_app-1.40.0-py3-none-any.whl", hash = "sha256:d9a754d9a30bd50e50bee95050d10ab9b267dd313ca08b77930c021a9eaba42f", size = 19524, upload-time = "2025-07-31T19:52:26.604Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-swf"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/55/43/281450b65dd0c92c98a9d0f1b936bc0306fc86cdd3909da55cb0b3381220/mypy_boto3_swf-1.38.0.tar.gz", hash = "sha256:6fa4e0bf159d408e53008fceb09ce6ce5b5ed6fdf435d26e71d79d2a009bf4b6", size = 30352, upload-time = "2025-04-22T21:35:48.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/35/d30932d8b8c41c55532342ad5b81506187c814f2cff493f4e327e47315bb/mypy_boto3_swf-1.40.0.tar.gz", hash = "sha256:aa4137ac5df65a4479e96079a6eddd2892c22d8e5ed6bbcc0cf600aeeca3f4ef", size = 30436, upload-time = "2025-07-31T19:52:35.807Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/a9/71570bcc8cb78c711842760ec00b427741fb47986be00b6822954d68324d/mypy_boto3_swf-1.38.0-py3-none-any.whl", hash = "sha256:24d58bad70c9c06821edd676f4ad903613b975cd75567992314fee4f45ab7c6b", size = 37748, upload-time = "2025-04-22T21:35:46.855Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/0e/01e1584e898be65ea9669ebcba900264f974d99d0553067ab958246cc2d9/mypy_boto3_swf-1.40.0-py3-none-any.whl", hash = "sha256:cc9de493737bf8397e52352844c5095cbfe93af96182965de4c7b0028a438a8a", size = 37812, upload-time = "2025-07-31T19:52:32.55Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-synthetics"
-version = "1.38.13"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/ca/1133c43b69ef6170fc1af1fa9082b2590cfcf5b0fbbdeb194adca8e92c75/mypy_boto3_synthetics-1.38.13.tar.gz", hash = "sha256:8281696094072f36326d8f20b7d1535155d7317fbc939f1837167c56c35fc2be", size = 19050, upload-time = "2025-05-09T19:42:17.907Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/fa/0594df23ca123d31fcd6b330b16a7ba22e1b91f726d30ef87c8c687a4c4e/mypy_boto3_synthetics-1.40.16.tar.gz", hash = "sha256:13bb29617b866d613b06b38f34ffdff2451a9178d32c67f524066e85dea6d188", size = 19374, upload-time = "2025-08-22T19:43:26.294Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d8/e458fb64ce294435840981e83d073816bf9663c9824bf28702b567bb1963/mypy_boto3_synthetics-1.38.13-py3-none-any.whl", hash = "sha256:32e17696c4d01c36ac689e0a22dbd63d613750c0aea54757cdc84b979660e981", size = 24560, upload-time = "2025-05-09T19:42:10.382Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b2/a4079f051a8d77d850cac749c29b82ed4790cfb8540c5ed4940b0a26e6dc/mypy_boto3_synthetics-1.40.16-py3-none-any.whl", hash = "sha256:6f32d2addf038440efe83bc86b8d92b3e3325a836c580034f34e136d573467cc", size = 25250, upload-time = "2025-08-22T19:43:24.672Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-taxsettings"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/7f/d65c959b9d2ed3abcbbfc9cb5c08043a4fda8f72933eb42db00212d8025f/mypy_boto3_taxsettings-1.38.0.tar.gz", hash = "sha256:d280dce118f80fd49e204c694cb37f9cd0f2c4f5c8651bb5b6dff2d66441dfe4", size = 20718, upload-time = "2025-04-22T21:35:52.859Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/19/40ae400b084a4e6a304569316e987c943bc0a060bfc78566eb7d22fb1915/mypy_boto3_taxsettings-1.40.0.tar.gz", hash = "sha256:40e2557e1e18f8df103d9dc7c6fd2d14ad4470296835e7992b3b2f8229fecb47", size = 20750, upload-time = "2025-07-31T19:52:44.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/3b/e504f62b5dfe579b998209876390de0c2097a56442e028ffed5f50a51c4b/mypy_boto3_taxsettings-1.38.0-py3-none-any.whl", hash = "sha256:d62287bde776f1d2532a6ff568e72d333627101739fb7d89067ef69c9ca6d90b", size = 28356, upload-time = "2025-04-22T21:35:51.481Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/4a/11117741da535415d0ffab8292a46489d0f8d492fd6aca0996f5a1ba568d/mypy_boto3_taxsettings-1.40.0-py3-none-any.whl", hash = "sha256:4b327a9b72db3ce5815b54ad9a7a266fa03cbec44c8fa5af8fb6ffa9df7af472", size = 28413, upload-time = "2025-07-31T19:52:39.474Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-textract"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/9e/38/3e4379831131dc883bad284127bbeb976d575de321076edaac5ff6412d00/mypy_boto3_textract-1.38.0.tar.gz", hash = "sha256:adf0d92d3d6178d0648efe23ad94ab845576f53c4455f84e626719473538971d", size = 21790, upload-time = "2025-04-22T21:35:54.726Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/ef/4e8d7d4be74c3b5484061f1d8782b4250b12924ffad847466136b7dc80ea/mypy_boto3_textract-1.40.0.tar.gz", hash = "sha256:84c2f1290e9a33076abb0da83a0781df73a2817db930e40526118405f1327fb5", size = 21821, upload-time = "2025-07-31T19:52:42.127Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/42/0744d74643f23dab6a5d2f19b7fc0a68feed7944453873eeefac01c18841/mypy_boto3_textract-1.38.0-py3-none-any.whl", hash = "sha256:8f633c11f1fa4fcd68a6488a4ea1a9a51805698ea62a012eb747293cffd83cd1", size = 30045, upload-time = "2025-04-22T21:35:53.627Z" },
+    { url = "https://files.pythonhosted.org/packages/54/96/0e41a224e71c6c4ff8ec9ceb66ef689c2d77162b4150691ef84b7ff07a8e/mypy_boto3_textract-1.40.0-py3-none-any.whl", hash = "sha256:8e9727d1a9674b1a8f723c0a4ec4a757efee7931a653b68cdf12c181e393db61", size = 30119, upload-time = "2025-07-31T19:52:39.88Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-timestream-influxdb"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/54/32/83313ba22b980185ef48a4e7840b41ee7c89b856ec6b1f373254b60444eb/mypy_boto3_timestream_influxdb-1.38.0.tar.gz", hash = "sha256:5f2dcbeedbe2f66082961c1436d3ab2dddfe0c8fc7ee0972a25179475c4fba9a", size = 20069, upload-time = "2025-04-22T21:35:56.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/43/7364a65cf03b81909cab95017ce3235d303b531628e2bb36da7a9975dfba/mypy_boto3_timestream_influxdb-1.40.0.tar.gz", hash = "sha256:8fa01c1b6e1cc558da77694087c1d0e2fc72f68891159f5262d8dcb2bba796ff", size = 20130, upload-time = "2025-07-31T19:52:50.115Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/f1/1d915f25c4d5b39784635ca875779d7ba82b1d20aee5eb4e47c1c0fd233e/mypy_boto3_timestream_influxdb-1.38.0-py3-none-any.whl", hash = "sha256:aeb750b6894bed391863ec4de4d6527772c85768d30e7d3fda25d952e46821dd", size = 27483, upload-time = "2025-04-22T21:35:55.459Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/46ad2a34f5cc2aac9a30d14ec898ece17166be386bbb49c8facdf977bcee/mypy_boto3_timestream_influxdb-1.40.0-py3-none-any.whl", hash = "sha256:17e4a216c74544a54e11afec16525ffda74e76b912dc9cfca47cc80d471a8e11", size = 27538, upload-time = "2025-07-31T19:52:46.004Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-timestream-query"
-version = "1.38.10"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/e8/ca0a6dba40a4572d0991661a6946227c35bd8341790d852302ebc267e708/mypy_boto3_timestream_query-1.38.10.tar.gz", hash = "sha256:15851b18fb76d1589ac0417d503de263b512d0941c49abd757ae6f9b856f1f02", size = 20809, upload-time = "2025-05-06T19:42:32.526Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/64/8e8e1518b78b0058372980e3ca1f51603e9091fe145cae45eb843bc637b9/mypy_boto3_timestream_query-1.40.0.tar.gz", hash = "sha256:9612dc0c9473442d45db612da1965a1b9b5787c82cef10a77d4e861dbd8eedb0", size = 20857, upload-time = "2025-07-31T19:52:54.453Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/8b/dbce8ae6cd4d840915b331a73e3278b92653dc479b18daac787c1e4dcbd0/mypy_boto3_timestream_query-1.38.10-py3-none-any.whl", hash = "sha256:712a9b4204aeae5a3d07f2a546319ac1bf80c8555385cb416bd463b88f562129", size = 28913, upload-time = "2025-05-06T19:42:29.095Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ed/453cb83ec3a95437737a67879fe244b8b46274bc8c799d11b88413d5e2e7/mypy_boto3_timestream_query-1.40.0-py3-none-any.whl", hash = "sha256:c6ea73a58cd7c9fd6f9da6493eae361c55e5fad8d6980dd2524843303377c3c5", size = 28947, upload-time = "2025-07-31T19:52:47.901Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-timestream-write"
-version = "1.38.10"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/21/06255e935ee6e1533ff47894a7a11217abb959cc5891e6d198080ad5c02b/mypy_boto3_timestream_write-1.38.10.tar.gz", hash = "sha256:0db8a1b3b98779690dcc830c826c40accf4e7d624ce4580311cd9538c2da4fd5", size = 19039, upload-time = "2025-05-06T19:42:39.017Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/63/e2cf025bae36142dab483e34215f807f94e3ea9a9ee90bd77f8d065fe589/mypy_boto3_timestream_write-1.40.0.tar.gz", hash = "sha256:7c59ce2e47642ea40a95b6af1387870971d8ce82195218f243036bb025daae39", size = 19077, upload-time = "2025-07-31T19:52:55.776Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/c1/78b56e5107782b5af99e751e8e8df72bfa1af62ab6842e8c9bcf72b28dd0/mypy_boto3_timestream_write-1.38.10-py3-none-any.whl", hash = "sha256:8e4c6b430b251d6ca7219b9547dbcf252a68da1334a43728132b6e92ca8b0891", size = 24749, upload-time = "2025-05-06T19:42:35.04Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fd/9897f136f490818a2821acc493ae86bc70a7a2845b6d4cb98a98b12f2d34/mypy_boto3_timestream_write-1.40.0-py3-none-any.whl", hash = "sha256:950d172291cff9a6a844cf47cefd5c29cdb80870996b223c65ea073ca9c316ab", size = 24786, upload-time = "2025-07-31T19:52:52.99Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-tnb"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/9c/d0/16fc83e78049be1b93d5c894c86d4094d705517a134723a724e66339bf7b/mypy_boto3_tnb-1.38.0.tar.gz", hash = "sha256:5fe72afb34109d49bff22bac2aace42b35544850ef4184e8884c116f8af04867", size = 22035, upload-time = "2025-04-22T21:36:02.262Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/da/3015aada73019dbed395fa6598ef6ff31e3aad27724f2d5259549f4ca38c/mypy_boto3_tnb-1.40.0.tar.gz", hash = "sha256:49f678b1828989cf6241f5b151011d576df763935b2131d68c2dd5b7e845a470", size = 22037, upload-time = "2025-07-31T19:52:59.266Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/c6/334d61b20d35cf7ef4eae6b718528b4d27c1f894b9210fc0af07303ea9c4/mypy_boto3_tnb-1.38.0-py3-none-any.whl", hash = "sha256:71fcec3a0ea8c3c32b6e4025d64bdd1da49aec9d4869adcf5a3dd0fe6c4af3c4", size = 29865, upload-time = "2025-04-22T21:36:00.852Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/81/b77ea949767034e030d4d96c1090419691fbf18e3ac334873232536906b7/mypy_boto3_tnb-1.40.0-py3-none-any.whl", hash = "sha256:e812b119b027e2f3fb155ef61d194e80a369450f651695118fa1fe23f7398431", size = 29922, upload-time = "2025-07-31T19:52:57.211Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-transcribe"
-version = "1.38.0"
+version = "1.40.8"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/f5/a6987f233c3f61671b0aec1c31f41360c1820daa85a119a8a39252eca121/mypy_boto3_transcribe-1.38.0.tar.gz", hash = "sha256:c9f2429262b71ff409d3102975419f69bc2382b1e0bbcaf49b328d0ceb040ea9", size = 26073, upload-time = "2025-04-22T21:36:04.167Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/c8/66d3dbc5ff62351e03c806054e62eb25b1f3aad16b4eb28df460c6271bd5/mypy_boto3_transcribe-1.40.8.tar.gz", hash = "sha256:8b9d39eb486273522d903d332630321eb69ea44cb18a8141bc7c0c5a47e0d249", size = 26268, upload-time = "2025-08-12T19:29:00.646Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/a9/41a4b3628ab7bf32f0f0fe0a17b88ec33a0fba0c235abda8e6ac5c101b95/mypy_boto3_transcribe-1.38.0-py3-none-any.whl", hash = "sha256:b1cb4b0ffe5258abd4b598ccfaa698fa3f4276539f1b6f77e9229204b4cbfafe", size = 31162, upload-time = "2025-04-22T21:36:03Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/08/5defed8df4ecb5ee4d520bc31fc7674921d7552779a9975474577e90c7df/mypy_boto3_transcribe-1.40.8-py3-none-any.whl", hash = "sha256:9e9219a8fbd283f872623d7f943b3fbfa91064d35aed7977ab79d218dba31ab2", size = 31518, upload-time = "2025-08-12T19:28:55.611Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-transfer"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/fc/4a70def155867dbb1c803e9318cdc99ec1f620cce3a8f4c09f7c59656d34/mypy_boto3_transfer-1.38.0.tar.gz", hash = "sha256:84e60e0fc97470318aaf714d392c0ca866f2eb83bac268c700bd05e6194e38ad", size = 40958, upload-time = "2025-04-22T21:36:06.646Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/54/2c5a837b4fa81f88cd6d71fb5981445cb57e1b29ba3f76124ddc4beb56b7/mypy_boto3_transfer-1.40.0.tar.gz", hash = "sha256:04cb183b6981acafc2b56463f6354d3b6b02e086ab850fb585877d15e243204c", size = 41061, upload-time = "2025-07-31T19:53:03.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/6a/f54d582e75a45c7221fe3cd58fc5715ae4a5b2d8dc4aac64e3d0ce9757ba/mypy_boto3_transfer-1.38.0-py3-none-any.whl", hash = "sha256:623257f763a6bae12954dbde102e0a24b01f895a9b15be813f15afa0cefab974", size = 47462, upload-time = "2025-04-22T21:36:04.886Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/af/8e86ad26e5b29542264cb29e530ae8f513f1dd16ade71ba8f6ac513da169/mypy_boto3_transfer-1.40.0-py3-none-any.whl", hash = "sha256:cc26cca695459e5048263255fcb55965ca2e80f981c1cd22c8a17011334556f4", size = 47608, upload-time = "2025-07-31T19:53:01.174Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-translate"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/73/eed19cdbb2a414d3821fc35cea039d3d89d587c18c5b728609aac367e4c7/mypy_boto3_translate-1.38.0.tar.gz", hash = "sha256:bdeec796502ff8f1ba8c7459369f50df68e92049026a9381e3165da4f62d6494", size = 19630, upload-time = "2025-04-22T21:36:08.903Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/db/76af0d85a853e253b55110550ca6d6aa1c203fe99c6c15dfc717191ca66e/mypy_boto3_translate-1.40.0.tar.gz", hash = "sha256:af45ae6c4b51a621161cd1ea87968f283efb4c0f4e2e50d08991cdded4554dc5", size = 19718, upload-time = "2025-07-31T19:53:08.561Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/28/131312862f6f30857960262b8fd04476466eeeee27a7e319323697737c97/mypy_boto3_translate-1.38.0-py3-none-any.whl", hash = "sha256:c2867ae1d41b4d72e0c938c380acc84bfe562b8855c0db08b3af656a5b214592", size = 26579, upload-time = "2025-04-22T21:36:07.71Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/88/dc591c047a058d62b973b03300ce80755e23c3212d638f1efca18ecd4e39/mypy_boto3_translate-1.40.0-py3-none-any.whl", hash = "sha256:3be014342d3040e71a56e0d3ae1bb7e9fb2fad2d342d155a2e63d19320eeb591", size = 26628, upload-time = "2025-07-31T19:53:02.684Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-trustedadvisor"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/ff/a8/ff678e68a6685b4a80f7588302ea9974f6740a2c0f32ec2a5c43504d2a25/mypy_boto3_trustedadvisor-1.38.0.tar.gz", hash = "sha256:8e6a1eddfad2897ccb39a17d61f4cc55b78bd97c8972f542e2831c7a0a75f098", size = 19745, upload-time = "2025-04-22T21:36:10.602Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/6d/af1005bc3a51add37e63972c0be4e74e57a2c1ca2c12d1af7a0335d891e5/mypy_boto3_trustedadvisor-1.40.0.tar.gz", hash = "sha256:e664070cf5864a59663851673e819ebf30fc05030dd968497a87b0c53289ad11", size = 19760, upload-time = "2025-07-31T19:53:10.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/16/9cfe6c2a925b62d5c89fb37bffbbc12efbe75c524bb44ef730de06735f18/mypy_boto3_trustedadvisor-1.38.0-py3-none-any.whl", hash = "sha256:cdd12d2e2ef80c4eae53a0dc1e7bb9c37f3c4745d8274a08d7c6e86cd6f973bf", size = 26342, upload-time = "2025-04-22T21:36:09.657Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e6/9306584903425c60b980af6ec8b5f05b778a0d5f1db41caadf56df455d50/mypy_boto3_trustedadvisor-1.40.0-py3-none-any.whl", hash = "sha256:75efe630b8fa7c14e5f392118c058c920e44e3db7f0e8edafcb69cf2f1719849", size = 26401, upload-time = "2025-07-31T19:53:07.653Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-verifiedpermissions"
-version = "1.38.7"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/38/7d/6096c38f254b40d9a24ba687efd59cb615b383e7d0ee2b3c057e4e01b97e/mypy_boto3_verifiedpermissions-1.38.7.tar.gz", hash = "sha256:7c8b5a065c7779e58790a7584d24dec94a534de15cddc65d15a1c1195c7b70b1", size = 24591, upload-time = "2025-05-01T19:26:25.797Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/70/5cd0955f3cfbc4afb4cc7e050310a23dfd164e94cfc8163a42e2bcb1342c/mypy_boto3_verifiedpermissions-1.40.0.tar.gz", hash = "sha256:bbb7f788387a8c21585947504e12eb14940ed5dff71aa88ff081403863badbbb", size = 24666, upload-time = "2025-07-31T19:53:13.919Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/41/428fed663c93059e37e8eda1faf0b5a4207dcbcb62e6df3312bcc95c8c45/mypy_boto3_verifiedpermissions-1.38.7-py3-none-any.whl", hash = "sha256:9bae1271379d0674fb5778ca23fcb89e000132bb12ec2e77d1c058c0568cee84", size = 31028, upload-time = "2025-05-01T19:26:19.498Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/48/f8d782c7b34ecfea6757320b7f8b7e620ce67a2f262ec7ace9fdc37af240/mypy_boto3_verifiedpermissions-1.40.0-py3-none-any.whl", hash = "sha256:d2160ca4167b764e0ad4e954e854ea000bb9c30a5377bfe513ff1e5dbe19db78", size = 31070, upload-time = "2025-07-31T19:53:10.009Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-voice-id"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/2a/b16f090dda32a2528ecdae2bb2b5ea4d7bf747b1913e81bbcde1ba92cd5f/mypy_boto3_voice_id-1.38.0.tar.gz", hash = "sha256:d7814b4fa042bc47c5a12f3a7efb6b6e0bbbed7cff76816336d1be8a5e7fa39c", size = 21610, upload-time = "2025-04-22T21:36:14.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/b0/14ebf1f023690fc8af1338106612ba6a24d7e52e0725f64857c7ac42f26e/mypy_boto3_voice_id-1.40.0.tar.gz", hash = "sha256:8d2620865ef45924471821219a156f78a4e937ddf2d895ad9574c1a9d1e07e0d", size = 21632, upload-time = "2025-07-31T19:53:17.225Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/25/fcbe451d723c3fd0897f6c7d1f77acbd0b64417212938fff6ae384b38939/mypy_boto3_voice_id-1.38.0-py3-none-any.whl", hash = "sha256:6a0dcb2c40fd217b5e843c406b853d6af81a7bfb70e7a1cc7108b58ff6770dcf", size = 29443, upload-time = "2025-04-22T21:36:13.062Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2e/651647cfa64727328bf513d9ef880c5669b48690341b030e6979c57d5db9/mypy_boto3_voice_id-1.40.0-py3-none-any.whl", hash = "sha256:d7dc59c4d38931f02eeb3a22984146e985615749a5a7faf84677467c78263e0b", size = 29496, upload-time = "2025-07-31T19:53:15.613Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-vpc-lattice"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/e1/e6/155e4e6c8e2eff7da0412bd57b31de56080895ed2d4844677a0e46c8e151/mypy_boto3_vpc_lattice-1.38.0.tar.gz", hash = "sha256:3f6decb90dc01ec869fd796a882be2ef5fc4cc075ebfc770787c773d790a14fa", size = 35971, upload-time = "2025-04-22T21:36:15.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/43/65718728659db8eb4406b8cecc3dfd635270aa62a58b09b3ef1cfa9a44d0/mypy_boto3_vpc_lattice-1.40.0.tar.gz", hash = "sha256:236acf6680be592bfba8d1c3fd42aa7800ad5f5d70cac7b808a045cbb86805f2", size = 36003, upload-time = "2025-07-31T19:53:18.026Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b1/46/c5b64da6edab04675b9902be747015c205a0db3b8e3a97088051c73aaebe/mypy_boto3_vpc_lattice-1.38.0-py3-none-any.whl", hash = "sha256:bbb9904bf4aca3b92e196333b226c2974bf5d0770b4dbb4ba8862c4ecf059bdf", size = 40580, upload-time = "2025-04-22T21:36:14.804Z" },
+    { url = "https://files.pythonhosted.org/packages/64/45/de5bca3b84a7669d856f8793e6dd5a00be8ce45be719e1b036d519c227aa/mypy_boto3_vpc_lattice-1.40.0-py3-none-any.whl", hash = "sha256:e15bd7646100c6305ffbf41464272ff3f2f9293044717b33f2e857cdbde2b605", size = 40624, upload-time = "2025-07-31T19:53:16.104Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-waf"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f2/b3/6cc6c8c4ac44de7150cb58a63b6da24fb3a398faed30604891c5488c4b92/mypy_boto3_waf-1.38.0.tar.gz", hash = "sha256:1f28d1e1e3976a60ed16b0baf809154fb33d11cbb1ebddde074f24dee9ee8b1a", size = 35068, upload-time = "2025-04-22T21:36:17.74Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/55/732057f898bed753009f81b4c73a6fea25d1097687c0b35ce4020d3ff269/mypy_boto3_waf-1.40.0.tar.gz", hash = "sha256:39353beec774e30d5eb0e779a4437a5f67da2d59092bfd3c27d4a95112c47b56", size = 35128, upload-time = "2025-07-31T19:53:20.987Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/e0/6ea03db327ba6b3b7d4216881a87ea95782af2b1c081f71a7b3ec9d5bdbc/mypy_boto3_waf-1.38.0-py3-none-any.whl", hash = "sha256:3f16eeda023495c605aa719f67596c13020257038a9d15b65216dacd3f84e883", size = 40473, upload-time = "2025-04-22T21:36:16.562Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5e/cc46f04c1aff27fc46fd824720c6742a362333ace0c242132f58b0292f4b/mypy_boto3_waf-1.40.0-py3-none-any.whl", hash = "sha256:8c432f8a1d57a9aa3f9af13e234f4cac048d6fc9f6af93e1b17d5871667dd005", size = 40535, upload-time = "2025-07-31T19:53:19.151Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-waf-regional"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f4/41/91c87ec6c020fba42238f59b4f6690c1ccc1a81ab120b253e28d99942a36/mypy_boto3_waf_regional-1.38.0.tar.gz", hash = "sha256:9dd4d139cd53d803e64072fb12c49e5375f158f633a757b7dadcea7b8503b3ff", size = 31012, upload-time = "2025-04-22T21:36:20.116Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/25/34a0c5747a1f544b6635bb6a162cf4bbba461499a5efd7d216811df397b5/mypy_boto3_waf_regional-1.40.0.tar.gz", hash = "sha256:04298639429f45bcc57332ca894e603239d4dd100b3852079a27f6a5ecb38206", size = 31038, upload-time = "2025-07-31T19:53:21.887Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/1b/1c6eef2e9ba481b27fa74df087ad64df8dabdc3a780ad90f95e852ac1b67/mypy_boto3_waf_regional-1.38.0-py3-none-any.whl", hash = "sha256:fb778173a51d3f802a8d1a8fcda96fd68d9a37267c9d0169758251d102139ce8", size = 33376, upload-time = "2025-04-22T21:36:18.526Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f9/3fe1d56cbbe377c707350c90f784f4c00a1462cc4588e73d22f004b751a9/mypy_boto3_waf_regional-1.40.0-py3-none-any.whl", hash = "sha256:1c7a825135b03bce5a48b3ae95f344b439be1bad5e651c3ef0280460c651f301", size = 33431, upload-time = "2025-07-31T19:53:19.649Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-wafv2"
-version = "1.38.0"
+version = "1.40.16"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/d5/56b9feb223423801370877698721c3d36315df4147360bc2dead3a525112/mypy_boto3_wafv2-1.38.0.tar.gz", hash = "sha256:8f9d2793e964e046928ca1d0f78656cf47aec504ae6c1c77a5345244e6f106d7", size = 40045, upload-time = "2025-04-22T21:36:22.05Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/df/8e6ff283ad4d90befb21022280de2300ffd96070f2a6cc3c9fbf4fc275b6/mypy_boto3_wafv2-1.40.16.tar.gz", hash = "sha256:a68836ca7b0aaee77ba82096d7d0db5d535bc9906abea9c479c771a7192e3446", size = 41111, upload-time = "2025-08-22T19:43:28.008Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/26/96269b31c6b28c37f4225fa8a635b57e45113e7bdfc9a42060fbd377b0f8/mypy_boto3_wafv2-1.38.0-py3-none-any.whl", hash = "sha256:ab75a39a9e0d367ec7de8a9e56221637bd45b5400186c561fea56f89ba0fbf99", size = 43405, upload-time = "2025-04-22T21:36:20.876Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/12/b9c9cd26e7663fc26a0499fe357186f48b6165053a49fc2e97cd3b78837c/mypy_boto3_wafv2-1.40.16-py3-none-any.whl", hash = "sha256:8cd84314381128ce3d3ddc3669e39405933ef39c726701369f0942384b0ea3fb", size = 44600, upload-time = "2025-08-22T19:43:25.103Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-wellarchitected"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/5a/9f/1f348f1ed872d64cfafe3df7f723b995aa8c5f47d66e6a8827a4d55da731/mypy_boto3_wellarchitected-1.38.0.tar.gz", hash = "sha256:473a99742b42c881db8fc5ba2529ea66cd7e557f8b673107faab91a90b28418c", size = 32894, upload-time = "2025-04-22T21:36:24.4Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/b7/bb7f99856248823267814957404c4d1fd168bcb82aaf54cc18f53f86b5c0/mypy_boto3_wellarchitected-1.40.0.tar.gz", hash = "sha256:342b034d703778664086b4d4fc6f338045504fd67c6481f7defa2a97cb763fa5", size = 32943, upload-time = "2025-07-31T19:53:27.63Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/15/d912c661dfe2c94b3565ea893373a8d17cb21fa9a815b41cc1c71af4fad8/mypy_boto3_wellarchitected-1.38.0-py3-none-any.whl", hash = "sha256:f5ad589b97e19e2992a0a1ad5c834e24c01924f14836eb193abb820fb0a5727c", size = 35567, upload-time = "2025-04-22T21:36:23.333Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/65/bcfd2ecf5aa08c6ca240313fd5fa1836fe29eb5453c5f264bb9fd6014ca2/mypy_boto3_wellarchitected-1.40.0-py3-none-any.whl", hash = "sha256:e297e21a29c68eb91b0f94452875346e01ca125e7813202bb0392dc73dcdb24b", size = 35625, upload-time = "2025-07-31T19:53:24.703Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-wisdom"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/0e/a0/9e363398980f7b83a8a9d4eb32a33830805ef63f5c81ea8048bb7afd7f78/mypy_boto3_wisdom-1.38.0.tar.gz", hash = "sha256:49b6b4495cf9ec34ee1d52e6d4237a180b1cbf742966bcbe40c33c8931f2103e", size = 29935, upload-time = "2025-04-22T21:36:26.341Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/41/c7d2b55d7c0e311704f8c09f7acc5716dd41c6e08db8f28a755023356450/mypy_boto3_wisdom-1.40.0.tar.gz", hash = "sha256:07e8603d93ea565d98a6c0719a456987e2fd94cbfb3f32407afa8c1171c05d24", size = 29981, upload-time = "2025-07-31T19:53:30.87Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/a6/ea506b58bfeab37cdc73339e29489ed11f4b694b2d2c29b9fdc2ef68e66d/mypy_boto3_wisdom-1.38.0-py3-none-any.whl", hash = "sha256:b44e55783fa39f91df53b944b61ff1fd3083b06f67324ddc9a01c5040ee6c721", size = 34392, upload-time = "2025-04-22T21:36:25.323Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/81/9ed41ba58b7e040f91c14c97fce3dc5976148118c41caf3ebc7e49666f74/mypy_boto3_wisdom-1.40.0-py3-none-any.whl", hash = "sha256:81ccf9dd2b853afb395faa4fa16f647de91bdacc9654c40da212352c10eb0456", size = 34452, upload-time = "2025-07-31T19:53:28.939Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-workdocs"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f0/8f/f5b612063c10a09d95bc850a385746308adbcf783e7d52f92c56b40429f7/mypy_boto3_workdocs-1.38.0.tar.gz", hash = "sha256:131b0ccf776a65577aaadaf69214ea6da16968cbc9b1aa61eb7ae1eff402b097", size = 29271, upload-time = "2025-04-22T21:36:28.281Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/df/c2a60e3eb05c12908c31026d60bfc41d64e4c6254be5e241ff7f89f87eac/mypy_boto3_workdocs-1.40.0.tar.gz", hash = "sha256:20a6a581889278319b7b13eb12217d480d3d880d9ac599a3a9fa630f69351a71", size = 29280, upload-time = "2025-07-31T19:53:34.067Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/3b/6443322637f70356c439ba5e406ed038804d0dc03b508f83170eb248d974/mypy_boto3_workdocs-1.38.0-py3-none-any.whl", hash = "sha256:d527179ea80fb258d06d5d08d698906ee2bbc15897e281870cad44516c56bfae", size = 37437, upload-time = "2025-04-22T21:36:27.103Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f7/fb6f90b8de74307059a732b9d98efb57d7f538e469f7c39efc856683583d/mypy_boto3_workdocs-1.40.0-py3-none-any.whl", hash = "sha256:4b5f36fd1b123e3c3d90d7e8a2c5e7c89e50d36e5c56328c13ad937ae99a0571", size = 37494, upload-time = "2025-07-31T19:53:30.181Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-workmail"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/f4/d9/74f62c1bfa42e444c56d2136fc54a6d661cf989f7e318dd0c2f1dea3bd07/mypy_boto3_workmail-1.38.0.tar.gz", hash = "sha256:64ff035dddda6f6f25deccc1113a55db63cd674a12f371f53a0b3d4296fc62db", size = 38578, upload-time = "2025-04-22T21:36:30.287Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/5e/45cf6e2342440adac87303b5285dcea7324d52d5e7a7d9cb90c9508e9ce0/mypy_boto3_workmail-1.40.0.tar.gz", hash = "sha256:b8049796f22396fc5aa4c92e370cf09b1bb4ad68b04679ad46eb4228106444d3", size = 38613, upload-time = "2025-07-31T19:53:37.802Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/dc/1fd985ef19b333119544364e0631f8c0379bca302a422942c32aa712141c/mypy_boto3_workmail-1.38.0-py3-none-any.whl", hash = "sha256:0dccf0de04a24bf3edc785b2bb9657f0b6202184368222cb3a34146bc44bd5d0", size = 43174, upload-time = "2025-04-22T21:36:29.081Z" },
+    { url = "https://files.pythonhosted.org/packages/99/95/76f8af9e0e097fc7d84a362d3847d64ec5d7d2c27da8d1de31bdc66cb338/mypy_boto3_workmail-1.40.0-py3-none-any.whl", hash = "sha256:2e172826e9df3a704ebb1bef51f21c38f614abb489a09ed7f675a9051c9a624b", size = 43233, upload-time = "2025-07-31T19:53:34.54Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-workmailmessageflow"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/32/98/e701376be6e02e0112bc012040d7bc7ad95311842a37ac1328d904f99ae8/mypy_boto3_workmailmessageflow-1.38.0.tar.gz", hash = "sha256:9da0a5342880a876a5853ffef1c239d74901cd8c6963767ec29a43a506d9b5d8", size = 15162, upload-time = "2025-04-22T21:36:32.151Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/57/411d588501f8cedf89f768bb92a003c5a1139db7d1a0db83c19a5d492b31/mypy_boto3_workmailmessageflow-1.40.0.tar.gz", hash = "sha256:cc0a57450f8ca739b0a50720867a02df815a2a52d0fe0f246595306d4d06f29f", size = 15196, upload-time = "2025-07-31T19:53:39.134Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/9c/d60f7b0df0c878f28cff2080c20c038e12a5b5b29819f31b1935f70e5cdd/mypy_boto3_workmailmessageflow-1.38.0-py3-none-any.whl", hash = "sha256:350f55b46f2074b09aebf4a517da12cd6cffd7af47ba0aea3dc8a35bde2f6e7f", size = 18082, upload-time = "2025-04-22T21:36:31.045Z" },
+    { url = "https://files.pythonhosted.org/packages/36/88/b2e248fcaaad9171dc140f6d775a7337cc65f835e9fe1c7856a066009eb7/mypy_boto3_workmailmessageflow-1.40.0-py3-none-any.whl", hash = "sha256:28f8e66d770f24ae261d6872c2de7ed1a64081ceafd4b40135e662af4330393a", size = 18141, upload-time = "2025-07-31T19:53:36.472Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-workspaces"
-version = "1.38.13"
+version = "1.40.10"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/2f/86362579098b3ff2d2c4cff0005748ad315fb88dc159402c8c1bc7e044a3/mypy_boto3_workspaces-1.38.13.tar.gz", hash = "sha256:8f871c116714d91052f5366f57398fc08da7e7c264445926c95472a2f32d292e", size = 44957, upload-time = "2025-05-09T19:42:21.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/4b/a1d173e16f1793bd3d0f23f8dda2a08ab22455d59b3d7961b1e113e3acf1/mypy_boto3_workspaces-1.40.10.tar.gz", hash = "sha256:e8f4c61776a476e392d15452e37ca470accadb98b241bf9baafa427be04cf50c", size = 46362, upload-time = "2025-08-14T19:27:54.85Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/dd/2b3d05136043cbfcae85bc77a593206676564241a242391aa6e247c7eb79/mypy_boto3_workspaces-1.38.13-py3-none-any.whl", hash = "sha256:2f9cf3b4097118f1aad418991cde99ac1a0ccbd86e6717a43f939a90036f02e0", size = 52128, upload-time = "2025-05-09T19:42:18.174Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/6e/bb0f1251abecda15d616424fb0d46efe8fb9e04621147dda9837c7bbee9d/mypy_boto3_workspaces-1.40.10-py3-none-any.whl", hash = "sha256:c5d2fd1698241520a3a2478704cfc9c59b747d9dc1a24a8a0a5b66fb357eb066", size = 53762, upload-time = "2025-08-14T19:27:49.591Z" },
+]
+
+[[package]]
+name = "mypy-boto3-workspaces-instances"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/d1/803b99f8805e0b94312c742a438947ab85d86a256e64b7cfc3cab911c526/mypy_boto3_workspaces_instances-1.40.0.tar.gz", hash = "sha256:25da25e94767dab14b5ab1d671002b06d5d8195980f49e93848d40d634a2ced3", size = 20143, upload-time = "2025-07-31T19:53:42.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/8f/7bb44f36c7b4e6dd794aedd5bfa889b94ccf1a42c688afdef4f7240264fc/mypy_boto3_workspaces_instances-1.40.0-py3-none-any.whl", hash = "sha256:3c9f33e173ce2423739cd39cceed1fa25fb88b4ef5fc4086e47c88e6f26650fd", size = 27854, upload-time = "2025-07-31T19:53:40.305Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-workspaces-thin-client"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/4a/69/d75484f5b5e3d7ef94defec5bb7bbada3e5abf518d22c2bd322244276fd0/mypy_boto3_workspaces_thin_client-1.38.0.tar.gz", hash = "sha256:3f5759b48ca74a2ce63aa6b4b5a6e763e3509426a611a479d8b9228fe1eef5d9", size = 19180, upload-time = "2025-04-22T21:36:35.92Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/69/b2a43c0acb6d877c185c6dcf4bac5e0b4a4e83b697da3efac88d2c6f5ff3/mypy_boto3_workspaces_thin_client-1.40.0.tar.gz", hash = "sha256:8c3fc07e5aba41b69b347c7e87e86b72e525e93d7ecb312747e362864aea8598", size = 19194, upload-time = "2025-07-31T19:53:47.88Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/6f/380d429a33f441cefbf50db5d3bd2a8469197a32cb030cddd8f05301b640/mypy_boto3_workspaces_thin_client-1.38.0-py3-none-any.whl", hash = "sha256:f260e24b019bb003984e54ae50e60e5c606c03411bd8b7cdc661a6410ccb7430", size = 26150, upload-time = "2025-04-22T21:36:34.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b2/6f42718a4e3ac00f51884c8d554932b578a05c27474d49c0c2c3a29ebf98/mypy_boto3_workspaces_thin_client-1.40.0-py3-none-any.whl", hash = "sha256:fab532edccfd8d094209360c9349c8e6d1dacde1aa0ebd088923fb52773e018d", size = 26206, upload-time = "2025-07-31T19:53:45.223Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-workspaces-web"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/c9/b8c54245cfa0a913feaaeb80795d0af698741dbf17825f86d1a7a0f5d9fe/mypy_boto3_workspaces_web-1.38.0.tar.gz", hash = "sha256:5c5fc6ce8769440573e4865a3f6b503e7837e1a5c5bc5d17c11a9dcda6cc1c89", size = 29667, upload-time = "2025-04-22T21:36:38.871Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/f1/97d2cc89a2e33fbfcdf4bae90f8fcc7a4ba12d8555a173f5add563b2d79a/mypy_boto3_workspaces_web-1.40.0.tar.gz", hash = "sha256:d4d9bedf202a320feab6977169ed9eb4f7a17eccc1ab8e7853f53fd4294f7868", size = 31477, upload-time = "2025-07-31T19:53:48.661Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/26/301953c90f888ae26691a978b87895694e08048528dab3d76b4b0538a7c6/mypy_boto3_workspaces_web-1.38.0-py3-none-any.whl", hash = "sha256:1f1c8a65a4969c5d6298b5ca2a3e01ed6d82532a27832f0049aad310824875bb", size = 33102, upload-time = "2025-04-22T21:36:37.643Z" },
+    { url = "https://files.pythonhosted.org/packages/52/f5/e228bb4ca1a629978e4f7ee9f4d9e8fa03acf8f06ffb91ba8f138eb0df7e/mypy_boto3_workspaces_web-1.40.0-py3-none-any.whl", hash = "sha256:72bf3cdfcdcac2e1d1c1de2b6842fa2827f4ffb4ea5ec31b95a4473f6325a5f9", size = 35326, upload-time = "2025-07-31T19:53:46.708Z" },
 ]
 
 [[package]]
 name = "mypy-boto3-xray"
-version = "1.38.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/f5/9121dae480352d0c0efd8094115527e8292e351005630407f5e2f2ccb719/mypy_boto3_xray-1.38.0.tar.gz", hash = "sha256:13dadd42be39f0b3e139d3d3a0021c24e617d67eb8b0d09dac3d7d7795b30384", size = 31804, upload-time = "2025-04-22T21:36:41.182Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/e7/4282651a4722dadb83cf096ee05811ff5f5c30db366a71d1a1e3e98b421e/mypy_boto3_xray-1.40.0.tar.gz", hash = "sha256:68ea729c33d83fdf27f9341c9cc359d72d68cc3919e40b5032be1d90b5486ab2", size = 31909, upload-time = "2025-07-31T19:53:51.811Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/b5/abb18a7d0c9b9c0baa95ed841352052fd3ab11c0d8f618cd4618c70e9250/mypy_boto3_xray-1.38.0-py3-none-any.whl", hash = "sha256:6c2eeb4e7e675e978e18761ced7af95866d01df7b5c21548e452c53c255237b8", size = 36631, upload-time = "2025-04-22T21:36:40.033Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0e/fb561e2d6898c7d2afa6c2c81b16abc961af60c81f894e759b3d25205dba/mypy_boto3_xray-1.40.0-py3-none-any.whl", hash = "sha256:21920eed90cb0fddd0b6122e998958d00df234f0a5950ddd3e3b2fdb353e87e7", size = 36696, upload-time = "2025-07-31T19:53:49.835Z" },
 ]
 
 [[package]]
@@ -4356,21 +4468,21 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "4.25.6"
+version = "5.29.5"
 source = { registry = "https://pypi.org/simple/" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/d5/cccc7e82bbda9909ced3e7a441a24205ea07fea4ce23a772743c0c7611fa/protobuf-4.25.6.tar.gz", hash = "sha256:f8cfbae7c5afd0d0eaccbe73267339bff605a2315860bb1ba08eb66670a9a91f", size = 380631, upload-time = "2025-01-24T20:53:09.498Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/29/d09e70352e4e88c9c7a198d5645d7277811448d76c23b00345670f7c8a38/protobuf-5.29.5.tar.gz", hash = "sha256:bc1463bafd4b0929216c35f437a8e28731a2b7fe3d98bb77a600efced5a15c84", size = 425226, upload-time = "2025-05-28T23:51:59.82Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/41/0ff3559d9a0fbdb37c9452f2b84e61f7784d8d7b9850182c7ef493f523ee/protobuf-4.25.6-cp310-abi3-win32.whl", hash = "sha256:61df6b5786e2b49fc0055f636c1e8f0aff263808bb724b95b164685ac1bcc13a", size = 392454, upload-time = "2025-01-24T20:52:51.08Z" },
-    { url = "https://files.pythonhosted.org/packages/79/84/c700d6c3f3be770495b08a1c035e330497a31420e4a39a24c22c02cefc6c/protobuf-4.25.6-cp310-abi3-win_amd64.whl", hash = "sha256:b8f837bfb77513fe0e2f263250f423217a173b6d85135be4d81e96a4653bcd3c", size = 413443, upload-time = "2025-01-24T20:52:54.523Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/03/361e87cc824452376c2abcef0eabd18da78a7439479ec6541cf29076a4dc/protobuf-4.25.6-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:6d4381f2417606d7e01750e2729fe6fbcda3f9883aa0c32b51d23012bded6c91", size = 394246, upload-time = "2025-01-24T20:52:56.694Z" },
-    { url = "https://files.pythonhosted.org/packages/64/d5/7dbeb69b74fa88f297c6d8f11b7c9cef0c2e2fb1fdf155c2ca5775cfa998/protobuf-4.25.6-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:5dd800da412ba7f6f26d2c08868a5023ce624e1fdb28bccca2dc957191e81fb5", size = 293714, upload-time = "2025-01-24T20:52:57.992Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/f0/6d5c100f6b18d973e86646aa5fc09bc12ee88a28684a56fd95511bceee68/protobuf-4.25.6-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:4434ff8bb5576f9e0c78f47c41cdf3a152c0b44de475784cd3fd170aef16205a", size = 294634, upload-time = "2025-01-24T20:52:59.671Z" },
-    { url = "https://files.pythonhosted.org/packages/71/eb/be11a1244d0e58ee04c17a1f939b100199063e26ecca8262c04827fe0bf5/protobuf-4.25.6-py3-none-any.whl", hash = "sha256:07972021c8e30b870cfc0863409d033af940213e0e7f64e27fe017b929d2c9f7", size = 156466, upload-time = "2025-01-24T20:53:08.287Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/11/6e40e9fc5bba02988a214c07cf324595789ca7820160bfd1f8be96e48539/protobuf-5.29.5-cp310-abi3-win32.whl", hash = "sha256:3f1c6468a2cfd102ff4703976138844f78ebd1fb45f49011afc5139e9e283079", size = 422963, upload-time = "2025-05-28T23:51:41.204Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7f/73cefb093e1a2a7c3ffd839e6f9fcafb7a427d300c7f8aef9c64405d8ac6/protobuf-5.29.5-cp310-abi3-win_amd64.whl", hash = "sha256:3f76e3a3675b4a4d867b52e4a5f5b78a2ef9565549d4037e06cf7b0942b1d3fc", size = 434818, upload-time = "2025-05-28T23:51:44.297Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/73/10e1661c21f139f2c6ad9b23040ff36fee624310dc28fba20d33fdae124c/protobuf-5.29.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:e38c5add5a311f2a6eb0340716ef9b039c1dfa428b28f25a7838ac329204a671", size = 418091, upload-time = "2025-05-28T23:51:45.907Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/04/98f6f8cf5b07ab1294c13f34b4e69b3722bb609c5b701d6c169828f9f8aa/protobuf-5.29.5-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:fa18533a299d7ab6c55a238bf8629311439995f2e7eca5caaff08663606e9015", size = 319824, upload-time = "2025-05-28T23:51:47.545Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e4/07c80521879c2d15f321465ac24c70efe2381378c00bf5e56a0f4fbac8cd/protobuf-5.29.5-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:63848923da3325e1bf7e9003d680ce6e14b07e55d0473253a690c3a8b8fd6e61", size = 319942, upload-time = "2025-05-28T23:51:49.11Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/cc/7e77861000a0691aeea8f4566e5d3aa716f2b1dece4a24439437e41d3d25/protobuf-5.29.5-py3-none-any.whl", hash = "sha256:6cf42630262c59b2d8de33954443d94b746c952b01434fc58a417fdbd2e84bd5", size = 172823, upload-time = "2025-05-28T23:51:58.157Z" },
 ]
 
 [[package]]
 name = "pulumi"
-version = "3.159.0"
+version = "3.191.0"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "debugpy" },
@@ -4380,43 +4492,42 @@ dependencies = [
     { name = "protobuf" },
     { name = "pyyaml" },
     { name = "semver" },
-    { name = "six" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/a8/6aa8dc73dc5810f72db651314adfc8a0306f187293aa53982747abe5d537/pulumi-3.159.0-py3-none-any.whl", hash = "sha256:3d3f4c9411be951d9b81ce521d8644d0ed6d0bc4786fb4afc12d3f75f61aae45", size = 326838, upload-time = "2025-03-27T15:37:24.78Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/9a/33c0f993b62b09a6f92d1135be6ba3938a9a50032940550cdb4a110cf931/pulumi-3.191.0-py3-none-any.whl", hash = "sha256:137ead3d750d66e9d67ab452bf2762e080a273229d6c77263420057be54529d3", size = 375069, upload-time = "2025-08-21T08:36:00.821Z" },
 ]
 
 [[package]]
 name = "pulumi-aws"
-version = "6.74.0"
+version = "7.5.0"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "parver" },
     { name = "pulumi" },
     { name = "semver" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/65/0f05a691cc32ccf1f1ecdb1f1eaffc160ffada26f4f36a280639b98e4863/pulumi_aws-6.74.0.tar.gz", hash = "sha256:f0e5b1e53eaa8ebde2238f1d8ffaafbf9038c60dc34db1ce23d9e7b439c23bc5", size = 7526426, upload-time = "2025-03-27T02:24:00.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/c8/e04c7e0dca4da3b114d53659106e29ad199fe6fd1fb9ded525b3c8e49933/pulumi_aws-7.5.0.tar.gz", hash = "sha256:d6170b4266c29ae40c2954734bca1b41c76530362ce5e4e3a671e33d79eeedcc", size = 8061769, upload-time = "2025-08-20T16:36:40.005Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/09/f76b199a304d01e92ba972704c054c78987166d34390d6772bde56a5b6a5/pulumi_aws-6.74.0-py3-none-any.whl", hash = "sha256:d3d46ce7297dcb5132cdbfb9a576e736df2149e39bdb9dffcd256d173092cb8f", size = 10269718, upload-time = "2025-03-27T02:23:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/48/e5/82bf9f3df691eca184c80c6710e7878222d30670a275cce6814938214a9e/pulumi_aws-7.5.0-py3-none-any.whl", hash = "sha256:f24b63be18e2b9308a45fca57fd9983bc010bbd289c76a440342339f1f32f70e", size = 10949895, upload-time = "2025-08-20T16:36:35.854Z" },
 ]
 
 [[package]]
 name = "pulumi-aws-native"
-version = "1.26.0"
+version = "1.32.0"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "parver" },
     { name = "pulumi" },
     { name = "semver" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/e3/a63582bda7c76a8e8dbaaf74e702db11b87361cf810c7d42f600a01a065b/pulumi_aws_native-1.26.0.tar.gz", hash = "sha256:7ac5a8ae5e2cecaee1ea739569d19d7f70b0daee38b5e8ca59eaa7b02fd1336d", size = 7095545, upload-time = "2025-03-12T13:59:14.21Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/3e/5c12df7ee1fb8fd21648b5abcc452e295c66b26cada45306928c8a7b09eb/pulumi_aws_native-1.32.0.tar.gz", hash = "sha256:e2a2eeaccdf9fd0549036e2c64d601f48aaf345128b8ad49c253ea44a0e2959c", size = 7628036, upload-time = "2025-08-13T14:53:56.597Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/f4/d116c236492574ef64ab477c5ff8ab503563324d11cec5e1ef9205b0ac09/pulumi_aws_native-1.26.0-py3-none-any.whl", hash = "sha256:a4de06c93698447a78bb1500cd6b5d7e7c5cb85146367b5da2ff8b5549743295", size = 10069831, upload-time = "2025-03-12T13:59:11.415Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/14/9b04b42cfe7d43a9d89debd8d87b022494735558a452c3368946cb84e484/pulumi_aws_native-1.32.0-py3-none-any.whl", hash = "sha256:d8f64d70421cd72703c71ce248ecb018cb66d1df9750090752b9f05cceaa4de4", size = 10790827, upload-time = "2025-08-13T14:53:53.329Z" },
 ]
 
 [[package]]
 name = "pydantic"
-version = "2.11.4"
+version = "2.11.7"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "annotated-types" },
@@ -4424,9 +4535,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/ab/5250d56ad03884ab5efd07f734203943c8a8ab40d551e208af81d0257bf2/pydantic-2.11.4.tar.gz", hash = "sha256:32738d19d63a226a52eed76645a98ee07c1f410ee41d93b4afbfa85ed8111c2d", size = 786540, upload-time = "2025-04-29T20:38:55.02Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/dd/4325abf92c39ba8623b5af936ddb36ffcfe0beae70405d456ab1fb2f5b8c/pydantic-2.11.7.tar.gz", hash = "sha256:d989c3c6cb79469287b1569f7447a17848c998458d49ebe294e975b9baf0f0db", size = 788350, upload-time = "2025-06-14T08:33:17.137Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/12/46b65f3534d099349e38ef6ec98b1a5a81f42536d17e0ba382c28c67ba67/pydantic-2.11.4-py3-none-any.whl", hash = "sha256:d9615eaa9ac5a063471da949c8fc16376a84afb5024688b3ff885693506764eb", size = 443900, upload-time = "2025-04-29T20:38:52.724Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c0/ec2b1c8712ca690e5d61979dee872603e92b8a32f94cc1b72d53beab008a/pydantic-2.11.7-py3-none-any.whl", hash = "sha256:dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b", size = 444782, upload-time = "2025-06-14T08:33:14.905Z" },
 ]
 
 [[package]]
@@ -4482,15 +4593,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.403"
+version = "1.1.404"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/f6/35f885264ff08c960b23d1542038d8da86971c5d8c955cfab195a4f672d7/pyright-1.1.403.tar.gz", hash = "sha256:3ab69b9f41c67fb5bbb4d7a36243256f0d549ed3608678d381d5f51863921104", size = 3913526, upload-time = "2025-07-09T07:15:52.882Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/6e/026be64c43af681d5632722acd100b06d3d39f383ec382ff50a71a6d5bce/pyright-1.1.404.tar.gz", hash = "sha256:455e881a558ca6be9ecca0b30ce08aa78343ecc031d37a198ffa9a7a1abeb63e", size = 4065679, upload-time = "2025-08-20T18:46:14.029Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/b6/b04e5c2f41a5ccad74a1a4759da41adb20b4bc9d59a5e08d29ba60084d07/pyright-1.1.403-py3-none-any.whl", hash = "sha256:c0eeca5aa76cbef3fcc271259bbd785753c7ad7bcac99a9162b4c4c7daed23b3", size = 5684504, upload-time = "2025-07-09T07:15:50.958Z" },
+    { url = "https://files.pythonhosted.org/packages/84/30/89aa7f7d7a875bbb9a577d4b1dc5a3e404e3d2ae2657354808e905e358e0/pyright-1.1.404-py3-none-any.whl", hash = "sha256:c7b7ff1fdb7219c643079e4c3e7d4125f0dafcc19d253b47e898d130ea426419", size = 5902951, upload-time = "2025-08-20T18:46:12.096Z" },
 ]
 
 [[package]]
@@ -4575,14 +4686,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.12.0"
+version = "0.13.1"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/9e/73b14aed38ee1f62cd30ab93cd0072dec7fb01f3033d116875ae3e7b8b44/s3transfer-0.12.0.tar.gz", hash = "sha256:8ac58bc1989a3fdb7c7f3ee0918a66b160d038a147c7b5db1500930a607e9a1c", size = 149178, upload-time = "2025-04-22T21:08:09.787Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/05/d52bf1e65044b4e5e27d4e63e8d1579dbdec54fce685908ae09bc3720030/s3transfer-0.13.1.tar.gz", hash = "sha256:c3fdba22ba1bd367922f27ec8032d6a1cf5f10c934fb5d68cf60fd5a23d936cf", size = 150589, upload-time = "2025-07-18T19:22:42.31Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/64/d2b49620039b82688aeebd510bd62ff4cdcdb86cbf650cc72ae42c5254a3/s3transfer-0.12.0-py3-none-any.whl", hash = "sha256:35b314d7d82865756edab59f7baebc6b477189e6ab4c53050e28c1de4d9cce18", size = 84773, upload-time = "2025-04-22T21:08:08.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4f/d073e09df851cfa251ef7840007d04db3293a0482ce607d2b993926089be/s3transfer-0.13.1-py3-none-any.whl", hash = "sha256:a981aa7429be23fe6dfc13e80e4020057cbab622b08c0315288758d67cabc724", size = 85308, upload-time = "2025-07-18T19:22:40.947Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
 ## Why is this change necessary?
New major version


 ## How does this change address the issue?
Updates requirements


 ## What side effects does this change have?
Need to use v7


 ## How is this change tested?
Downstream repos have already been using v7


 ## Other
Pulls in other copier updates