### PR TITLE
Don't delete before replace for security groups on EC2s

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -77,5 +77,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 6bb8ab51 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 5b08ab52 # spellchecker:disable-line
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,13 +28,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 
+## [0.2.1] - 2026-04-28
+
+### Fixed
+- Do not delete security groups on EC2 before replacement
+
+---
+
 ## [0.1.18] - 2024-12-22
 
 ### Added
 - Python 3.14 support
 
 ---
-
 
 ## [0.1.0] - 2024-12-18
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lab-auto-pulumi"
-version = "0.2.0"
+version = "0.2.1"
 description = "Pulumi helpers. Especially useful for tooling created by the LabAutomationAndScreening github organization."
 authors = [
     {name = "Eli Fine"},

--- a/src/lab_auto_pulumi/ec2.py
+++ b/src/lab_auto_pulumi/ec2.py
@@ -102,7 +102,9 @@ class Ec2WithRdp(ComponentResource):
                 ),
                 group_description=security_group_config.description,
                 tags=[TagArgs(key="Name", value=name), *common_tags_native()],
-                opts=ResourceOptions(parent=self, delete_before_replace=True, replace_on_changes=["*"]),
+                opts=ResourceOptions(
+                    parent=self, replace_on_changes=["groupDescription", "vpcId"]
+                ),  # these are immutable in
             )
             for idx, rule_args in enumerate(security_group_config.ingress_rules):
                 if not rule_args.description:

--- a/src/lab_auto_pulumi/ec2.py
+++ b/src/lab_auto_pulumi/ec2.py
@@ -103,8 +103,13 @@ class Ec2WithRdp(ComponentResource):
                 group_description=security_group_config.description,
                 tags=[TagArgs(key="Name", value=name), *common_tags_native()],
                 opts=ResourceOptions(
-                    parent=self, replace_on_changes=["groupDescription", "vpcId"]
-                ),  # these are immutable in
+                    parent=self,
+                    replace_on_changes=[  # these are immutable  https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-ec2-securitygroup.html
+                        "groupDescription",
+                        "groupName",
+                        "vpcId",
+                    ],
+                ),
             )
             for idx, rule_args in enumerate(security_group_config.ingress_rules):
                 if not rule_args.description:

--- a/uv.lock
+++ b/uv.lock
@@ -773,7 +773,7 @@ wheels = [
 
 [[package]]
 name = "lab-auto-pulumi"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Why is this change necessary?
EC2s always need a security group...trying to delete before replace causes huge problems


## How does this change address the issue?
Removes that.  Also, limits the replacement trigger to just the immutable attributes.


## What side effects does this change have?
Hopefully none


## How is this change tested?
Repo using the manually edited venv to this source code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced EC2 security group resource management. Security groups will no longer be deleted and recreated before replacement during infrastructure updates. Resource replacement now occurs exclusively when immutable properties are modified, significantly improving the stability and efficiency of your infrastructure operations.

* **Chores**
  * Version bumped to 0.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->