### PR TITLE
Add new and deprecate old ORG_MANAGED_SSM_PARAM_PREFIX constant

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -77,5 +77,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 5b08ab52 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 4a58ab53 # spellchecker:disable-line
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ---
 ## [0.2.2] - 2026-05-05
+
 ### Added
 - ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX constant for consistent namespace for all managed secrets and ssm params.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Describe security fixes or improvements.
 
 ---
+## [0.2.2] - 2026-05-05
+### Added
+- ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX constant for consistent namespace for all managed secrets and ssm params.
+
+### Deprecated
+- ORG_MANAGED_SSM_PARAM_PREFIX has been deprecated in favor of ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX. Value is same but name changed.
 
 ## [0.2.1] - 2026-04-28
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lab-auto-pulumi"
-version = "0.2.1"
+version = "0.2.2"
 description = "Pulumi helpers. Especially useful for tooling created by the LabAutomationAndScreening github organization."
 authors = [
     {name = "Eli Fine"},

--- a/src/lab_auto_pulumi/__init__.py
+++ b/src/lab_auto_pulumi/__init__.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from . import constants
 from .constants import CENTRAL_NETWORKING_SSM_PREFIX
 from .constants import GENERIC_CENTRAL_PRIVATE_SUBNET_NAME
@@ -8,7 +10,7 @@ from .constants import GITHUB_PREVIEW_TOKEN_SECRET_NAME
 from .constants import MANAGEMENT_ACCOUNT_ID_PARAM_NAME
 from .constants import MANUAL_IAC_SECRETS_PREFIX
 from .constants import MANUAL_SECRETS_PREFIX
-from .constants import ORG_MANAGED_SSM_PARAM_PREFIX
+from .constants import ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX
 from .constants import SSO_INTO_EC2_PERM_SET_NAME
 from .constants import TAG_KEY_FOR_SSO_INTO_EC2_ACCESS
 from .constants import TAG_VALUE_FOR_DELETE_ACCESS
@@ -52,7 +54,7 @@ __all__ = [
     "MANUAL_IAC_SECRETS_PREFIX",
     "MANUAL_SECRETS_PREFIX",
     "ORG_INFO",
-    "ORG_MANAGED_SSM_PARAM_PREFIX",
+    "ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX",
     "SSO_INTO_EC2_PERM_SET_NAME",
     "TAG_KEY_FOR_SSO_INTO_EC2_ACCESS",
     "TAG_VALUE_FOR_DELETE_ACCESS",
@@ -85,3 +87,13 @@ __all__ = [
     "get_ssm_param_value",
     "principal_in_org_condition",
 ]
+
+
+def __getattr__(name: str) -> Any:  # noqa: ANN401 # In this case it can in fact by anything so Any is appropriate
+    if name == "ORG_MANAGED_SSM_PARAM_PREFIX":
+        from .constants import (  # noqa:PLC0415 # Must be here so that we can verify the deprecation in a test otherwise it happens at init time and we miss it.
+            ORG_MANAGED_SSM_PARAM_PREFIX,
+        )
+
+        return ORG_MANAGED_SSM_PARAM_PREFIX
+    raise AttributeError(f"module {__name__} has no attribute {name}")  # noqa:TRY003 # this is infact an attribute error. Its fine

--- a/src/lab_auto_pulumi/constants.py
+++ b/src/lab_auto_pulumi/constants.py
@@ -1,11 +1,15 @@
+import warnings
+from typing import Any
+
 GENERIC_CENTRAL_VPC_NAME = "generic"
 GENERIC_CENTRAL_PUBLIC_SUBNET_NAME = "generic-public"
 GENERIC_CENTRAL_PRIVATE_SUBNET_NAME = "generic-private"
-ORG_MANAGED_SSM_PARAM_PREFIX = "/org-managed"
-WORKLOAD_INFO_SSM_PARAM_PREFIX = f"{ORG_MANAGED_SSM_PARAM_PREFIX}/logical-workloads"
-MANAGEMENT_ACCOUNT_ID_PARAM_NAME = f"{ORG_MANAGED_SSM_PARAM_PREFIX}/management-account-id"
+ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX = "/org-managed"
+_DEPRECATED_ORG_MANAGED_SSM_PARAM_PREFIX = ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX
+WORKLOAD_INFO_SSM_PARAM_PREFIX = f"{ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX}/logical-workloads"
+MANAGEMENT_ACCOUNT_ID_PARAM_NAME = f"{ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX}/management-account-id"
 
-CENTRAL_NETWORKING_SSM_PREFIX = f"{ORG_MANAGED_SSM_PARAM_PREFIX}/central-networking"
+CENTRAL_NETWORKING_SSM_PREFIX = f"{ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX}/central-networking"
 
 MANUAL_SECRETS_PREFIX = "/manually-entered-secrets"
 MANUAL_IAC_SECRETS_PREFIX = f"{MANUAL_SECRETS_PREFIX}/iac"
@@ -21,3 +25,15 @@ TAG_KEY_FOR_SSO_INTO_EC2_ACCESS = "SsoIntoEc2AccessLevel"  # note: S3 Buckets an
 TAG_VALUE_FOR_READ_ACCESS = "Read"
 TAG_VALUE_FOR_WRITE_ACCESS = "Write"
 TAG_VALUE_FOR_DELETE_ACCESS = "Delete"
+
+
+def __getattr__(name: str) -> Any:  # noqa: ANN401 # In this case it can in fact by anything so Any is appropriate
+    # https://peps.python.org/pep-0562/
+    if name == "ORG_MANAGED_SSM_PARAM_PREFIX":
+        warnings.warn(
+            "'ORG_MANAGED_SSM_PARAM_PREFIX' has been deprecated and will be removed in the future. Use 'ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX'",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()["_DEPRECATED_ORG_MANAGED_SSM_PARAM_PREFIX"]
+    raise AttributeError(f"module {__name__} has no attribute {name}")  # noqa:TRY003 # this is infact an attribute error. Its fine

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -1,0 +1,17 @@
+import warnings
+
+import pytest
+
+
+def test_deprecation_warning_in_place():
+    warnings.resetwarnings()
+
+    with pytest.warns(
+        DeprecationWarning,
+        match="'ORG_MANAGED_SSM_PARAM_PREFIX' has been deprecated and will be removed in the future. Use 'ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX'",
+    ):
+        from lab_auto_pulumi import (  # noqa:PLC0415 # this import has to be here so that we can catch the warning that it produces
+            ORG_MANAGED_SSM_PARAM_PREFIX,
+        )
+
+    assert ORG_MANAGED_SSM_PARAM_PREFIX == "/org-managed"

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -1,11 +1,7 @@
-import warnings
-
 import pytest
 
 
 def test_deprecation_warning_in_place():
-    warnings.resetwarnings()
-
     with pytest.warns(
         DeprecationWarning,
         match="'ORG_MANAGED_SSM_PARAM_PREFIX' has been deprecated and will be removed in the future. Use 'ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX'",

--- a/uv.lock
+++ b/uv.lock
@@ -773,7 +773,7 @@ wheels = [
 
 [[package]]
 name = "lab-auto-pulumi"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Why is this change necessary?
Wanted to have consistent pathing for org managed secrets and SSM params so changing the name.


## How does this change address the issue?
Introduces a new variable and deprecates the old. Old and new have exactly the same value. This is simply an interface change so that downstream it doesn't read oddly when used to create secrets.


## What side effects does this change have?
N/A


## How is this change tested?
Pulled in downstream and verified warning shows when using the old value and is no longer there when using the new one. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX` constant for unified namespace across managed secrets and SSM parameters.

* **Deprecated**
  * `ORG_MANAGED_SSM_PARAM_PREFIX` is now deprecated in favor of `ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX`. Backward compatibility maintained with deprecation warnings.

* **Tests**
  * Added deprecation warning verification tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->