### PR TITLE
Enable passing an existing security group into creation of EC2

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -25,6 +25,6 @@ exclude_also =
     # Abstract methods inherently can't be hit
     @abstractmethod
 
-fail_under = 50
+fail_under = 65
 [html]
 directory = coverage-report-pytest

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -73,5 +73,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 22ed96cc # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 4dc59694 # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -73,5 +73,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 4dc59694 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 585e5690 # spellchecker:disable-line
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lab-auto-pulumi"
-version = "0.1.18"
+version = "0.2.0"
 description = "Pulumi helpers. Especially useful for tooling created by the LabAutomationAndScreening github organization."
 authors = [
     {name = "Eli Fine"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     # Specific to this repository
 
     "boto3-stubs[all]", # version specification is in main dependencies already
+    "faker>=40.11.0",
 
     # Managed by upstream template
     "pyright>=1.1.408",

--- a/src/lab_auto_pulumi/__init__.py
+++ b/src/lab_auto_pulumi/__init__.py
@@ -17,6 +17,8 @@ from .constants import TAG_VALUE_FOR_WRITE_ACCESS
 from .constants import USER_ACCESS_TAG_DELIMITER
 from .constants import WORKLOAD_INFO_SSM_PARAM_PREFIX
 from .ec2 import Ec2WithRdp
+from .ec2 import ExistingSecurityGroupConfig
+from .ec2 import NewSecurityGroupConfig
 from .lib import AwsAccountId
 from .lib import WorkloadName
 from .lib import create_resource_name_safe_str
@@ -64,7 +66,9 @@ __all__ = [
     "AwsSsoPermissionSet",
     "AwsSsoPermissionSetAccountAssignments",
     "Ec2WithRdp",
+    "ExistingSecurityGroupConfig",
     "ManualArtifactsBucket",
+    "NewSecurityGroupConfig",
     "OrgInfo",
     "OrganizationInfo",
     "User",

--- a/src/lab_auto_pulumi/ec2.py
+++ b/src/lab_auto_pulumi/ec2.py
@@ -14,12 +14,28 @@ from pulumi_aws.iam import get_policy_document
 from pulumi_aws_native import TagArgs
 from pulumi_aws_native import ec2
 from pulumi_aws_native import iam
+from pydantic import BaseModel
+from pydantic import ConfigDict
 
 from .constants import CENTRAL_NETWORKING_SSM_PREFIX
 from .lib import create_resource_name_safe_str
 from .lib import get_org_managed_ssm_param_value
 
 logger = logging.getLogger(__name__)
+
+
+class NewSecurityGroupConfig(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    central_networking_vpc_name: str
+    description: str = "Allow all outbound traffic for SSM access"
+    ingress_rules: list[ec2.SecurityGroupIngressArgs] = []
+
+
+class ExistingSecurityGroupConfig(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    security_group_id: Output[str]
 
 
 class Ec2WithRdp(ComponentResource):
@@ -30,13 +46,11 @@ class Ec2WithRdp(ComponentResource):
         central_networking_subnet_name: str,
         instance_type: str,
         image_id: str,
-        central_networking_vpc_name: str,
+        security_group_config: NewSecurityGroupConfig | ExistingSecurityGroupConfig,
         root_volume_gb: int = 30,
         user_data: Output[str]
         | None = None,  # On Windows EC2, Userdata script shows up here: C:\Windows\system32\config\systemprofile\AppData\Local\Temp\Amazon\EC2-Windows\Launch\InvokeUserData\UserScript.ps1.  You may need to start just at system32 and navigate down, because it will keep asking for permissions
         additional_instance_tags: list[TagArgs] | None = None,
-        security_group_description: str = "Allow all outbound traffic for SSM access",
-        ingress_rules: list[ec2.SecurityGroupIngressArgs] | None = None,
         instance_ignore_changes: list[str] | None = None,
         export_user_data: bool = True,
         persist_user_data: bool = False,  # if false, then user data changes will result in replacing the instance (because new user data won't take effect unless the instance is replaced). if true, then you can replace the user data, but it will force an immediate restart of the EC2...which may not actually show up in the Pulumi plan
@@ -47,8 +61,6 @@ class Ec2WithRdp(ComponentResource):
         super().__init__("labauto:Ec2WithRdp", append_resource_suffix(name), None, opts=ResourceOptions(parent=parent))
         replace_on_changes = ["user_data"] if not persist_user_data else []
         self.name = name
-        if ingress_rules is None:
-            ingress_rules = []
         if additional_instance_tags is None:
             additional_instance_tags = []
         resource_name = f"{name}-ec2"
@@ -75,43 +87,52 @@ class Ec2WithRdp(ComponentResource):
             roles=[self.instance_role.role_name],  # pyright: ignore[reportArgumentType] # pyright thinks only inputs can be set as role names, but Outputs seem to work fine
             opts=ResourceOptions(parent=self),
         )
-        self.security_group = ec2.SecurityGroup(
-            append_resource_suffix(name),
-            vpc_id=get_org_managed_ssm_param_value(
-                f"{CENTRAL_NETWORKING_SSM_PREFIX}/vpcs/{central_networking_vpc_name}/id"
-            ),
-            group_description=security_group_description,
-            tags=[TagArgs(key="Name", value=name), *common_tags_native()],
-            opts=ResourceOptions(parent=self),
-        )
-        for idx, rule_args in enumerate(ingress_rules):
-            if not rule_args.description:
-                raise ValueError(  # noqa: TRY003 # not worth making a custom exception for this...especially until we figure out how to test Pulumi components
-                    f"Security group ingress rule index {idx} must have a description ({rule_args})"
-                )
-            assert isinstance(rule_args.description, str), (
-                f"Expected str but got type {type(rule_args.description)} for {rule_args.description}"
+        if isinstance(security_group_config, ExistingSecurityGroupConfig):
+            self.security_group = ec2.SecurityGroup.get(
+                append_resource_suffix(name),
+                security_group_config.security_group_id,
+                opts=ResourceOptions(parent=self),
             )
-            resource_safe_description = create_resource_name_safe_str(rule_args.description)
+            resolved_security_group_id = self.security_group.id
+        else:
+            self.security_group = ec2.SecurityGroup(
+                append_resource_suffix(name),
+                vpc_id=get_org_managed_ssm_param_value(
+                    f"{CENTRAL_NETWORKING_SSM_PREFIX}/vpcs/{security_group_config.central_networking_vpc_name}/id"
+                ),
+                group_description=security_group_config.description,
+                tags=[TagArgs(key="Name", value=name), *common_tags_native()],
+                opts=ResourceOptions(parent=self),
+            )
+            for idx, rule_args in enumerate(security_group_config.ingress_rules):
+                if not rule_args.description:
+                    raise ValueError(  # noqa: TRY003 # not worth making a custom exception for this...especially until we figure out how to test Pulumi components
+                        f"Security group ingress rule index {idx} must have a description ({rule_args})"
+                    )
+                assert isinstance(rule_args.description, str), (
+                    f"Expected str but got type {type(rule_args.description)} for {rule_args.description}"
+                )
+                resource_safe_description = create_resource_name_safe_str(rule_args.description)
 
-            _ = ec2.SecurityGroupIngress(
-                append_resource_suffix(f"{name}-ingress-{resource_safe_description}", max_length=190),
+                _ = ec2.SecurityGroupIngress(
+                    append_resource_suffix(f"{name}-ingress-{resource_safe_description}", max_length=190),
+                    opts=ResourceOptions(parent=self.security_group),
+                    ip_protocol=rule_args.ip_protocol,
+                    from_port=rule_args.from_port,
+                    to_port=rule_args.to_port,
+                    source_security_group_id=rule_args.source_security_group_id,
+                    group_id=self.security_group.id,
+                )
+            _ = ec2.SecurityGroupEgress(  # TODO: see if this can be further restricted
+                append_resource_suffix(f"{name}-egress", max_length=190),
                 opts=ResourceOptions(parent=self.security_group),
-                ip_protocol=rule_args.ip_protocol,
-                from_port=rule_args.from_port,
-                to_port=rule_args.to_port,
-                source_security_group_id=rule_args.source_security_group_id,
+                ip_protocol="-1",
+                from_port=0,
+                to_port=0,
+                cidr_ip="0.0.0.0/0",
                 group_id=self.security_group.id,
             )
-        _ = ec2.SecurityGroupEgress(  # TODO: see if this can be further restricted
-            append_resource_suffix(f"{name}-egress", max_length=190),
-            opts=ResourceOptions(parent=self.security_group),
-            ip_protocol="-1",
-            from_port=0,
-            to_port=0,
-            cidr_ip="0.0.0.0/0",
-            group_id=self.security_group.id,
-        )
+            resolved_security_group_id = self.security_group.id
         self.instance = ec2.Instance(
             append_resource_suffix(name),
             instance_type=instance_type,
@@ -119,7 +140,7 @@ class Ec2WithRdp(ComponentResource):
             subnet_id=get_org_managed_ssm_param_value(
                 f"{CENTRAL_NETWORKING_SSM_PREFIX}/subnets/{central_networking_subnet_name}/id"
             ),
-            security_group_ids=[self.security_group.id],
+            security_group_ids=[resolved_security_group_id],
             block_device_mappings=[
                 ec2.InstanceBlockDeviceMappingArgs(
                     device_name="/dev/sda1", ebs=ec2.InstanceEbsArgs(volume_size=root_volume_gb, volume_type="gp3")

--- a/src/lab_auto_pulumi/ec2.py
+++ b/src/lab_auto_pulumi/ec2.py
@@ -102,7 +102,7 @@ class Ec2WithRdp(ComponentResource):
                 ),
                 group_description=security_group_config.description,
                 tags=[TagArgs(key="Name", value=name), *common_tags_native()],
-                opts=ResourceOptions(parent=self),
+                opts=ResourceOptions(parent=self, delete_before_replace=True, replace_on_changes=["*"]),
             )
             for idx, rule_args in enumerate(security_group_config.ingress_rules):
                 if not rule_args.description:
@@ -116,7 +116,9 @@ class Ec2WithRdp(ComponentResource):
 
                 _ = ec2.SecurityGroupIngress(
                     append_resource_suffix(f"{name}-ingress-{resource_safe_description}", max_length=190),
-                    opts=ResourceOptions(parent=self.security_group),
+                    opts=ResourceOptions(
+                        parent=self.security_group, delete_before_replace=True, replace_on_changes=["*"]
+                    ),
                     ip_protocol=rule_args.ip_protocol,
                     from_port=rule_args.from_port,
                     to_port=rule_args.to_port,
@@ -125,7 +127,7 @@ class Ec2WithRdp(ComponentResource):
                 )
             _ = ec2.SecurityGroupEgress(  # TODO: see if this can be further restricted
                 append_resource_suffix(f"{name}-egress", max_length=190),
-                opts=ResourceOptions(parent=self.security_group),
+                opts=ResourceOptions(parent=self.security_group, delete_before_replace=True, replace_on_changes=["*"]),
                 ip_protocol="-1",
                 from_port=0,
                 to_port=0,

--- a/src/lab_auto_pulumi/ec2.py
+++ b/src/lab_auto_pulumi/ec2.py
@@ -124,6 +124,7 @@ class Ec2WithRdp(ComponentResource):
                     to_port=rule_args.to_port,
                     source_security_group_id=rule_args.source_security_group_id,
                     group_id=self.security_group.id,
+                    description=rule_args.description,
                 )
             _ = ec2.SecurityGroupEgress(  # TODO: see if this can be further restricted
                 append_resource_suffix(f"{name}-egress", max_length=190),
@@ -133,6 +134,7 @@ class Ec2WithRdp(ComponentResource):
                 to_port=0,
                 cidr_ip="0.0.0.0/0",
                 group_id=self.security_group.id,
+                description="Allow all outbound traffic",
             )
             resolved_security_group_id = self.security_group.id
         self.instance = ec2.Instance(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+from collections.abc import Generator
 
 import pytest
 
@@ -7,5 +9,17 @@ logger = logging.getLogger(__name__)
 
 def pytest_configure(
     config: pytest.Config,
-):
+) -> None:
     """Configure pytest itself, such as logging levels."""
+
+
+@pytest.fixture(autouse=True)
+def event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
+    # Python 3.14 removed the implicit event loop creation in asyncio.get_event_loop().
+    # pulumi.runtime.test relies on that implicit creation, so we create one explicitly
+    # before each test and tear it down after.
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    yield loop
+    loop.close()
+    asyncio.set_event_loop(None)

--- a/tests/unit/test_ec2.py
+++ b/tests/unit/test_ec2.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import random
 from collections.abc import Sequence
 from typing import Any
 from unittest import mock
@@ -7,6 +8,7 @@ from unittest import mock
 import pulumi
 import pulumi.runtime
 import pytest
+from faker import Faker
 from pulumi_aws_native import TagArgs
 from pulumi_aws_native import ec2
 
@@ -16,6 +18,8 @@ from lab_auto_pulumi.ec2 import ExistingSecurityGroupConfig
 from lab_auto_pulumi.ec2 import NewSecurityGroupConfig
 
 _pulumi_test = pulumi.runtime.test  # type: ignore[reportUnknownMemberType] # pulumi.runtime.test is partially typed in the Pulumi SDK; alias avoids repeating the ignore on every test
+
+_EC2_INSTANCE_TYPES = ["t3.micro", "t3.large", "m5.xlarge", "c5.2xlarge"]
 
 
 class Ec2Mocks(pulumi.runtime.Mocks):
@@ -49,16 +53,25 @@ class Ec2Mocks(pulumi.runtime.Mocks):
 
 def _new_ec2_with_rdp(  # noqa: PLR0913 # too many parameters, but it's more readable to specify them as arguments in the tests than pack them into a config object, they are keyword args anyways with a bunch of default values
     *,
-    name: str = "test-instance",
-    central_networking_subnet_name: str = "test-subnet",
-    instance_type: str = "t3.micro",
-    image_id: str = "ami-12345678",
+    name: str | None = None,
+    central_networking_subnet_name: str | None = None,
+    instance_type: str | None = None,
+    image_id: str | None = None,
     security_group_config: NewSecurityGroupConfig | ExistingSecurityGroupConfig | None = None,
     user_data: pulumi.Output[str] | None = None,
     additional_instance_tags: list[TagArgs] | None = None,
 ) -> Ec2WithRdp:
+    _faker = Faker()
+    if name is None:
+        name = _faker.slug()
+    if central_networking_subnet_name is None:
+        central_networking_subnet_name = _faker.slug()
+    if instance_type is None:
+        instance_type = random.choice(_EC2_INSTANCE_TYPES)
+    if image_id is None:
+        image_id = f"ami-{_faker.hexify('????????')}"
     if security_group_config is None:
-        security_group_config = NewSecurityGroupConfig(central_networking_vpc_name="test-vpc")
+        security_group_config = NewSecurityGroupConfig(central_networking_vpc_name=_faker.slug())
     with (
         mock.patch.object(lab_auto_ec2_module, lab_auto_ec2_module.common_tags_native.__name__, return_value=[]),
         mock.patch.object(
@@ -92,25 +105,29 @@ def ec2_mocks() -> Ec2Mocks:
 class TestNewSecurityGroupConfig:
     @_pulumi_test
     def test_When_new_sg_config__Then_instance_has_correct_instance_type(self) -> pulumi.Output[None]:
-        component = _new_ec2_with_rdp(instance_type="t3.micro")
+        instance_type = random.choice(_EC2_INSTANCE_TYPES)
+        component = _new_ec2_with_rdp(instance_type=instance_type)
 
-        def check(instance_type: str | None) -> None:
-            assert instance_type == "t3.micro"
+        def check(actual: str | None) -> None:
+            assert actual == instance_type
 
         return component.instance.instance_type.apply(check)
 
     @_pulumi_test
-    def test_When_new_sg_config__Then_instance_has_correct_image_id_and_subnet(self) -> pulumi.Output[None]:
+    def test_When_new_sg_config__Then_instance_has_correct_image_id_and_subnet(
+        self, faker: Faker
+    ) -> pulumi.Output[None]:
+        image_id = f"ami-{faker.hexify('????????')}"
         component = _new_ec2_with_rdp(
-            image_id="ami-87654321",
-            central_networking_subnet_name="my-subnet",
-            instance_type="t3.large",
+            image_id=image_id,
+            central_networking_subnet_name=faker.slug(),
+            instance_type=random.choice(_EC2_INSTANCE_TYPES),
         )
 
         def check(args: list[Any]) -> None:
-            image_id, subnet_id = args
-            assert image_id == "ami-87654321"
-            assert subnet_id == "mock-id", f"Expected 'mock-id' but got {subnet_id!r}"
+            actual_image_id, actual_subnet_id = args
+            assert actual_image_id == image_id
+            assert actual_subnet_id == "mock-id", f"Expected 'mock-id' but got {actual_subnet_id!r}"
 
         return pulumi.Output.all(
             component.instance.image_id,
@@ -118,9 +135,11 @@ class TestNewSecurityGroupConfig:
         ).apply(check)
 
     @_pulumi_test
-    def test_When_new_sg_config__Then_security_group_created_with_vpc_id_from_ssm(self) -> pulumi.Output[None]:
+    def test_When_new_sg_config__Then_security_group_created_with_vpc_id_from_ssm(
+        self, faker: Faker
+    ) -> pulumi.Output[None]:
         component = _new_ec2_with_rdp(
-            security_group_config=NewSecurityGroupConfig(central_networking_vpc_name="test-vpc")
+            security_group_config=NewSecurityGroupConfig(central_networking_vpc_name=faker.slug())
         )
 
         def check(vpc_id: str | None) -> None:
@@ -130,11 +149,11 @@ class TestNewSecurityGroupConfig:
 
     @_pulumi_test
     def test_When_new_sg_with_ingress_rule__Then_ingress_resource_created(
-        self, ec2_mocks: Ec2Mocks
+        self, ec2_mocks: Ec2Mocks, faker: Faker
     ) -> pulumi.Output[None]:
         component = _new_ec2_with_rdp(
             security_group_config=NewSecurityGroupConfig(
-                central_networking_vpc_name="test-vpc",
+                central_networking_vpc_name=faker.slug(),
                 ingress_rules=[
                     ec2.SecurityGroupIngressArgs(
                         description="Allow RDP",
@@ -170,11 +189,11 @@ class TestNewSecurityGroupConfig:
         return component.instance.id.apply(check)
 
     @_pulumi_test
-    def test_When_ingress_rule_has_no_description__Then_raises_value_error(self) -> None:
+    def test_When_ingress_rule_has_no_description__Then_raises_value_error(self, faker: Faker) -> None:
         with pytest.raises(ValueError, match="must have a description"):
             _ = _new_ec2_with_rdp(
                 security_group_config=NewSecurityGroupConfig(
-                    central_networking_vpc_name="test-vpc",
+                    central_networking_vpc_name=faker.slug(),
                     ingress_rules=[
                         ec2.SecurityGroupIngressArgs(
                             description="",
@@ -189,14 +208,15 @@ class TestNewSecurityGroupConfig:
 
 class TestExistingSecurityGroup:
     @_pulumi_test
-    def test_When_existing_sg_config__Then_no_new_security_group_resource_created(self) -> pulumi.Output[None]:
+    def test_When_existing_sg_config__Then_no_new_security_group_resource_created(
+        self, faker: Faker
+    ) -> pulumi.Output[None]:
         mocks = Ec2Mocks()
         pulumi.runtime.set_mocks(mocks, project="test-project", stack="test-stack")
 
+        sg_id = f"sg-{faker.hexify('????????')}"
         component = _new_ec2_with_rdp(
-            security_group_config=ExistingSecurityGroupConfig(
-                security_group_id=pulumi.Output.from_input("sg-existing-123")
-            )
+            security_group_config=ExistingSecurityGroupConfig(security_group_id=pulumi.Output.from_input(sg_id))
         )
 
         def check(_: str) -> None:
@@ -206,43 +226,42 @@ class TestExistingSecurityGroup:
             new_sgs = [
                 r for r in mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroup" and not r.resource_id
             ]
-            assert [r.resource_id for r in read_sgs] == ["sg-existing-123"]
+            assert [r.resource_id for r in read_sgs] == [sg_id]
             assert new_sgs == [], f"Expected no new SecurityGroup resources but got {new_sgs}"
 
         return component.instance.id.apply(check)
 
     @_pulumi_test
-    def test_When_existing_sg_config__Then_instance_uses_provided_sg_id(self) -> pulumi.Output[None]:
-
+    def test_When_existing_sg_config__Then_instance_uses_provided_sg_id(self, faker: Faker) -> pulumi.Output[None]:
+        sg_id = f"sg-{faker.hexify('????????')}"
         component = _new_ec2_with_rdp(
-            security_group_config=ExistingSecurityGroupConfig(
-                security_group_id=pulumi.Output.from_input("sg-existing-123")
-            )
+            security_group_config=ExistingSecurityGroupConfig(security_group_id=pulumi.Output.from_input(sg_id))
         )
 
         def check(sg_ids: Sequence[Any] | None) -> None:
             assert sg_ids is not None, "Expected sg_ids to be not None"
-            assert "sg-existing-123" in sg_ids, f"Expected 'sg-existing-123' in {sg_ids}"
+            assert sg_id in sg_ids, f"Expected {sg_id!r} in {sg_ids}"
 
         return component.instance.security_group_ids.apply(check)
 
 
 class TestUserData:
     @_pulumi_test
-    def test_When_user_data_provided__Then_instance_user_data_is_base64_encoded(self) -> pulumi.Output[None]:
+    def test_When_user_data_provided__Then_instance_user_data_is_base64_encoded(
+        self, faker: Faker
+    ) -> pulumi.Output[None]:
 
-        raw = "write-me-a-script"
-        component = _new_ec2_with_rdp(user_data=pulumi.Output.from_input(raw))
+        raw_user_data_script = faker.sentence()
+        component = _new_ec2_with_rdp(user_data=pulumi.Output.from_input(raw_user_data_script))
 
         def check(encoded: str | None) -> None:
-            expected = base64.b64encode(raw.encode()).decode()
+            expected = base64.b64encode(raw_user_data_script.encode()).decode()
             assert encoded == expected, f"Expected {expected!r} but got {encoded!r}"
 
         return component.instance.user_data.apply(check)
 
     @_pulumi_test
     def test_When_no_user_data__Then_instance_user_data_is_none(self) -> pulumi.Output[None]:
-
         component = _new_ec2_with_rdp(user_data=None)
 
         def check(user_data: str | None) -> None:
@@ -252,19 +271,23 @@ class TestUserData:
 
 
 @_pulumi_test
-def test_When_additional_instance_tags_provided__Then_tags_appear_on_instance() -> pulumi.Output[None]:
+def test_When_additional_instance_tags_provided__Then_tags_appear_on_instance(faker: Faker) -> pulumi.Output[None]:
+    key_one = faker.word()
+    value_one = faker.word()
+    key_two = faker.word()
+    value_two = faker.word()
     component = _new_ec2_with_rdp(
         additional_instance_tags=[
-            TagArgs(key="env", value="testing"),
-            TagArgs(key="owner", value="automation"),
+            TagArgs(key=key_one, value=value_one),
+            TagArgs(key=key_two, value=value_two),
         ]
     )
 
     def check(tags: Sequence[Any] | None) -> None:
         assert tags is not None, "Expected tags to be not None"
         tag_map: dict[str, str] = {t["key"]: t["value"] for t in tags}
-        assert tag_map.get("env") == "testing", f"Missing or wrong 'env' tag in {tag_map}"
-        assert tag_map.get("owner") == "automation", f"Missing or wrong 'owner' tag in {tag_map}"
+        assert tag_map.get(key_one) == value_one, f"Missing or wrong {key_one!r} tag in {tag_map}"
+        assert tag_map.get(key_two) == value_two, f"Missing or wrong {key_two!r} tag in {tag_map}"
 
     return component.instance.tags.apply(check)
 

--- a/tests/unit/test_ec2.py
+++ b/tests/unit/test_ec2.py
@@ -10,6 +10,7 @@ import pytest
 from pulumi_aws_native import TagArgs
 from pulumi_aws_native import ec2
 
+from lab_auto_pulumi import ec2 as lab_auto_ec2_module
 from lab_auto_pulumi.ec2 import Ec2WithRdp
 from lab_auto_pulumi.ec2 import ExistingSecurityGroupConfig
 from lab_auto_pulumi.ec2 import NewSecurityGroupConfig
@@ -59,9 +60,10 @@ def _new_ec2_with_rdp(  # noqa: PLR0913 # too many parameters, but it's more rea
     if security_group_config is None:
         security_group_config = NewSecurityGroupConfig(central_networking_vpc_name="test-vpc")
     with (
-        mock.patch("lab_auto_pulumi.ec2.common_tags_native", return_value=[]),
-        mock.patch(
-            "lab_auto_pulumi.ec2.get_org_managed_ssm_param_value",
+        mock.patch.object(lab_auto_ec2_module, lab_auto_ec2_module.common_tags_native.__name__, return_value=[]),
+        mock.patch.object(
+            lab_auto_ec2_module,
+            lab_auto_ec2_module.get_org_managed_ssm_param_value.__name__,
             side_effect=_ssm_side_effect,
         ),
     ):

--- a/tests/unit/test_ec2.py
+++ b/tests/unit/test_ec2.py
@@ -1,0 +1,315 @@
+import base64
+import json
+from collections.abc import Sequence
+from typing import Any
+from unittest import mock
+
+import pulumi
+import pulumi.runtime
+import pytest
+from pulumi_aws_native import TagArgs
+from pulumi_aws_native import ec2
+
+from lab_auto_pulumi.ec2 import Ec2WithRdp
+from lab_auto_pulumi.ec2 import ExistingSecurityGroupConfig
+from lab_auto_pulumi.ec2 import NewSecurityGroupConfig
+
+# pulumi.runtime.test is partially typed in the Pulumi SDK; alias avoids repeating the ignore on every test
+_pulumi_test = pulumi.runtime.test  # type: ignore[reportUnknownMemberType]
+
+
+class Ec2Mocks(pulumi.runtime.Mocks):
+    def __init__(self) -> None:
+        super().__init__()
+        self.created_resources: list[pulumi.runtime.MockResourceArgs] = []
+
+    def new_resource(self, args: pulumi.runtime.MockResourceArgs) -> tuple[str, dict[str, Any]]:  # type: ignore[override] # pyright infers Optional[str] for id but str is always safe here
+        self.created_resources.append(args)
+        resource_id = args.resource_id or f"{args.name}-id"
+        return (resource_id, args.inputs)  # type: ignore[return-value] # Pulumi SDK types inputs as dict[Unknown, Unknown]
+
+    def call(self, args: pulumi.runtime.MockCallArgs) -> dict[str, Any]:  # type: ignore[override] # pyright infers tuple[dict, Optional[list]] but plain dict is accepted
+        if args.token == "aws:iam/getPolicyDocument:getPolicyDocument":  # noqa:S105 # definitely not a password
+            return {
+                "json": json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": "sts:AssumeRole",
+                                "Principal": {"Service": "ec2.amazonaws.com"},
+                            }
+                        ],
+                    }
+                )
+            }
+        return {}
+
+
+def _new_ec2_with_rdp(  # noqa: PLR0913 # too many parameters, but it's more readable to specify them as arguments in the tests than pack them into a config object, they are keyword args anyways with a bunch of default values
+    *,
+    name: str = "test-instance",
+    central_networking_subnet_name: str = "test-subnet",
+    instance_type: str = "t3.micro",
+    image_id: str = "ami-12345678",
+    security_group_config: NewSecurityGroupConfig | ExistingSecurityGroupConfig | None = None,
+    user_data: pulumi.Output[str] | None = None,
+    additional_instance_tags: list[TagArgs] | None = None,
+) -> Ec2WithRdp:
+    if security_group_config is None:
+        security_group_config = NewSecurityGroupConfig(central_networking_vpc_name="test-vpc")
+    with (
+        mock.patch("lab_auto_pulumi.ec2.common_tags_native", return_value=[]),
+        mock.patch(
+            "lab_auto_pulumi.ec2.get_org_managed_ssm_param_value",
+            side_effect=_ssm_side_effect,
+        ),
+    ):
+        return Ec2WithRdp(
+            name=name,
+            central_networking_subnet_name=central_networking_subnet_name,
+            instance_type=instance_type,
+            image_id=image_id,
+            security_group_config=security_group_config,
+            user_data=user_data,
+            additional_instance_tags=additional_instance_tags,
+        )
+
+
+def _ssm_side_effect(param: str) -> str:
+    return f"mock-{param.rsplit('/', maxsplit=1)[-1]}"
+
+
+# ============================================================================
+# New security group path
+# ============================================================================
+
+
+@_pulumi_test
+def test_When_new_sg_config__Then_instance_has_correct_instance_type() -> pulumi.Output[None]:
+    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
+
+    component = _new_ec2_with_rdp(instance_type="t3.micro")
+
+    def check(instance_type: str | None) -> None:
+        assert instance_type == "t3.micro"
+
+    return component.instance.instance_type.apply(check)
+
+
+@_pulumi_test
+def test_When_new_sg_config__Then_instance_has_correct_image_id_and_subnet() -> pulumi.Output[None]:
+    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
+
+    component = _new_ec2_with_rdp(
+        image_id="ami-87654321",
+        central_networking_subnet_name="my-subnet",
+        instance_type="t3.large",
+    )
+
+    def check(args: list[Any]) -> None:
+        image_id, subnet_id = args
+        assert image_id == "ami-87654321"
+        assert subnet_id == "mock-id", f"Expected 'mock-id' but got {subnet_id!r}"
+
+    return pulumi.Output.all(
+        component.instance.image_id,
+        component.instance.subnet_id,
+    ).apply(check)
+
+
+@_pulumi_test
+def test_When_new_sg_config__Then_security_group_created_with_vpc_id_from_ssm() -> pulumi.Output[None]:
+    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
+
+    component = _new_ec2_with_rdp(security_group_config=NewSecurityGroupConfig(central_networking_vpc_name="test-vpc"))
+
+    def check(vpc_id: str | None) -> None:
+        assert vpc_id == "mock-id", f"Expected 'mock-id' but got {vpc_id!r}"
+
+    return component.security_group.vpc_id.apply(check)
+
+
+@_pulumi_test
+def test_When_new_sg_with_ingress_rule__Then_ingress_resource_created() -> pulumi.Output[None]:
+    mocks = Ec2Mocks()
+    pulumi.runtime.set_mocks(mocks, project="test-project", stack="test-stack")
+
+    component = _new_ec2_with_rdp(
+        security_group_config=NewSecurityGroupConfig(
+            central_networking_vpc_name="test-vpc",
+            ingress_rules=[
+                ec2.SecurityGroupIngressArgs(
+                    description="Allow RDP",
+                    ip_protocol="tcp",
+                    from_port=3389,
+                    to_port=3389,
+                )
+            ],
+        )
+    )
+
+    def check(_: str) -> None:
+        ingress = [r for r in mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroupIngress"]
+        assert [r.inputs.get("ipProtocol") for r in ingress] == ["tcp"]  # type: ignore[reportUnknownMemberType] # Pulumi SDK types inputs as dict[Unknown, Unknown]
+        assert [r.inputs.get("fromPort") for r in ingress] == [3389]  # type: ignore[reportUnknownMemberType]
+        assert [r.inputs.get("toPort") for r in ingress] == [3389]  # type: ignore[reportUnknownMemberType]
+
+    return component.instance.id.apply(check)
+
+
+@_pulumi_test
+def test_When_new_sg_config__Then_egress_rule_always_created() -> pulumi.Output[None]:
+    mocks = Ec2Mocks()
+    pulumi.runtime.set_mocks(mocks, project="test-project", stack="test-stack")
+
+    component = _new_ec2_with_rdp()
+
+    def check(_: str) -> None:
+        egress = [r for r in mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroupEgress"]
+        assert len(egress) == 1
+        assert egress[0].inputs.get("ipProtocol") == "-1"  # type: ignore[reportUnknownMemberType] # Pulumi SDK types inputs as dict[Unknown, Unknown]
+        assert egress[0].inputs.get("cidrIp") == "0.0.0.0/0"  # type: ignore[reportUnknownMemberType]
+
+    return component.instance.id.apply(check)
+
+
+def test_When_ingress_rule_has_no_description__Then_raises_value_error() -> None:
+    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
+
+    with pytest.raises(ValueError, match="must have a description"):
+        _ = _new_ec2_with_rdp(
+            security_group_config=NewSecurityGroupConfig(
+                central_networking_vpc_name="test-vpc",
+                ingress_rules=[
+                    ec2.SecurityGroupIngressArgs(
+                        description="",
+                        ip_protocol="tcp",
+                        from_port=3389,
+                        to_port=3389,
+                    )
+                ],
+            )
+        )
+
+
+# ============================================================================
+# Existing security group path
+# ============================================================================
+
+
+@_pulumi_test
+def test_When_existing_sg_config__Then_no_new_security_group_resource_created() -> pulumi.Output[None]:
+    mocks = Ec2Mocks()
+    pulumi.runtime.set_mocks(mocks, project="test-project", stack="test-stack")
+
+    component = _new_ec2_with_rdp(
+        security_group_config=ExistingSecurityGroupConfig(security_group_id=pulumi.Output.from_input("sg-existing-123"))
+    )
+
+    def check(_: str) -> None:
+        # ec2.SecurityGroup.get() is a ReadResource, which flows through new_resource in the mock
+        # with resource_id set to the ID being read. Assert we read the right one and never created a new one.
+        read_sgs = [r for r in mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroup" and r.resource_id]
+        new_sgs = [r for r in mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroup" and not r.resource_id]
+        assert [r.resource_id for r in read_sgs] == ["sg-existing-123"]
+        assert new_sgs == [], f"Expected no new SecurityGroup resources but got {new_sgs}"
+
+    return component.instance.id.apply(check)
+
+
+@_pulumi_test
+def test_When_existing_sg_config__Then_instance_uses_provided_sg_id() -> pulumi.Output[None]:
+    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
+
+    component = _new_ec2_with_rdp(
+        security_group_config=ExistingSecurityGroupConfig(security_group_id=pulumi.Output.from_input("sg-existing-123"))
+    )
+
+    def check(sg_ids: Sequence[Any] | None) -> None:
+        assert sg_ids is not None, "Expected sg_ids to be not None"
+        assert "sg-existing-123" in sg_ids, f"Expected 'sg-existing-123' in {sg_ids}"
+
+    return component.instance.security_group_ids.apply(check)
+
+
+# ============================================================================
+# user_data, additional tags, and instance role
+# ============================================================================
+
+
+@_pulumi_test
+def test_When_user_data_provided__Then_instance_user_data_is_base64_encoded() -> pulumi.Output[None]:
+    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
+
+    raw = "write-me-a-script"
+    component = _new_ec2_with_rdp(user_data=pulumi.Output.from_input(raw))
+
+    def check(encoded: str | None) -> None:
+        expected = base64.b64encode(raw.encode()).decode()
+        assert encoded == expected, f"Expected {expected!r} but got {encoded!r}"
+
+    return component.instance.user_data.apply(check)
+
+
+@_pulumi_test
+def test_When_no_user_data__Then_instance_user_data_is_none() -> pulumi.Output[None]:
+    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
+
+    component = _new_ec2_with_rdp(user_data=None)
+
+    def check(user_data: str | None) -> None:
+        assert user_data is None, f"Expected None but got {user_data!r}"
+
+    return component.instance.user_data.apply(check)
+
+
+@_pulumi_test
+def test_When_additional_instance_tags_provided__Then_tags_appear_on_instance() -> pulumi.Output[None]:
+    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
+
+    component = _new_ec2_with_rdp(
+        additional_instance_tags=[
+            TagArgs(key="env", value="testing"),
+            TagArgs(key="owner", value="automation"),
+        ]
+    )
+
+    def check(tags: Sequence[Any] | None) -> None:
+        assert tags is not None, "Expected tags to be not None"
+        tag_map: dict[str, str] = {t["key"]: t["value"] for t in tags}
+        assert tag_map.get("env") == "testing", f"Missing or wrong 'env' tag in {tag_map}"
+        assert tag_map.get("owner") == "automation", f"Missing or wrong 'owner' tag in {tag_map}"
+
+    return component.instance.tags.apply(check)
+
+
+@_pulumi_test
+def test_When_component_created__Then_instance_role_has_ssm_managed_policy() -> pulumi.Output[None]:
+    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
+
+    component = _new_ec2_with_rdp()
+
+    def check(arns: Sequence[str] | None) -> None:
+        assert arns is not None, "Expected arns to be not None"
+        expected = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+        assert expected in arns, f"Expected SSM policy in {arns}"
+
+    return component.instance_role.managed_policy_arns.apply(check)
+
+
+@_pulumi_test
+def test_When_component_created__Then_instance_role_trust_policy_allows_ec2() -> pulumi.Output[None]:
+    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
+
+    component = _new_ec2_with_rdp()
+
+    def check(policy_json: str) -> None:
+        policy = json.loads(policy_json)
+        services: str | list[str] = policy["Statement"][0]["Principal"]["Service"]
+        if isinstance(services, str):
+            services = [services]
+        assert "ec2.amazonaws.com" in services, f"Expected ec2.amazonaws.com in trust policy but got {services}"
+
+    return component.instance_role.assume_role_policy_document.apply(check)

--- a/tests/unit/test_ec2.py
+++ b/tests/unit/test_ec2.py
@@ -174,14 +174,11 @@ class TestNewSecurityGroupConfig:
         return component.instance.id.apply(check)
 
     @_pulumi_test
-    def test_When_new_sg_config__Then_egress_rule_always_created(self) -> pulumi.Output[None]:
-        mocks = Ec2Mocks()
-        pulumi.runtime.set_mocks(mocks, project="test-project", stack="test-stack")
-
+    def test_When_new_sg_config__Then_egress_rule_always_created(self, ec2_mocks: Ec2Mocks) -> pulumi.Output[None]:
         component = _new_ec2_with_rdp()
 
         def check(_: str) -> None:
-            egress = [r for r in mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroupEgress"]
+            egress = [r for r in ec2_mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroupEgress"]
             assert len(egress) == 1
             assert egress[0].inputs.get("ipProtocol") == "-1"  # type: ignore[reportUnknownMemberType] # Pulumi SDK types inputs as dict[Unknown, Unknown]
             assert egress[0].inputs.get("cidrIp") == "0.0.0.0/0"  # type: ignore[reportUnknownMemberType]
@@ -209,11 +206,8 @@ class TestNewSecurityGroupConfig:
 class TestExistingSecurityGroup:
     @_pulumi_test
     def test_When_existing_sg_config__Then_no_new_security_group_resource_created(
-        self, faker: Faker
+        self, faker: Faker, ec2_mocks: Ec2Mocks
     ) -> pulumi.Output[None]:
-        mocks = Ec2Mocks()
-        pulumi.runtime.set_mocks(mocks, project="test-project", stack="test-stack")
-
         sg_id = f"sg-{faker.hexify('????????')}"
         component = _new_ec2_with_rdp(
             security_group_config=ExistingSecurityGroupConfig(security_group_id=pulumi.Output.from_input(sg_id))
@@ -222,9 +216,11 @@ class TestExistingSecurityGroup:
         def check(_: str) -> None:
             # ec2.SecurityGroup.get() is a ReadResource, which flows through new_resource in the mock
             # with resource_id set to the ID being read. Assert we read the right one and never created a new one.
-            read_sgs = [r for r in mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroup" and r.resource_id]
+            read_sgs = [
+                r for r in ec2_mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroup" and r.resource_id
+            ]
             new_sgs = [
-                r for r in mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroup" and not r.resource_id
+                r for r in ec2_mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroup" and not r.resource_id
             ]
             assert [r.resource_id for r in read_sgs] == [sg_id]
             assert new_sgs == [], f"Expected no new SecurityGroup resources but got {new_sgs}"

--- a/tests/unit/test_ec2.py
+++ b/tests/unit/test_ec2.py
@@ -26,6 +26,7 @@ class Ec2Mocks(pulumi.runtime.Mocks):
     def __init__(self) -> None:
         super().__init__()
         self.created_resources: list[pulumi.runtime.MockResourceArgs] = []
+        self.captured_calls: list[pulumi.runtime.MockCallArgs] = []
 
     def new_resource(self, args: pulumi.runtime.MockResourceArgs) -> tuple[str, dict[str, Any]]:  # type: ignore[override] # pyright infers Optional[str] for id but str is always safe here
         self.created_resources.append(args)
@@ -33,6 +34,7 @@ class Ec2Mocks(pulumi.runtime.Mocks):
         return (resource_id, args.inputs)  # type: ignore[return-value] # Pulumi SDK types inputs as dict[Unknown, Unknown]
 
     def call(self, args: pulumi.runtime.MockCallArgs) -> dict[str, Any]:  # type: ignore[override] # pyright infers tuple[dict, Optional[list]] but plain dict is accepted
+        self.captured_calls.append(args)
         if args.token == "aws:iam/getPolicyDocument:getPolicyDocument":  # noqa:S105 # definitely not a password
             return {
                 "json": json.dumps(
@@ -42,7 +44,7 @@ class Ec2Mocks(pulumi.runtime.Mocks):
                             {
                                 "Effect": "Allow",
                                 "Action": "sts:AssumeRole",
-                                "Principal": {"Service": "ec2.amazonaws.com"},
+                                "Principal": {"Service": Faker().slug() + ".amazonaws.com"},
                             }
                         ],
                     }
@@ -301,14 +303,23 @@ def test_When_component_created__Then_instance_role_has_ssm_managed_policy() -> 
 
 
 @_pulumi_test
-def test_When_component_created__Then_instance_role_trust_policy_allows_ec2() -> pulumi.Output[None]:
+def test_When_component_created__Then_instance_role_trust_policy_allows_ec2(
+    ec2_mocks: Ec2Mocks,
+) -> pulumi.Output[None]:
     component = _new_ec2_with_rdp()
 
-    def check(policy_json: str) -> None:
-        policy = json.loads(policy_json)
-        services: str | list[str] = policy["Statement"][0]["Principal"]["Service"]
-        if isinstance(services, str):
-            services = [services]
-        assert "ec2.amazonaws.com" in services, f"Expected ec2.amazonaws.com in trust policy but got {services}"
+    def check(_: str) -> None:
+        policy_calls = [c for c in ec2_mocks.captured_calls if c.token == "aws:iam/getPolicyDocument:getPolicyDocument"]  # noqa:S105 # definitely not a password
+        assert len(policy_calls) == 1
+        call_args: dict[str, Any] = policy_calls[0].args  # type: ignore[reportUnknownMemberType] # MockCallArgs.args is typed as bare dict in the Pulumi SDK
+        statements: list[dict[str, Any]] = call_args.get("statements", [])
+        assert len(statements) == 1
+        stmt = statements[0]
+        assert stmt.get("effect") == "Allow"
+        assert stmt.get("actions") == ["sts:AssumeRole"]
+        principals: list[dict[str, Any]] = stmt.get("principals", [])
+        assert len(principals) == 1
+        assert principals[0].get("type") == "Service"
+        assert principals[0].get("identifiers") == ["ec2.amazonaws.com"]
 
     return component.instance_role.assume_role_policy_document.apply(check)

--- a/tests/unit/test_ec2.py
+++ b/tests/unit/test_ec2.py
@@ -14,8 +14,7 @@ from lab_auto_pulumi.ec2 import Ec2WithRdp
 from lab_auto_pulumi.ec2 import ExistingSecurityGroupConfig
 from lab_auto_pulumi.ec2 import NewSecurityGroupConfig
 
-# pulumi.runtime.test is partially typed in the Pulumi SDK; alias avoids repeating the ignore on every test
-_pulumi_test = pulumi.runtime.test  # type: ignore[reportUnknownMemberType]
+_pulumi_test = pulumi.runtime.test  # type: ignore[reportUnknownMemberType] # pulumi.runtime.test is partially typed in the Pulumi SDK; alias avoids repeating the ignore on every test
 
 
 class Ec2Mocks(pulumi.runtime.Mocks):
@@ -81,110 +80,62 @@ def _ssm_side_effect(param: str) -> str:
     return f"mock-{param.rsplit('/', maxsplit=1)[-1]}"
 
 
-# ============================================================================
-# New security group path
-# ============================================================================
-
-
-@_pulumi_test
-def test_When_new_sg_config__Then_instance_has_correct_instance_type() -> pulumi.Output[None]:
-    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
-
-    component = _new_ec2_with_rdp(instance_type="t3.micro")
-
-    def check(instance_type: str | None) -> None:
-        assert instance_type == "t3.micro"
-
-    return component.instance.instance_type.apply(check)
-
-
-@_pulumi_test
-def test_When_new_sg_config__Then_instance_has_correct_image_id_and_subnet() -> pulumi.Output[None]:
-    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
-
-    component = _new_ec2_with_rdp(
-        image_id="ami-87654321",
-        central_networking_subnet_name="my-subnet",
-        instance_type="t3.large",
-    )
-
-    def check(args: list[Any]) -> None:
-        image_id, subnet_id = args
-        assert image_id == "ami-87654321"
-        assert subnet_id == "mock-id", f"Expected 'mock-id' but got {subnet_id!r}"
-
-    return pulumi.Output.all(
-        component.instance.image_id,
-        component.instance.subnet_id,
-    ).apply(check)
-
-
-@_pulumi_test
-def test_When_new_sg_config__Then_security_group_created_with_vpc_id_from_ssm() -> pulumi.Output[None]:
-    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
-
-    component = _new_ec2_with_rdp(security_group_config=NewSecurityGroupConfig(central_networking_vpc_name="test-vpc"))
-
-    def check(vpc_id: str | None) -> None:
-        assert vpc_id == "mock-id", f"Expected 'mock-id' but got {vpc_id!r}"
-
-    return component.security_group.vpc_id.apply(check)
-
-
-@_pulumi_test
-def test_When_new_sg_with_ingress_rule__Then_ingress_resource_created() -> pulumi.Output[None]:
+@pytest.fixture(autouse=True)
+def ec2_mocks() -> Ec2Mocks:
     mocks = Ec2Mocks()
     pulumi.runtime.set_mocks(mocks, project="test-project", stack="test-stack")
+    return mocks
 
-    component = _new_ec2_with_rdp(
-        security_group_config=NewSecurityGroupConfig(
-            central_networking_vpc_name="test-vpc",
-            ingress_rules=[
-                ec2.SecurityGroupIngressArgs(
-                    description="Allow RDP",
-                    ip_protocol="tcp",
-                    from_port=3389,
-                    to_port=3389,
-                )
-            ],
+
+class TestNewSecurityGroupConfig:
+    @_pulumi_test
+    def test_When_new_sg_config__Then_instance_has_correct_instance_type(self) -> pulumi.Output[None]:
+        component = _new_ec2_with_rdp(instance_type="t3.micro")
+
+        def check(instance_type: str | None) -> None:
+            assert instance_type == "t3.micro"
+
+        return component.instance.instance_type.apply(check)
+
+    @_pulumi_test
+    def test_When_new_sg_config__Then_instance_has_correct_image_id_and_subnet(self) -> pulumi.Output[None]:
+        component = _new_ec2_with_rdp(
+            image_id="ami-87654321",
+            central_networking_subnet_name="my-subnet",
+            instance_type="t3.large",
         )
-    )
 
-    def check(_: str) -> None:
-        ingress = [r for r in mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroupIngress"]
-        assert [r.inputs.get("ipProtocol") for r in ingress] == ["tcp"]  # type: ignore[reportUnknownMemberType] # Pulumi SDK types inputs as dict[Unknown, Unknown]
-        assert [r.inputs.get("fromPort") for r in ingress] == [3389]  # type: ignore[reportUnknownMemberType]
-        assert [r.inputs.get("toPort") for r in ingress] == [3389]  # type: ignore[reportUnknownMemberType]
+        def check(args: list[Any]) -> None:
+            image_id, subnet_id = args
+            assert image_id == "ami-87654321"
+            assert subnet_id == "mock-id", f"Expected 'mock-id' but got {subnet_id!r}"
 
-    return component.instance.id.apply(check)
+        return pulumi.Output.all(
+            component.instance.image_id,
+            component.instance.subnet_id,
+        ).apply(check)
 
+    @_pulumi_test
+    def test_When_new_sg_config__Then_security_group_created_with_vpc_id_from_ssm(self) -> pulumi.Output[None]:
+        component = _new_ec2_with_rdp(
+            security_group_config=NewSecurityGroupConfig(central_networking_vpc_name="test-vpc")
+        )
 
-@_pulumi_test
-def test_When_new_sg_config__Then_egress_rule_always_created() -> pulumi.Output[None]:
-    mocks = Ec2Mocks()
-    pulumi.runtime.set_mocks(mocks, project="test-project", stack="test-stack")
+        def check(vpc_id: str | None) -> None:
+            assert vpc_id == "mock-id", f"Expected 'mock-id' but got {vpc_id!r}"
 
-    component = _new_ec2_with_rdp()
+        return component.security_group.vpc_id.apply(check)
 
-    def check(_: str) -> None:
-        egress = [r for r in mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroupEgress"]
-        assert len(egress) == 1
-        assert egress[0].inputs.get("ipProtocol") == "-1"  # type: ignore[reportUnknownMemberType] # Pulumi SDK types inputs as dict[Unknown, Unknown]
-        assert egress[0].inputs.get("cidrIp") == "0.0.0.0/0"  # type: ignore[reportUnknownMemberType]
-
-    return component.instance.id.apply(check)
-
-
-def test_When_ingress_rule_has_no_description__Then_raises_value_error() -> None:
-    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
-
-    with pytest.raises(ValueError, match="must have a description"):
-        _ = _new_ec2_with_rdp(
+    @_pulumi_test
+    def test_When_new_sg_with_ingress_rule__Then_ingress_resource_created(
+        self, ec2_mocks: Ec2Mocks
+    ) -> pulumi.Output[None]:
+        component = _new_ec2_with_rdp(
             security_group_config=NewSecurityGroupConfig(
                 central_networking_vpc_name="test-vpc",
                 ingress_rules=[
                     ec2.SecurityGroupIngressArgs(
-                        description="",
+                        description="Allow RDP",
                         ip_protocol="tcp",
                         from_port=3389,
                         to_port=3389,
@@ -193,82 +144,113 @@ def test_When_ingress_rule_has_no_description__Then_raises_value_error() -> None
             )
         )
 
+        def check(_: str) -> None:
+            ingress = [r for r in ec2_mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroupIngress"]
+            assert [r.inputs.get("ipProtocol") for r in ingress] == ["tcp"]  # type: ignore[reportUnknownMemberType] # Pulumi SDK types inputs as dict[Unknown, Unknown]
+            assert [r.inputs.get("fromPort") for r in ingress] == [3389]  # type: ignore[reportUnknownMemberType]
+            assert [r.inputs.get("toPort") for r in ingress] == [3389]  # type: ignore[reportUnknownMemberType]
 
-# ============================================================================
-# Existing security group path
-# ============================================================================
+        return component.instance.id.apply(check)
 
+    @_pulumi_test
+    def test_When_new_sg_config__Then_egress_rule_always_created(self) -> pulumi.Output[None]:
+        mocks = Ec2Mocks()
+        pulumi.runtime.set_mocks(mocks, project="test-project", stack="test-stack")
 
-@_pulumi_test
-def test_When_existing_sg_config__Then_no_new_security_group_resource_created() -> pulumi.Output[None]:
-    mocks = Ec2Mocks()
-    pulumi.runtime.set_mocks(mocks, project="test-project", stack="test-stack")
+        component = _new_ec2_with_rdp()
 
-    component = _new_ec2_with_rdp(
-        security_group_config=ExistingSecurityGroupConfig(security_group_id=pulumi.Output.from_input("sg-existing-123"))
-    )
+        def check(_: str) -> None:
+            egress = [r for r in mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroupEgress"]
+            assert len(egress) == 1
+            assert egress[0].inputs.get("ipProtocol") == "-1"  # type: ignore[reportUnknownMemberType] # Pulumi SDK types inputs as dict[Unknown, Unknown]
+            assert egress[0].inputs.get("cidrIp") == "0.0.0.0/0"  # type: ignore[reportUnknownMemberType]
 
-    def check(_: str) -> None:
-        # ec2.SecurityGroup.get() is a ReadResource, which flows through new_resource in the mock
-        # with resource_id set to the ID being read. Assert we read the right one and never created a new one.
-        read_sgs = [r for r in mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroup" and r.resource_id]
-        new_sgs = [r for r in mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroup" and not r.resource_id]
-        assert [r.resource_id for r in read_sgs] == ["sg-existing-123"]
-        assert new_sgs == [], f"Expected no new SecurityGroup resources but got {new_sgs}"
+        return component.instance.id.apply(check)
 
-    return component.instance.id.apply(check)
-
-
-@_pulumi_test
-def test_When_existing_sg_config__Then_instance_uses_provided_sg_id() -> pulumi.Output[None]:
-    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
-
-    component = _new_ec2_with_rdp(
-        security_group_config=ExistingSecurityGroupConfig(security_group_id=pulumi.Output.from_input("sg-existing-123"))
-    )
-
-    def check(sg_ids: Sequence[Any] | None) -> None:
-        assert sg_ids is not None, "Expected sg_ids to be not None"
-        assert "sg-existing-123" in sg_ids, f"Expected 'sg-existing-123' in {sg_ids}"
-
-    return component.instance.security_group_ids.apply(check)
-
-
-# ============================================================================
-# user_data, additional tags, and instance role
-# ============================================================================
+    @_pulumi_test
+    def test_When_ingress_rule_has_no_description__Then_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="must have a description"):
+            _ = _new_ec2_with_rdp(
+                security_group_config=NewSecurityGroupConfig(
+                    central_networking_vpc_name="test-vpc",
+                    ingress_rules=[
+                        ec2.SecurityGroupIngressArgs(
+                            description="",
+                            ip_protocol="tcp",
+                            from_port=3389,
+                            to_port=3389,
+                        )
+                    ],
+                )
+            )
 
 
-@_pulumi_test
-def test_When_user_data_provided__Then_instance_user_data_is_base64_encoded() -> pulumi.Output[None]:
-    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
+class TestExistingSecurityGroup:
+    @_pulumi_test
+    def test_When_existing_sg_config__Then_no_new_security_group_resource_created(self) -> pulumi.Output[None]:
+        mocks = Ec2Mocks()
+        pulumi.runtime.set_mocks(mocks, project="test-project", stack="test-stack")
 
-    raw = "write-me-a-script"
-    component = _new_ec2_with_rdp(user_data=pulumi.Output.from_input(raw))
+        component = _new_ec2_with_rdp(
+            security_group_config=ExistingSecurityGroupConfig(
+                security_group_id=pulumi.Output.from_input("sg-existing-123")
+            )
+        )
 
-    def check(encoded: str | None) -> None:
-        expected = base64.b64encode(raw.encode()).decode()
-        assert encoded == expected, f"Expected {expected!r} but got {encoded!r}"
+        def check(_: str) -> None:
+            # ec2.SecurityGroup.get() is a ReadResource, which flows through new_resource in the mock
+            # with resource_id set to the ID being read. Assert we read the right one and never created a new one.
+            read_sgs = [r for r in mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroup" and r.resource_id]
+            new_sgs = [
+                r for r in mocks.created_resources if r.typ == "aws-native:ec2:SecurityGroup" and not r.resource_id
+            ]
+            assert [r.resource_id for r in read_sgs] == ["sg-existing-123"]
+            assert new_sgs == [], f"Expected no new SecurityGroup resources but got {new_sgs}"
 
-    return component.instance.user_data.apply(check)
+        return component.instance.id.apply(check)
+
+    @_pulumi_test
+    def test_When_existing_sg_config__Then_instance_uses_provided_sg_id(self) -> pulumi.Output[None]:
+
+        component = _new_ec2_with_rdp(
+            security_group_config=ExistingSecurityGroupConfig(
+                security_group_id=pulumi.Output.from_input("sg-existing-123")
+            )
+        )
+
+        def check(sg_ids: Sequence[Any] | None) -> None:
+            assert sg_ids is not None, "Expected sg_ids to be not None"
+            assert "sg-existing-123" in sg_ids, f"Expected 'sg-existing-123' in {sg_ids}"
+
+        return component.instance.security_group_ids.apply(check)
 
 
-@_pulumi_test
-def test_When_no_user_data__Then_instance_user_data_is_none() -> pulumi.Output[None]:
-    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
+class TestUserData:
+    @_pulumi_test
+    def test_When_user_data_provided__Then_instance_user_data_is_base64_encoded(self) -> pulumi.Output[None]:
 
-    component = _new_ec2_with_rdp(user_data=None)
+        raw = "write-me-a-script"
+        component = _new_ec2_with_rdp(user_data=pulumi.Output.from_input(raw))
 
-    def check(user_data: str | None) -> None:
-        assert user_data is None, f"Expected None but got {user_data!r}"
+        def check(encoded: str | None) -> None:
+            expected = base64.b64encode(raw.encode()).decode()
+            assert encoded == expected, f"Expected {expected!r} but got {encoded!r}"
 
-    return component.instance.user_data.apply(check)
+        return component.instance.user_data.apply(check)
+
+    @_pulumi_test
+    def test_When_no_user_data__Then_instance_user_data_is_none(self) -> pulumi.Output[None]:
+
+        component = _new_ec2_with_rdp(user_data=None)
+
+        def check(user_data: str | None) -> None:
+            assert user_data is None, f"Expected None but got {user_data!r}"
+
+        return component.instance.user_data.apply(check)
 
 
 @_pulumi_test
 def test_When_additional_instance_tags_provided__Then_tags_appear_on_instance() -> pulumi.Output[None]:
-    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
-
     component = _new_ec2_with_rdp(
         additional_instance_tags=[
             TagArgs(key="env", value="testing"),
@@ -287,8 +269,6 @@ def test_When_additional_instance_tags_provided__Then_tags_appear_on_instance() 
 
 @_pulumi_test
 def test_When_component_created__Then_instance_role_has_ssm_managed_policy() -> pulumi.Output[None]:
-    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
-
     component = _new_ec2_with_rdp()
 
     def check(arns: Sequence[str] | None) -> None:
@@ -301,8 +281,6 @@ def test_When_component_created__Then_instance_role_has_ssm_managed_policy() -> 
 
 @_pulumi_test
 def test_When_component_created__Then_instance_role_trust_policy_allows_ec2() -> pulumi.Output[None]:
-    pulumi.runtime.set_mocks(Ec2Mocks(), project="test-project", stack="test-stack")
-
     component = _new_ec2_with_rdp()
 
     def check(policy_json: str) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -727,7 +727,7 @@ wheels = [
 
 [[package]]
 name = "lab-auto-pulumi"
-version = "0.1.18"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/uv.lock
+++ b/uv.lock
@@ -633,6 +633,18 @@ wheels = [
 ]
 
 [[package]]
+name = "faker"
+version = "40.12.0"
+source = { registry = "https://pypi.org/simple/" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c1/f8224fe97fea2f98d455c22438c1b09b10e14ef2cb95ae4f7cec9aa59659/faker-40.12.0.tar.gz", hash = "sha256:58b5a9054c367bd5fb2e948634105364cc570e78a98a8e5161a74691c45f158f", size = 1962003, upload-time = "2026-03-30T18:00:56.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/5c/39452a6b6aa76ffa518fa7308e1975b37e9ba77caa6172a69d61e7180221/faker-40.12.0-py3-none-any.whl", hash = "sha256:6238a4058a8b581892e3d78fe5fdfa7568739e1c8283e4ede83f1dde0bfc1a3b", size = 1994601, upload-time = "2026-03-30T18:00:54.804Z" },
+]
+
+[[package]]
 name = "grpcio"
 version = "1.74.0"
 source = { registry = "https://pypi.org/simple/" }
@@ -742,6 +754,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "boto3-stubs", extra = ["all"] },
+    { name = "faker" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -762,6 +775,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "boto3-stubs", extras = ["all"] },
+    { name = "faker", specifier = ">=40.11.0" },
     { name = "pyright", specifier = ">=1.1.408" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
@@ -4867,6 +4881,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.1"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why is this change necessary?
Want to have a way to create a single security group for a group of EC2 instances vs having a bunch of manage that all have the same rules in them.   


## How does this change address the issue?
Extract the security group arguments into 2 classes. Allowing you to either pass in an existing id or you can use the same properties as before. 


## What side effects does this change have?
This is a breaking change in that the method signature of the class will now be different. The underlying resources is you pass in the same value but in a NewSecurityGroupConfig should produce a clean diff.


## How is this change tested?



## Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * EC2 component now supports two security-group options (create new or reference existing) and exposes them for top-level import.

* **Tests**
  * Added comprehensive unit tests covering both security-group flows, instance behavior, IAM trust/policy, SSM lookups, and async test loop management.

* **Chores**
  * Package version bumped to 0.2.0.
  * Added a dev test dependency (faker).
  * Increased test coverage threshold.
  * Updated devcontainer context hash.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->