### PR TITLE
Bump version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -77,5 +77,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 4a58ab53 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 39a8ab54 # spellchecker:disable-line
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,13 +27,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Describe security fixes or improvements.
 
 ---
-## [0.2.2] - 2026-05-05
+## [0.2.3] - 2026-05-05
 
 ### Added
 - ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX constant for consistent namespace for all managed secrets and ssm params.
 
 ### Deprecated
 - ORG_MANAGED_SSM_PARAM_PREFIX has been deprecated in favor of ORG_MANAGED_PARAMS_AND_SECRETS_PREFIX. Value is same but name changed.
+
+## [0.2.2] - Unreleased
+
+CI Issue caused us to skip this version
 
 ## [0.2.1] - 2026-04-28
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lab-auto-pulumi"
-version = "0.2.2"
+version = "0.2.3"
 description = "Pulumi helpers. Especially useful for tooling created by the LabAutomationAndScreening github organization."
 authors = [
     {name = "Eli Fine"},

--- a/uv.lock
+++ b/uv.lock
@@ -773,7 +773,7 @@ wheels = [
 
 [[package]]
 name = "lab-auto-pulumi"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
## Link to Issue or Message thread
https://github.com/LabAutomationAndScreening/lab-auto-pulumi/actions/runs/25391084088


## Why is this change necessary?
I tried to publish but forgot to check the primary repo checkbox. Then tried to run it again and it failed. Even with a delete of the package on testpypi its failing. 


## How does this change address the issue?
Bumps version to publish a new version


## What side effects does this change have?
N/A


## How is this change tested?
N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new configuration option for organization-managed parameters and secrets handling.

* **Deprecations**
  * Previous parameter prefix configuration deprecated in favor of a unified alternative with equivalent functionality.

* **Chores**
  * Version released: 0.2.3.
  * Development environment configuration updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->